### PR TITLE
add "Aux/" prefix to RG props

### DIFF
--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -255,11 +255,11 @@ func (params *Parameters) ToResourceGroupModify(rg *lapi.ResourceGroup) (lapi.Re
 	}
 
 	for _, p := range params.ReplicasOnDifferent {
-		rgModify.SelectFilter.ReplicasOnDifferent = append(rgModify.SelectFilter.ReplicasOnDifferent, p)
+		rgModify.SelectFilter.ReplicasOnDifferent = append(rgModify.SelectFilter.ReplicasOnDifferent, maybeAddAux(p))
 	}
 
 	for _, p := range params.ReplicasOnSame {
-		rgModify.SelectFilter.ReplicasOnSame = append(rgModify.SelectFilter.ReplicasOnSame, p)
+		rgModify.SelectFilter.ReplicasOnSame = append(rgModify.SelectFilter.ReplicasOnSame, maybeAddAux(p))
 	}
 
 	for _, p := range params.LayerList {
@@ -487,4 +487,13 @@ type VolumeStatter interface {
 type Expander interface {
 	NodeExpand(source, target string) error
 	ControllerExpand(ctx context.Context, vol *Info) error
+}
+
+func maybeAddAux(prop string) string {
+	auxPrefix := lc.NamespcAuxiliary + "/"
+	if strings.HasPrefix(prop, auxPrefix) {
+		return prop
+	}
+
+	return auxPrefix + prop
 }


### PR DESCRIPTION
This fixes a convenience issue that bit some users already. LINSTOR aux
properties need the "Aux/" prefix on their keys. With that in place
users can specify it in "LINSTOR notation" with the prefix, or leave it
out and then the driver adds them. The LINSTOR command line client also
automatically adds the prefix under certain conditions, so it should be
fine to add this magic here as well.

The prefix is added to "replicasOnSame" and "replicasOnDifferent".

This allows:
parameters:
  autoPlace: "2"
  replicasOnDifferent: Aux/zone
  resourceGroup: linstor-volume-r2

as well as:
parameters:
  autoPlace: "2"
  replicasOnDifferent: zone
  resourceGroup: linstor-volume-r2