### PR TITLE
add support for ROX block volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Support for ROX filesystem volumes ([#87])
+- Support for ROX filesystem and block volumes ([#87] and [#88])
 - Support all currently available LINSTOR layers
   - DRBD
   - STORAGE
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Use storage pools for CSI topology support. ([#83])
 
+[#88]: https://github.com/piraeusdatastore/linstor-csi/pull/88
 [#87]: https://github.com/piraeusdatastore/linstor-csi/pull/87
 [#83]: https://github.com/piraeusdatastore/linstor-csi/pull/83
 

--- a/pkg/client/mock.go
+++ b/pkg/client/mock.go
@@ -208,7 +208,7 @@ func mockMountPath(target string) string {
 	return filepath.Join(os.TempDir(), filepath.Base(target), "_mounted")
 }
 
-func (s *MockStorage) Mount(vol *volume.Info, source, target, fsType string, options []string) error {
+func (s *MockStorage) Mount(vol *volume.Info, source, target, fsType string, readonly bool, options []string) error {
 	p := mockMountPath(target)
 	if _, err := os.Stat(p); os.IsNotExist(err) {
 		return os.MkdirAll(p, 0755)

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -495,7 +495,7 @@ type Querier interface {
 
 // Mounter handles the filesystems located on volumes.
 type Mounter interface {
-	Mount(vol *Info, source, target, fsType string, options []string) error
+	Mount(vol *Info, source, target, fsType string, readonly bool, options []string) error
 	Unmount(target string) error
 	IsNotMountPoint(target string) (bool, error)
 }


### PR DESCRIPTION
Block volumes are special, extra care must be taken such that they
are not accidentally opened RW in ROX mode. In our setup, block volumes
are exposed to Kubernetes as simple bind mounts (with "ro").

However, it is still possible to open DRBD devices as O_RDWR through the
bind mount. In a later stage, Kubernetes sets up a loop device using
losetup for our block volume. By default, losetup opens the device
as O_RDWR if it can. This means we need a way to disallow O_RDWR on
our exported devices.

The solution implemented here is to set up _another_ loop device, using
losetup's "--read-only" option to ensure the backing device is only opened
using O_RDONLY.