### PR TITLE
fix: NodePublishVolume checks for nil volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Crash when calling NodePublishVolume on non-existent volume ([#96])
+
+[#96]: https://github.com/piraeusdatastore/linstor-csi/issues/96
+
 ## [0.10.1] - 2020-11-19
 
 ### Changed

--- a/pkg/client/linstor.go
+++ b/pkg/client/linstor.go
@@ -223,9 +223,9 @@ func (s *Linstor) resourceDefinitionToVolume(resDef lapi.ResourceDefinition) (*v
 	return vol, nil
 }
 
-// GetByName retrives a volume.Info that has a name that matches the CSI volume
+// FindByID retrives a volume.Info that has a name that matches the CSI volume
 // Name, not nessesarily the LINSTOR resource name or UUID.
-func (s *Linstor) GetByName(ctx context.Context, name string) (*volume.Info, error) {
+func (s *Linstor) FindByName(ctx context.Context, name string) (*volume.Info, error) {
 	s.log.WithFields(logrus.Fields{
 		"csiVolumeName": name,
 	}).Debug("looking up resource by CSI volume name")
@@ -249,9 +249,9 @@ func (s *Linstor) GetByName(ctx context.Context, name string) (*volume.Info, err
 	return nil, nil
 }
 
-// GetByID retrives a volume.Info that has an id that matches the CSI volume
+// FindByID retrives a volume.Info that has an id that matches the CSI volume
 // id. Matches the LINSTOR resource name.
-func (s *Linstor) GetByID(ctx context.Context, id string) (*volume.Info, error) {
+func (s *Linstor) FindByID(ctx context.Context, id string) (*volume.Info, error) {
 	s.log.WithFields(logrus.Fields{
 		"csiVolumeID": id,
 	}).Debug("looking up resource by CSI volume id")
@@ -486,7 +486,7 @@ func (s *Linstor) CapacityBytes(ctx context.Context, parameters map[string]strin
 // SnapCreate calls linstor to create a new snapshot on the volume indicated by
 // the SourceVolumeId contained in the CSI Snapshot.
 func (s *Linstor) SnapCreate(ctx context.Context, snap *volume.SnapInfo) (*volume.SnapInfo, error) {
-	vol, err := s.GetByID(ctx, snap.CsiSnap.SourceVolumeId)
+	vol, err := s.FindByID(ctx, snap.CsiSnap.SourceVolumeId)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve volume info from id %s", snap.CsiSnap.SourceVolumeId)
 	}
@@ -533,7 +533,7 @@ func (s *Linstor) SnapCreate(ctx context.Context, snap *volume.SnapInfo) (*volum
 
 // SnapDelete calls LINSTOR to delete the snapshot based on the CSI Snapshot ID.
 func (s *Linstor) SnapDelete(ctx context.Context, snap *volume.SnapInfo) error {
-	vol, err := s.GetByID(ctx, snap.CsiSnap.SourceVolumeId)
+	vol, err := s.FindByID(ctx, snap.CsiSnap.SourceVolumeId)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve volume info from id %s", snap.CsiSnap.SourceVolumeId)
 	}

--- a/pkg/client/mock.go
+++ b/pkg/client/mock.go
@@ -47,7 +47,7 @@ func (s *MockStorage) AllocationSizeKiB(requiredBytes, limitBytes int64) (int64,
 	return requiredBytes / 1024, nil
 }
 
-func (s *MockStorage) GetByName(ctx context.Context, name string) (*volume.Info, error) {
+func (s *MockStorage) FindByName(ctx context.Context, name string) (*volume.Info, error) {
 	for _, vol := range s.createdVolumes {
 		if vol.Name == name {
 			return vol, nil
@@ -56,7 +56,7 @@ func (s *MockStorage) GetByName(ctx context.Context, name string) (*volume.Info,
 	return nil, nil
 }
 
-func (s *MockStorage) GetByID(ctx context.Context, id string) (*volume.Info, error) {
+func (s *MockStorage) FindByID(ctx context.Context, id string) (*volume.Info, error) {
 	for _, vol := range s.createdVolumes {
 		if vol.ID == id {
 			return vol, nil
@@ -101,7 +101,7 @@ func (s *MockStorage) SnapCreate(ctx context.Context, snap *volume.SnapInfo) (*v
 		ReadyToUse:     true,
 	}
 
-	vol, _ := s.GetByID(ctx, snap.CsiSnap.SourceVolumeId)
+	vol, _ := s.FindByID(ctx, snap.CsiSnap.SourceVolumeId)
 	vol.Snapshots = append(vol.Snapshots, snap)
 
 	return snap, nil

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -484,9 +484,10 @@ type AttacherDettacher interface {
 type Querier interface {
 	// ListAll should return a sorted list of pointers to Info.
 	ListAll(ctx context.Context) ([]*Info, error)
-	GetByName(ctx context.Context, name string) (*Info, error)
-	//GetByID should return nil when volume is not found.
-	GetByID(ctx context.Context, ID string) (*Info, error)
+	// FindByName returns nil when volume is not found.
+	FindByName(ctx context.Context, name string) (*Info, error)
+	// FindByID returns nil when volume is not found.
+	FindByID(ctx context.Context, ID string) (*Info, error)
 	// AllocationSizeKiB returns the number of KiB required to provision required bytes.
 	AllocationSizeKiB(requiredBytes, limitBytes int64) (int64, error)
 	// CapacityBytes determines the capacity of the underlying storage in Bytes.


### PR DESCRIPTION
This commit adds a missing check to NodePublishVolume that ensures the
volume exists in the LINSTOR backend.
    
The method "GetByID" was renamed to "FindByID". This should help indicate
that a "nil, nil" return is possible. For the same reason, "GetByName"
was renamed "FindByName".

Fixes #96