### PR TITLE
Add support for ROX volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Support for ROX filesystem volumes ([#87])
 - Support all currently available LINSTOR layers
   - DRBD
   - STORAGE
@@ -19,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Use storage pools for CSI topology support. ([#83])
 
+[#87]: https://github.com/piraeusdatastore/linstor-csi/pull/87
 [#83]: https://github.com/piraeusdatastore/linstor-csi/pull/83
 
 ## [0.9.1] - 2020-07-28


### PR DESCRIPTION
DRBD and by extension LINSTOR support ROX configurations, as
long as the device is mounted with the "ro" option. This commit enables
the CSI driver to provision such ROX volumes. For this to work we need to:
* tell CSI we can handle ROX configurations
* validate ROX volumes are used with the "readOnly" option set