### PR TITLE
pass layerlist in all resource create requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- LayerList was ignored when not using the AutoPlace scheduler. All schedulers not pass this information to LINSTOR. [#102]
+
+[#102]: https://github.com/piraeusdatastore/linstor-csi/issues/102
+
 ## [0.10.2] - 2020-12-04
 
 ### Fixed

--- a/pkg/topology/scheduler/balancer/balancer.go
+++ b/pkg/topology/scheduler/balancer/balancer.go
@@ -421,5 +421,6 @@ func volToDiskfullResourceCreate(vol *volume.Info, params volume.Parameters, nod
 			},
 			Flags: make([]string, 0),
 		},
+		LayerList: params.LayerList,
 	}
 }

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -401,7 +401,9 @@ func (i *Info) toGenericResourceCreate(params Parameters, node string) lapi.Reso
 			NodeName: node,
 			Props:    make(map[string]string, 1),
 			Flags:    make([]string, 0),
-		}}
+		},
+		LayerList: params.LayerList,
+	}
 }
 
 // ToAutoPlace prepares a Info to be deployed by linstor via autoplace.


### PR DESCRIPTION
The LayerList must be passed to LINSTOR anytime a resource is created.
This commit adds the information to all create calls. Previously, it was
only done in AutoPlace requests.

Fixes #102 