### PR TITLE
allow empty storage pools

### DIFF
--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -292,8 +292,10 @@ func (i *Info) ToResourceGroupModify(rg lapi.ResourceGroup) (lapi.ResourceGroupM
 
 	rgModify.SelectFilter.PlaceCount = params.PlacementCount
 
-	rgModify.SelectFilter.StoragePool = params.StoragePool
-	rgModify.OverrideProps[lc.KeyStorPoolName] = params.StoragePool
+	if params.StoragePool != "" { // otherwise we set the storagepool to "", which does not make LINSTOR happy
+		rgModify.SelectFilter.StoragePool = params.StoragePool
+		rgModify.OverrideProps[lc.KeyStorPoolName] = params.StoragePool
+	}
 
 	for _, p := range params.ReplicasOnDifferent {
 		rgModify.SelectFilter.ReplicasOnDifferent = append(rgModify.SelectFilter.ReplicasOnDifferent, p)


### PR DESCRIPTION
For LINSTOR it is perfectly fine that a RG does not contain a dedicated
storage pool. LINSTOR then chooses one.

In this case the Go string for the SP if not set in the SC had it's
default value (i.e., ""). This was then set on the RG, which then is not
valid in later on in LINSTOR.