### PR TITLE
Update examples

### DIFF
--- a/examples/k8s/deploy/linstor-csi-1.17.yaml
+++ b/examples/k8s/deploy/linstor-csi-1.17.yaml
@@ -381,3 +381,17 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots/status"]
     verbs: ["update"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linstor-csi-snapshotter-binding
+subjects:
+  - kind: ServiceAccount
+    name: linstor-csi-controller-sa
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: linstor-csi-snapshotter-role
+  apiGroup: rbac.authorization.k8s.io

--- a/examples/k8s/deploy/linstor-csi-1.17.yaml
+++ b/examples/k8s/deploy/linstor-csi-1.17.yaml
@@ -18,7 +18,7 @@ spec:
         role: linstor-csi
     spec:
       priorityClassName: system-cluster-critical
-      serviceAccount: linstor-csi-controller-sa
+      serviceAccountName: linstor-csi-controller-sa
       containers:
         - name: csi-provisioner
           image: quay.io/k8scsi/csi-provisioner:v1.5.0
@@ -227,7 +227,7 @@ spec:
         role: linstor-csi
     spec:
       priorityClassName: system-node-critical
-      serviceAccount: linstor-csi-node-sa
+      serviceAccountName: linstor-csi-node-sa
       containers:
         - name: csi-node-driver-registrar
           image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0

--- a/examples/k8s/deploy/linstor-csi-1.19.yaml
+++ b/examples/k8s/deploy/linstor-csi-1.19.yaml
@@ -387,3 +387,17 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots/status"]
     verbs: ["update"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linstor-csi-snapshotter-binding
+subjects:
+  - kind: ServiceAccount
+    name: linstor-csi-controller-sa
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: linstor-csi-snapshotter-role
+  apiGroup: rbac.authorization.k8s.io

--- a/examples/k8s/deploy/linstor-csi-1.19.yaml
+++ b/examples/k8s/deploy/linstor-csi-1.19.yaml
@@ -18,7 +18,7 @@ spec:
         role: linstor-csi
     spec:
       priorityClassName: system-cluster-critical
-      serviceAccount: linstor-csi-controller-sa
+      serviceAccountName: linstor-csi-controller-sa
       containers:
         - name: csi-provisioner
           image: quay.io/k8scsi/csi-provisioner:v2.0.2
@@ -233,7 +233,7 @@ spec:
         role: linstor-csi
     spec:
       priorityClassName: system-node-critical
-      serviceAccount: linstor-csi-node-sa
+      serviceAccountName: linstor-csi-node-sa
       containers:
         - name: csi-node-driver-registrar
           image: quay.io/k8scsi/csi-node-driver-registrar:v2.0.1

--- a/examples/k8s/deploy/linstor-csi-dev.yaml
+++ b/examples/k8s/deploy/linstor-csi-dev.yaml
@@ -381,3 +381,17 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots/status"]
     verbs: ["update"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: linstor-csi-snapshotter-binding
+subjects:
+  - kind: ServiceAccount
+    name: linstor-csi-controller-sa
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: linstor-csi-snapshotter-role
+  apiGroup: rbac.authorization.k8s.io

--- a/examples/k8s/deploy/linstor-csi-dev.yaml
+++ b/examples/k8s/deploy/linstor-csi-dev.yaml
@@ -18,7 +18,7 @@ spec:
         role: linstor-csi
     spec:
       priorityClassName: system-cluster-critical
-      serviceAccount: linstor-csi-controller-sa
+      serviceAccountName: linstor-csi-controller-sa
       containers:
         - name: csi-provisioner
           image: quay.io/k8scsi/csi-provisioner:v1.5.0
@@ -227,7 +227,7 @@ spec:
         role: linstor-csi
     spec:
       priorityClassName: system-node-critical
-      serviceAccount: linstor-csi-node-sa
+      serviceAccountName: linstor-csi-node-sa
       containers:
         - name: csi-node-driver-registrar
           image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0


### PR DESCRIPTION
* Use `serviceAccountName` instead of deprecated `serviceAccount`
* Add role binding for snapshotter role (closes #104)