### PR TITLE
add "nouuid" option to XFS mounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Add `nouuid` to default XFS mount options. This enables mounting restored snapshots on the same node as the original.
+
 ## [0.11.0] - 2020-12-21
 
 ### Changed

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -300,6 +300,12 @@ func (d Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolum
 		}
 	}
 
+	if fsType == "xfs" {
+		// Restored snapshots inherit the XFS UUID of the original source. If mounted on the same node as the original
+		// without this option, XFS will complain about a duplicate UUID and refuse to mount.
+		mntOpts = append(mntOpts, "nouuid")
+	}
+
 	// Retrieve device path from storage backend.
 	existingVolume, err := d.Storage.FindByID(ctx, req.GetVolumeId())
 	if err != nil {


### PR DESCRIPTION
Restored snapshots inherit the XFS UUID of the original source. If mounted
on the same node as the original without the "nouuid" option, XFS will
complain about a duplicate UUID and refuse to mount.