### PR TITLE
CI: fix git describe failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          # Fetch all tags + branches so "git describe" can find the latest tag
+          fetch-depth: 0
       - name: build
         run: |
           make update TAG="$(git describe --dirty --tags --long --match "v*.*")"


### PR DESCRIPTION
The default checkout action only fetches a single commit. For
git describe to work we need access to the history (until the latest tag)
We cannot know ahead of time how many commits we need to fetch, so instead
we fetch the entire history

Fix for #79 