### PR TITLE
Snapshot refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Snapshot information is persisted using native LINSTOR Snapshots instead of storing it in properties of RDs.
+- Snapshots are marked as ready only after LINSTOR reports success
+- Generate fallback id for a snapshot based on the suggested name using UUIDv5
+- Only create a single snapshot in volume-from-volume scenarios
+
 ### Fixed
 - LayerList was ignored when not using the AutoPlace scheduler. All schedulers not pass this information to LINSTOR. [#102]
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,20 @@ This project must be used in conjunction with a working LINSTOR cluster, version
 [LINSTOR's documentation](https://www.linbit.com/drbd-user-guide/linstor-guide-1_0-en/)
 is the foremost guide on setting up and administering LINSTOR.
 
+## :warning:️ Known issues
+
+* Due to the way [ZFS snapshots work], provisioning new Volumes from existing Volumes
+  does not work using ZFS storage pools. The internal temporary snapshot cannot be
+  deleted after the new volume is created.
+
+  As a workaround, first create a VolumeSnapshot of the existing volume and restore from
+  that snapshot. Also read the issue below!
+
+* Deletion of VolumeSnapshots will fail for ZFS based volumes if a volume restored from
+  the snapshot exists in the cluster.
+
+[ZFS snapshots work]: https://docs.oracle.com/cd/E23824_01/html/821-1448/gbciq.html
+
 ## Kubernetes
 
 After the plugin has been deployed, you're free to create storage classes

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/piraeusdatastore/linstor-csi
 go 1.12
 
 require (
-	github.com/LINBIT/golinstor v0.24.2
+	github.com/LINBIT/golinstor v0.33.1
 	github.com/alvaroloes/enumer v1.1.2
 	github.com/container-storage-interface/spec v1.2.0
 	github.com/golang/protobuf v1.3.2
@@ -13,7 +13,6 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/smartystreets/goconvey v1.6.4 // indirect
 	github.com/stretchr/testify v1.4.0
-	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/sys v0.0.0-20191113165036-4c7a9d0fe056
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 	google.golang.org/grpc v1.25.1

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/Azure/go-autorest/logger v0.1.0/go.mod h1:oExouG+K6PryycPJfVSxi/koC6L
 github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/LINBIT/golinstor v0.24.2 h1:CbsqLqgKN6ff2HAb5k+5oh0eiTrlwbysqDTikBDggMU=
-github.com/LINBIT/golinstor v0.24.2/go.mod h1:p2V1Y5ppce3isjO7IBiZGOwY8R8oIm+nYZqOa77bpXM=
+github.com/LINBIT/golinstor v0.33.1 h1:KHdsSfBN2O3H2hjr1gWvsMSEaV+Vf/XBOt748YuIQgU=
+github.com/LINBIT/golinstor v0.33.1/go.mod h1:506Wb/BCd449g/u2IGXlsIKNdiEmAEsgyOPrIYjbKyg=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
@@ -27,6 +27,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
+github.com/donovanhide/eventsource v0.0.0-20171031113327-3ed64d21fb0b h1:eR1P/A4QMYF2/LpHRhYAts9wyYEtF7qNk/tVNiYCWc8=
+github.com/donovanhide/eventsource v0.0.0-20171031113327-3ed64d21fb0b/go.mod h1:56wL82FO0bfMU5RvfXoIwSOP2ggqqxT+tAfNEIyxuHw=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/test/compat_test.go
+++ b/test/compat_test.go
@@ -1,0 +1,137 @@
+package test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	lapi "github.com/LINBIT/golinstor/client"
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/golang/protobuf/ptypes/timestamp"
+	"github.com/piraeusdatastore/linstor-csi/pkg/client"
+	hlc "github.com/piraeusdatastore/linstor-csi/pkg/linstor/highlevelclient"
+	"github.com/piraeusdatastore/linstor-csi/pkg/volume"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	snapshotA = &csi.Snapshot{
+		SnapshotId:     "snapshot-a1b89a9c-f59d-40f1-843a-e4240e98d956",
+		SourceVolumeId: "pvc-5113e62a-2874-421c-979a-ef08e1543581",
+		CreationTime: &timestamp.Timestamp{
+			Seconds: 1607588003,
+			Nanos:   699615502,
+		},
+		SizeBytes:  838860800,
+		ReadyToUse: true,
+	}
+
+	snapshotB = &csi.Snapshot{
+		SnapshotId:     "snapshot-2255bcf5-6e8a-43ba-8856-a3e330424831",
+		SourceVolumeId: "pvc-9f0cceb1-6ef7-425e-9f29-15c482b3ac65",
+		CreationTime: &timestamp.Timestamp{
+			Seconds: 1607588003,
+			Nanos:   274799909,
+		},
+		SizeBytes:  524288000,
+		ReadyToUse: true,
+	}
+
+	fakeControllerResponses = []fakeControllerCfg{
+		{
+			Path:     "/v1/view/snapshots",
+			Response: "[{\"name\":\"snapshot-a1b89a9c-f59d-40f1-843a-e4240e98d956\",\"resource_name\":\"pvc-5113e62a-2874-421c-979a-ef08e1543581\",\"nodes\":[\"demo1.linstor-days.at.linbit.com\",\"demo2.linstor-days.at.linbit.com\",\"demo3.linstor-days.at.linbit.com\"],\"props\":{\"Aux/csi-volume-annotations\":\"{\\\"name\\\":\\\"pvc-5113e62a-2874-421c-979a-ef08e1543581\\\",\\\"id\\\":\\\"pvc-5113e62a-2874-421c-979a-ef08e1543581\\\",\\\"createdBy\\\":\\\"linstor.csi.linbit.com\\\",\\\"creationTime\\\":\\\"2020-12-10T08:07:44.79360651Z\\\",\\\"sizeBytes\\\":838860800,\\\"readonly\\\":false,\\\"parameters\\\":{\\\"autoPlace\\\":\\\"3\\\",\\\"resourceGroup\\\":\\\"linstor-3-replicas\\\",\\\"storagePool\\\":\\\"vdb\\\"},\\\"snapshots\\\":[]}\",\"DrbdOptions/Resource/on-no-quorum\":\"io-error\",\"DrbdOptions/Resource/quorum\":\"majority\",\"DrbdPrimarySetOn\":\"DEMO3.LINSTOR-DAYS.AT.LINBIT.COM\",\"SequenceNumber\":\"1\"},\"flags\":[\"SUCCESSFUL\"],\"volume_definitions\":[{\"volume_number\":0,\"size_kib\":819200}],\"uuid\":\"0b733015-6d70-4b04-878e-08faa1992bc3\",\"snapshots\":[{\"snapshot_name\":\"snapshot-a1b89a9c-f59d-40f1-843a-e4240e98d956\",\"node_name\":\"demo1.linstor-days.at.linbit.com\",\"create_timestamp\":1607588002126,\"uuid\":\"8f19860f-d7f8-4082-a145-d28e2cd556cc\"},{\"snapshot_name\":\"snapshot-a1b89a9c-f59d-40f1-843a-e4240e98d956\",\"node_name\":\"demo2.linstor-days.at.linbit.com\",\"create_timestamp\":1607588002126,\"uuid\":\"2eee497e-b368-4957-b559-0de8baea0f36\"},{\"snapshot_name\":\"snapshot-a1b89a9c-f59d-40f1-843a-e4240e98d956\",\"node_name\":\"demo3.linstor-days.at.linbit.com\",\"create_timestamp\":1607588002126,\"uuid\":\"e2fe91c2-3ead-4d7f-b464-cd2595465417\"}]},{\"name\":\"snapshot-2255bcf5-6e8a-43ba-8856-a3e330424831\",\"resource_name\":\"pvc-9f0cceb1-6ef7-425e-9f29-15c482b3ac65\",\"nodes\":[\"demo1.linstor-days.at.linbit.com\",\"demo2.linstor-days.at.linbit.com\",\"demo3.linstor-days.at.linbit.com\"],\"props\":{\"Aux/csi-volume-annotations\":\"{\\\"name\\\":\\\"pvc-9f0cceb1-6ef7-425e-9f29-15c482b3ac65\\\",\\\"id\\\":\\\"pvc-9f0cceb1-6ef7-425e-9f29-15c482b3ac65\\\",\\\"createdBy\\\":\\\"linstor.csi.linbit.com\\\",\\\"creationTime\\\":\\\"2020-12-10T08:06:07.850996937Z\\\",\\\"sizeBytes\\\":524288000,\\\"readonly\\\":false,\\\"parameters\\\":{\\\"autoPlace\\\":\\\"3\\\",\\\"resourceGroup\\\":\\\"linstor-3-replicas\\\",\\\"storagePool\\\":\\\"vdb\\\"},\\\"snapshots\\\":[]}\",\"DrbdOptions/Resource/on-no-quorum\":\"io-error\",\"DrbdOptions/Resource/quorum\":\"majority\",\"DrbdPrimarySetOn\":\"DEMO3.LINSTOR-DAYS.AT.LINBIT.COM\",\"SequenceNumber\":\"1\"},\"flags\":[\"SUCCESSFUL\"],\"volume_definitions\":[{\"volume_number\":0,\"size_kib\":512000}],\"uuid\":\"3a9be40d-441d-414a-8958-f6f0cb68289d\",\"snapshots\":[{\"snapshot_name\":\"snapshot-2255bcf5-6e8a-43ba-8856-a3e330424831\",\"node_name\":\"demo1.linstor-days.at.linbit.com\",\"create_timestamp\":1607588001392,\"uuid\":\"8c87e9be-18a1-41f3-8790-8e36a85f7950\"},{\"snapshot_name\":\"snapshot-2255bcf5-6e8a-43ba-8856-a3e330424831\",\"node_name\":\"demo2.linstor-days.at.linbit.com\",\"create_timestamp\":1607588001393,\"uuid\":\"b8f309fe-5b27-42b5-9c9c-e50cf025dd9e\"},{\"snapshot_name\":\"snapshot-2255bcf5-6e8a-43ba-8856-a3e330424831\",\"node_name\":\"demo3.linstor-days.at.linbit.com\",\"create_timestamp\":1607588001393,\"uuid\":\"8c6fea5f-7350-46b8-882e-179bd48b724e\"}]}]",
+		},
+		{
+			Path:     "/v1/resource-definitions",
+			Response: "[{\"name\":\"pvc-5113e62a-2874-421c-979a-ef08e1543581\",\"external_name\":\"pvc-5113e62a-2874-421c-979a-ef08e1543581\",\"props\":{\"DrbdPrimarySetOn\":\"DEMO3.LINSTOR-DAYS.AT.LINBIT.COM\",\"Aux/csi-volume-annotations\":\"{\\\"name\\\":\\\"pvc-5113e62a-2874-421c-979a-ef08e1543581\\\",\\\"id\\\":\\\"pvc-5113e62a-2874-421c-979a-ef08e1543581\\\",\\\"createdBy\\\":\\\"linstor.csi.linbit.com\\\",\\\"creationTime\\\":\\\"2020-12-10T08:07:44.79360651Z\\\",\\\"sizeBytes\\\":838860800,\\\"readonly\\\":false,\\\"parameters\\\":{\\\"autoPlace\\\":\\\"3\\\",\\\"resourceGroup\\\":\\\"linstor-3-replicas\\\",\\\"storagePool\\\":\\\"vdb\\\"},\\\"snapshots\\\":[{\\\"name\\\":\\\"snapshot-a1b89a9c-f59d-40f1-843a-e4240e98d956\\\",\\\"csiSnapshot\\\":{\\\"size_bytes\\\":838860800,\\\"snapshot_id\\\":\\\"snapshot-a1b89a9c-f59d-40f1-843a-e4240e98d956\\\",\\\"source_volume_id\\\":\\\"pvc-5113e62a-2874-421c-979a-ef08e1543581\\\",\\\"creation_time\\\":{\\\"seconds\\\":1607588003,\\\"nanos\\\":699615502},\\\"ready_to_use\\\":true}}]}\",\"DrbdOptions/Resource/on-no-quorum\":\"io-error\",\"DrbdOptions/Resource/quorum\":\"majority\"},\"layer_data\":[{\"type\":\"DRBD\",\"data\":{\"peer_slots\":7,\"al_stripes\":1,\"al_stripe_size_kib\":32,\"port\":7001,\"transport_type\":\"IP\",\"secret\":\"KTEO4qfkz4HIEPeCloRT\",\"down\":false}}],\"uuid\":\"470c748a-3888-4011-b63f-274f943890c2\",\"resource_group_name\":\"linstor-3-replicas\"},{\"name\":\"pvc-9f0cceb1-6ef7-425e-9f29-15c482b3ac65\",\"external_name\":\"pvc-9f0cceb1-6ef7-425e-9f29-15c482b3ac65\",\"props\":{\"DrbdPrimarySetOn\":\"DEMO3.LINSTOR-DAYS.AT.LINBIT.COM\",\"Aux/csi-volume-annotations\":\"{\\\"name\\\":\\\"pvc-9f0cceb1-6ef7-425e-9f29-15c482b3ac65\\\",\\\"id\\\":\\\"pvc-9f0cceb1-6ef7-425e-9f29-15c482b3ac65\\\",\\\"createdBy\\\":\\\"linstor.csi.linbit.com\\\",\\\"creationTime\\\":\\\"2020-12-10T08:06:07.850996937Z\\\",\\\"sizeBytes\\\":524288000,\\\"readonly\\\":false,\\\"parameters\\\":{\\\"autoPlace\\\":\\\"3\\\",\\\"resourceGroup\\\":\\\"linstor-3-replicas\\\",\\\"storagePool\\\":\\\"vdb\\\"},\\\"snapshots\\\":[{\\\"name\\\":\\\"snapshot-2255bcf5-6e8a-43ba-8856-a3e330424831\\\",\\\"csiSnapshot\\\":{\\\"size_bytes\\\":524288000,\\\"snapshot_id\\\":\\\"snapshot-2255bcf5-6e8a-43ba-8856-a3e330424831\\\",\\\"source_volume_id\\\":\\\"pvc-9f0cceb1-6ef7-425e-9f29-15c482b3ac65\\\",\\\"creation_time\\\":{\\\"seconds\\\":1607588003,\\\"nanos\\\":274799909},\\\"ready_to_use\\\":true}}]}\",\"DrbdOptions/Resource/on-no-quorum\":\"io-error\",\"DrbdOptions/Resource/quorum\":\"majority\"},\"layer_data\":[{\"type\":\"DRBD\",\"data\":{\"peer_slots\":7,\"al_stripes\":1,\"al_stripe_size_kib\":32,\"port\":7000,\"transport_type\":\"IP\",\"secret\":\"0yUVJALiaegVZtj/9f3D\",\"down\":false}}],\"uuid\":\"4f55956e-4cb1-4303-af51-3401173e0fd7\",\"resource_group_name\":\"linstor-3-replicas\"},{\"name\":\"pvc-a2c61755-25b4-4799-b6e1-36dc889a1604\",\"external_name\":\"pvc-a2c61755-25b4-4799-b6e1-36dc889a1604\",\"props\":{\"DrbdPrimarySetOn\":\"DEMO3.LINSTOR-DAYS.AT.LINBIT.COM\",\"SequenceNumber\":\"1\",\"Aux/csi-volume-annotations\":\"{\\\"name\\\":\\\"pvc-a2c61755-25b4-4799-b6e1-36dc889a1604\\\",\\\"id\\\":\\\"pvc-a2c61755-25b4-4799-b6e1-36dc889a1604\\\",\\\"createdBy\\\":\\\"linstor.csi.linbit.com\\\",\\\"creationTime\\\":\\\"2020-12-10T08:40:26.035193795Z\\\",\\\"sizeBytes\\\":858993459200,\\\"readonly\\\":false,\\\"parameters\\\":{\\\"autoPlace\\\":\\\"3\\\",\\\"resourceGroup\\\":\\\"linstor-3-replicas\\\",\\\"storagePool\\\":\\\"vdb\\\"},\\\"snapshots\\\":[]}\",\"DrbdOptions/Resource/on-no-quorum\":\"io-error\",\"DrbdOptions/Resource/quorum\":\"majority\"},\"layer_data\":[{\"type\":\"DRBD\",\"data\":{\"peer_slots\":7,\"al_stripes\":1,\"al_stripe_size_kib\":32,\"port\":7002,\"transport_type\":\"IP\",\"secret\":\"UPRKVMupBCrS/GFOfFi1\",\"down\":false}}],\"uuid\":\"5c73fdfe-abf4-4f79-a1be-4a0b2f221cca\",\"resource_group_name\":\"linstor-3-replicas\"}]",
+		},
+		{
+			Path:     "/v1/resource-definitions/pvc-a2c61755-25b4-4799-b6e1-36dc889a1604/snapshots",
+			Response: "[]",
+		},
+		{
+			Path:     "/v1/resource-definitions/pvc-9f0cceb1-6ef7-425e-9f29-15c482b3ac65/snapshots",
+			Response: "[{\"name\":\"snapshot-2255bcf5-6e8a-43ba-8856-a3e330424831\",\"resource_name\":\"pvc-9f0cceb1-6ef7-425e-9f29-15c482b3ac65\",\"nodes\":[\"demo1.linstor-days.at.linbit.com\",\"demo2.linstor-days.at.linbit.com\",\"demo3.linstor-days.at.linbit.com\"],\"props\":{\"Aux/csi-volume-annotations\":\"{\\\"name\\\":\\\"pvc-9f0cceb1-6ef7-425e-9f29-15c482b3ac65\\\",\\\"id\\\":\\\"pvc-9f0cceb1-6ef7-425e-9f29-15c482b3ac65\\\",\\\"createdBy\\\":\\\"linstor.csi.linbit.com\\\",\\\"creationTime\\\":\\\"2020-12-10T08:06:07.850996937Z\\\",\\\"sizeBytes\\\":524288000,\\\"readonly\\\":false,\\\"parameters\\\":{\\\"autoPlace\\\":\\\"3\\\",\\\"resourceGroup\\\":\\\"linstor-3-replicas\\\",\\\"storagePool\\\":\\\"vdb\\\"},\\\"snapshots\\\":[]}\",\"DrbdOptions/Resource/on-no-quorum\":\"io-error\",\"DrbdOptions/Resource/quorum\":\"majority\",\"DrbdPrimarySetOn\":\"DEMO3.LINSTOR-DAYS.AT.LINBIT.COM\",\"SequenceNumber\":\"1\"},\"flags\":[\"SUCCESSFUL\"],\"volume_definitions\":[{\"volume_number\":0,\"size_kib\":512000}],\"uuid\":\"3a9be40d-441d-414a-8958-f6f0cb68289d\",\"snapshots\":[{\"snapshot_name\":\"snapshot-2255bcf5-6e8a-43ba-8856-a3e330424831\",\"node_name\":\"demo1.linstor-days.at.linbit.com\",\"create_timestamp\":1607588001392,\"uuid\":\"8c87e9be-18a1-41f3-8790-8e36a85f7950\"},{\"snapshot_name\":\"snapshot-2255bcf5-6e8a-43ba-8856-a3e330424831\",\"node_name\":\"demo2.linstor-days.at.linbit.com\",\"create_timestamp\":1607588001393,\"uuid\":\"b8f309fe-5b27-42b5-9c9c-e50cf025dd9e\"},{\"snapshot_name\":\"snapshot-2255bcf5-6e8a-43ba-8856-a3e330424831\",\"node_name\":\"demo3.linstor-days.at.linbit.com\",\"create_timestamp\":1607588001393,\"uuid\":\"8c6fea5f-7350-46b8-882e-179bd48b724e\"}]}]",
+		},
+		{
+			Path:     "/v1/resource-definitions/pvc-5113e62a-2874-421c-979a-ef08e1543581/snapshots",
+			Response: "[{\"name\":\"snapshot-a1b89a9c-f59d-40f1-843a-e4240e98d956\",\"resource_name\":\"pvc-5113e62a-2874-421c-979a-ef08e1543581\",\"nodes\":[\"demo1.linstor-days.at.linbit.com\",\"demo2.linstor-days.at.linbit.com\",\"demo3.linstor-days.at.linbit.com\"],\"props\":{\"Aux/csi-volume-annotations\":\"{\\\"name\\\":\\\"pvc-5113e62a-2874-421c-979a-ef08e1543581\\\",\\\"id\\\":\\\"pvc-5113e62a-2874-421c-979a-ef08e1543581\\\",\\\"createdBy\\\":\\\"linstor.csi.linbit.com\\\",\\\"creationTime\\\":\\\"2020-12-10T08:07:44.79360651Z\\\",\\\"sizeBytes\\\":838860800,\\\"readonly\\\":false,\\\"parameters\\\":{\\\"autoPlace\\\":\\\"3\\\",\\\"resourceGroup\\\":\\\"linstor-3-replicas\\\",\\\"storagePool\\\":\\\"vdb\\\"},\\\"snapshots\\\":[]}\",\"DrbdOptions/Resource/on-no-quorum\":\"io-error\",\"DrbdOptions/Resource/quorum\":\"majority\",\"DrbdPrimarySetOn\":\"DEMO3.LINSTOR-DAYS.AT.LINBIT.COM\",\"SequenceNumber\":\"1\"},\"flags\":[\"SUCCESSFUL\"],\"volume_definitions\":[{\"volume_number\":0,\"size_kib\":819200}],\"uuid\":\"0b733015-6d70-4b04-878e-08faa1992bc3\",\"snapshots\":[{\"snapshot_name\":\"snapshot-a1b89a9c-f59d-40f1-843a-e4240e98d956\",\"node_name\":\"demo1.linstor-days.at.linbit.com\",\"create_timestamp\":1607588002126,\"uuid\":\"8f19860f-d7f8-4082-a145-d28e2cd556cc\"},{\"snapshot_name\":\"snapshot-a1b89a9c-f59d-40f1-843a-e4240e98d956\",\"node_name\":\"demo2.linstor-days.at.linbit.com\",\"create_timestamp\":1607588002126,\"uuid\":\"2eee497e-b368-4957-b559-0de8baea0f36\"},{\"snapshot_name\":\"snapshot-a1b89a9c-f59d-40f1-843a-e4240e98d956\",\"node_name\":\"demo3.linstor-days.at.linbit.com\",\"create_timestamp\":1607588002126,\"uuid\":\"e2fe91c2-3ead-4d7f-b464-cd2595465417\"}]}]",
+		},
+	}
+)
+
+type fakeControllerCfg struct {
+	Path     string
+	Response string
+}
+
+func prepareFakeClient(t *testing.T) *client.Linstor {
+	handler := &http.ServeMux{}
+	for i := range fakeControllerResponses {
+		cfg := fakeControllerResponses[i]
+		handler.HandleFunc(cfg.Path, func(writer http.ResponseWriter, request *http.Request) {
+			_, _ = writer.Write([]byte(cfg.Response))
+		})
+	}
+
+	httpMock := httptest.NewServer(handler)
+	t.Cleanup(httpMock.Close)
+
+	baseURL, err := url.Parse(httpMock.URL)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	compatLinstorClient, err := hlc.NewHighLevelClient(lapi.HTTPClient(httpMock.Client()), lapi.BaseURL(baseURL))
+
+	compatClient, err := client.NewLinstor(client.APIClient(compatLinstorClient))
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	return compatClient
+}
+
+func TestCompatListSnaps(t *testing.T) {
+	ctx := context.Background()
+
+	compatClient := prepareFakeClient(t)
+
+	snaps, err := compatClient.ListSnaps(ctx)
+	assert.NoError(t, err)
+
+	expectedSnaps := []*volume.SnapInfo{
+		{
+			Name:    snapshotA.SnapshotId,
+			CsiSnap: snapshotA,
+		},
+		{
+			Name:    snapshotB.SnapshotId,
+			CsiSnap: snapshotB,
+		},
+	}
+	assert.ElementsMatch(t, expectedSnaps, snaps)
+}
+
+func TestCompatGetSnapByID(t *testing.T) {
+	ctx := context.Background()
+
+	compatClient := prepareFakeClient(t)
+
+	empty, err := compatClient.GetSnapByID(ctx, "none")
+	assert.NoError(t, err)
+	assert.Empty(t, empty)
+
+	actual, err := compatClient.GetSnapByID(ctx, snapshotA.SnapshotId)
+	assert.NoError(t, err)
+	assert.NotNil(t, actual)
+
+	expected := &volume.SnapInfo{
+		Name:    snapshotA.SnapshotId,
+		CsiSnap: snapshotA,
+	}
+	assert.Equal(t, expected, actual)
+}


### PR DESCRIPTION
The changes in detail:

Instead of storing snapshot information in resource definitions, use native
LINSTOR snapshots. This makes it easier to retry a timed out snapshot attempt.
A basic test was added using "old" format LINSTOR responses to ensure no
information is lost in transition.

To ensure stable snapshot ID between tries, the suggested name is either
used directly or a generated UUIDv5 based on the name is used. Since the CSI
snapshotter image will always suggest a compatible name, this is mostly done
for complying with the CSI spec.

In volume-from-volume scenario, re-use the snap-create and vol-from-snap logic
instead of implementing it in the LINSTOR client. This is done by first creating
a stable snapshot name for the new PVC, restoring using the existing
vol-from-snap logic and deleting the snapshot again.

The snapshots itself are only considered ready if LINSTOR reports the SUCCESS
flag. This prevents a lot of churn with snapshots that are not immediatly ready
being deleted over and over again.

Pagination is handled directly by the client, as we use the /view/snapshots
API directly.
