### PR TITLE
Fix a idempotency issues in CreateVolume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Crash when calling NodePublishVolume on non-existent volume ([#96])
+- Fix an issue where newly created volumes would not be placed on any nodes, leaving them unusable ([#99])
 
 [#96]: https://github.com/piraeusdatastore/linstor-csi/issues/96
+[#99]: https://github.com/piraeusdatastore/linstor-csi/issues/99
 
 ## [0.10.1] - 2020-11-19
 


### PR DESCRIPTION
In case creating a new volume takes longer than the GRPC timeout,
the provisioner could get in a state where volumes are considered
ready even if no resource was ever created. This commit fixes this
issue by ensuring that volumes are only considered ready after the
expected amount of volumes was placed.

The bug happened in cases where:
* `Create()` succesfully called `saveVolume()`, persisting the volume
  information as annotations, which is interpreted as "ready" resources
* Immediatly after, the GRPC timeout cancels the request context, meaning
  the volume scheduler aborted before any resources could be assigned to
  nodes

A simple reording of `volumeScheduler.Create()` and `saveVolume()` would
lead to a different issue, in which continuously more volumes are placed
but never marked as ready. To prevent this, volumes that reference at least
the number of resources as required by the parameters are considered ready.

Note that this is a stopgap solution until volume schedulers are re-written
to be idempotent themselves.