### PR TITLE
ensure annotations on RDs are up-to-date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- PVC from snapshots mount the restored volume instead of the original
 
 ## [0.8.2] - 2020-06-04
 ### Fixed


### PR DESCRIPTION
CSI Node needs annotations on resource definitions to determine
which volume to mount. On snapshot restore, LINSTOR will overwrite
all props of a RD with the original value. This lead to CSI Node mounting
the "original" volume instead of the one restored from a snapshot.

The fix is to move the creation/update of these annotations to the end
of the snapshot-restore method.