### PR TITLE
Drop secrets permission

### DIFF
--- a/examples/k8s/deploy/linstor-csi-1.17.yaml
+++ b/examples/k8s/deploy/linstor-csi-1.17.yaml
@@ -97,9 +97,6 @@ metadata:
   name: linstor-csi-provisioner-role
 rules:
   - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list"]
-  - apiGroups: [""]
     resources: ["persistentvolumes"]
     verbs: ["get", "list", "watch", "create", "delete"]
   - apiGroups: [""]
@@ -321,9 +318,6 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotclasses"]
     verbs: ["get", "list", "watch"]


### PR DESCRIPTION
This PR drops permissions for read secrets in all cluster for linstor-csi-provisioner and linstor-csi-snapshoter.
This is not required for LINSTOR.