### PR TITLE
use explicit fstype in storageclass example

### DIFF
--- a/examples/k8s/class.yaml
+++ b/examples/k8s/class.yaml
@@ -8,3 +8,4 @@ parameters:
   placementCount: "2"
   storagePool: "my-storage-pool"
   resourceGroup: "linstor-basic-storage"
+  csi.storage.k8s.io/fstype: xfs


### PR DESCRIPTION
When using newer CSI components, no default fstype is set for PVs.
This leads to kubelet skipping the fsGroup step since it expects
the volume to be in block mode.

See https://github.com/piraeusdatastore/linstor-csi/issues/91