### PR TITLE
remove losetup dependency for ROX support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- ROX block volumes support requires DRBD v9.0.26 ([#93])
+
+[#93]: https://github.com/piraeusdatastore/linstor-csi/pull/93
+
 ## [0.10.0] - 2020-11-11
 
 ### Added

--- a/pkg/client/linstor.go
+++ b/pkg/client/linstor.go
@@ -1014,20 +1014,19 @@ func (s *Linstor) Mount(vol *volume.Info, source, target, fsType string, readonl
 		return fmt.Errorf("checking for exclusive open failed: %v, check device health", err)
 	}
 
-	// Ensure the exported device is RO comes in 2 flavours:
-	// * For fs volumes: just mount with the "ro" flag.
-	// * For block volumes: using the "ro" flag to bind-mount the original device will have no effect, the device
-	//   can then still be opened using O_RDWR. Kubernetes itself sets up a loop device which uses open(..,  O_RDWR) by
-	//   default. This would mean that DRBD would automatically try to promote this node to primary. The fix applied
-	//   here is to introduce another indirection in the form of another loop device, set RO using the --readonly flag.
 	if readonly {
 		options = append(options, "ro")
 
-		if block {
-			source, err = s.setupReadonlyLoopDevice(source)
-			if err != nil {
-				return fmt.Errorf("failed to setup readonly loop device: %w", err)
-			}
+		// This requires DRBD 9.0.26+, older versions ignore this flag
+		err := s.setDevReadOnly(source)
+		if err != nil {
+			return fmt.Errorf("failed to set source device readonly: %w", err)
+		}
+	} else {
+		// We might be re-using an existing device that was set RO previously
+		err = s.setDevReadWrite(source)
+		if err != nil {
+			return fmt.Errorf("failed to set source device readwrite: %w", err)
 		}
 	}
 
@@ -1114,20 +1113,14 @@ func mkfsArgs(opts, source string) []string {
 	return append(strings.Split(opts, " "), source)
 }
 
-func (s *Linstor) setupReadonlyLoopDevice(srcPath string) (string, error) {
-	out, err := s.mounter.Exec.Run("losetup", "--associated", srcPath)
-	if err != nil {
-		return "", fmt.Errorf("couldn't check on existing loop device for '%s': %w", srcPath, err)
-	}
+func (s *Linstor) setDevReadOnly(srcPath string) error {
+	_, err := s.mounter.Exec.Run("blockdev", "--setro", srcPath)
+	return err
+}
 
-	if len(out) == 0 {
-		out, err = s.mounter.Exec.Run("losetup", "--find", "--show", "--read-only", srcPath)
-		if err != nil {
-			return "", fmt.Errorf("couldn't set up new loop device for '%s': %w", srcPath, err)
-		}
-	}
-
-	return losetupParseDevice(string(out)), nil
+func (s *Linstor) setDevReadWrite(srcPath string) error {
+	_, err := s.mounter.Exec.Run("blockdev", "--setrw", srcPath)
+	return err
 }
 
 // IsNotMountPoint determines if a directory is a mountpoint.
@@ -1136,7 +1129,6 @@ func (s *Linstor) IsNotMountPoint(target string) (bool, error) {
 }
 
 // Unmount unmounts the target. Operates locally on the machines where it is called.
-// It also detaches any loop device set-up during the Mount call.
 func (s *Linstor) Unmount(target string) error {
 	s.log.WithFields(logrus.Fields{
 		"target": target,
@@ -1151,37 +1143,12 @@ func (s *Linstor) Unmount(target string) error {
 		return nil
 	}
 
-	err = s.detachLoopDevice(target)
-	if err != nil {
-		return fmt.Errorf("unable to remove possible loop devices for target '%s': %w", target, err)
-	}
-
 	err = s.mounter.Unmount(target)
 	if err != nil {
 		return fmt.Errorf("unable to unmount target '%s': %w", target, err)
 	}
 
 	return nil
-}
-
-func (s *Linstor) detachLoopDevice(devicePath string) error {
-	_, err := s.mounter.Exec.Run("losetup", "--list", devicePath)
-	if err != nil {
-		// Not a loop device
-		return nil
-	}
-
-	_, err = s.mounter.Exec.Run("losetup", "--detach", devicePath)
-	return err
-}
-
-// Parses the output of losetup calls to get the returned loop device path
-func losetupParseDevice(input string) string {
-	// losetup --associated outputs:
-	// /dev/loop1: [0073]:148662 (/dev/sda)
-	// losetup --find --show outputs:
-	// /dev/loop1
-	return strings.TrimSpace(strings.SplitN(input, ":", 2)[0])
 }
 
 // validResourceName returns an error if the input string is not a valid LINSTOR name


### PR DESCRIPTION
In d2f23d6 we introduced ROX volume support, which works around DRBD's
autopromote feature by introducing a readonly loop-device so all access
is done readonly.

The code to handle detaching needed to clean up the loop device, which
relied on a specifc implementation of "losetup --list", which is not
compatible with older version (such as the one found in CentOS 7).
This meant that _all_ PVC failed to detach.

This commit switches to using "blockdev --setro" to ensure readonly access.
That in turn requires DRBD v9.0.26, which is not released yet. This should
not be a problem, as the feature was probably never used anyways.