### PR TITLE
Make snapshots independent from their source PV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- PVCs can now be deleted independently of Snapshots. LINSTOR ResourceDefinitions for the PVC will exist until
+  both Snapshots and Resources are deleted.
+
 ### Fixed
 - Add `nouuid` to default XFS mount options. This enables mounting restored snapshots on the same node as the original.
 

--- a/pkg/client/linstor.go
+++ b/pkg/client/linstor.go
@@ -648,12 +648,12 @@ func (s *Linstor) reconcileResourceGroup(ctx context.Context, params volume.Para
 		}
 	}
 
-	rgModify, err := params.ToResourceGroupModify(&rg)
-	if err != nil {
-		return nil, err
-	}
-	if err := s.client.ResourceGroups.Modify(ctx, rgName, rgModify); err != nil {
-		return nil, err
+	rgModify, changed := params.ToResourceGroupModify(&rg)
+	if changed {
+		err := s.client.ResourceGroups.Modify(ctx, rgName, rgModify)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	rg, err = s.client.ResourceGroups.Get(ctx, rgName)

--- a/pkg/volume/volume_test.go
+++ b/pkg/volume/volume_test.go
@@ -40,10 +40,10 @@ func TestDisklessFlag(t *testing.T) {
 			isError:  false,
 		},
 		{
-			name: "openflex-like-nvme",
-			params: volume.Parameters{LayerList: []lapi.LayerType{lapi.OPENFLEX, lapi.STORAGE}},
+			name:     "openflex-like-nvme",
+			params:   volume.Parameters{LayerList: []lapi.LayerType{lapi.OPENFLEX, lapi.STORAGE}},
 			expected: lc.FlagNvmeInitiator,
-			isError: false,
+			isError:  false,
 		},
 		{
 			name:     "no-diskless-layer",
@@ -64,6 +64,59 @@ func TestDisklessFlag(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestParameters_ToResourceGroupModify(t *testing.T) {
+	testcases := []struct {
+		name            string
+		params          volume.Parameters
+		existing        lapi.ResourceGroup
+		expectedModify  lapi.ResourceGroupModify
+		expectedChanged bool
+	}{
+		{
+			name:           "matching-rg-is-empty-modify",
+			params:         volume.Parameters{DRBDOpts: map[string]string{"DrbdOptions/Net/Protocol": "C"}, LayerList: []lapi.LayerType{lapi.DRBD, lapi.STORAGE}, PlacementCount: 2, ResourceGroup: "matching-rg-is-empty-modify"},
+			existing:       lapi.ResourceGroup{Name: "matching-rg-is-empty-modify", Props: map[string]string{lc.KeyStorPoolName: "", "DrbdOptions/Net/Protocol": "C"}, SelectFilter: lapi.AutoSelectFilter{LayerStack: []string{string(lapi.DRBD), string(lapi.STORAGE)}, PlaceCount: 2}},
+			expectedModify: lapi.ResourceGroupModify{OverrideProps: map[string]string{}},
+		},
+		{
+			name:     "wrong-select-filters",
+			params:   volume.Parameters{LayerList: []lapi.LayerType{lapi.WRITECACHE, lapi.DRBD, lapi.STORAGE}, PlacementCount: 3, ResourceGroup: "wrong-select-filters", StoragePool: "pool"},
+			existing: lapi.ResourceGroup{Name: "wrong-select-filters", SelectFilter: lapi.AutoSelectFilter{LayerStack: []string{string(lapi.DRBD)}, PlaceCount: 2}},
+			expectedModify: lapi.ResourceGroupModify{
+				OverrideProps: map[string]string{
+					lc.KeyStorPoolName: "pool",
+				},
+				SelectFilter: lapi.AutoSelectFilter{
+					LayerStack:  []string{string(lapi.WRITECACHE), string(lapi.DRBD), string(lapi.STORAGE)},
+					PlaceCount:  3,
+					StoragePool: "pool",
+				},
+			},
+			expectedChanged: true,
+		},
+		{
+			name:     "override-and-delete-props",
+			params:   volume.Parameters{DRBDOpts: map[string]string{"DrbdOptions/Net/Protocol": "C"}, LayerList: []lapi.LayerType{lapi.DRBD, lapi.STORAGE}, PlacementCount: 2, ResourceGroup: "override-and-delete-props"},
+			existing: lapi.ResourceGroup{Name: "override-and-delete-props", Props: map[string]string{lc.KeyStorPoolName: "", "DrbdOptions/Net/Protocol": "A", "DrbdOptions/Foo/Bar": "baz"}, SelectFilter: lapi.AutoSelectFilter{LayerStack: []string{string(lapi.DRBD), string(lapi.STORAGE)}, PlaceCount: 2}},
+			expectedModify: lapi.ResourceGroupModify{
+				OverrideProps: map[string]string{"DrbdOptions/Net/Protocol": "C"},
+				DeleteProps:   []string{"DrbdOptions/Foo/Bar"},
+			},
+			expectedChanged: true,
+		},
+	}
+
+	t.Parallel()
+	for i := range testcases {
+		tcase := testcases[i]
+		t.Run(tcase.name, func(t *testing.T) {
+			actualModified, actualChanged := tcase.params.ToResourceGroupModify(&tcase.existing)
+			assert.Equal(t, tcase.expectedChanged, actualChanged)
+			assert.Equal(t, tcase.expectedModify, actualModified)
 		})
 	}
 }


### PR DESCRIPTION
This commit enables deletion of PV while taken snapshots are kept around.
To implement this a couple of changes needed to be made:

Snapshots in LINSTOR are attached to a ResourceDefinition (RD), not to the
Resources directly. This means we can remove a PV by deleting the Resources
in LINSTOR without deleting the RD.

In turn, we cannot rely on the "volume.Info" struct to exist when
restoring from a snapshot. While it was queried, it actually did not serve
any purpose, the query is just removed.

Not deleting the RD on PV deletion requires another set of changes:
* Once the last RD "user" (Resource or Snapshot) is deleted, we need to
  delete the RD (and maybe also the Resource Group)
* We use aux props on the RD to persist important metadata. Specifically,
  it was also used to identify RDs and their matching PV. This metadata
  is now stripped on volume deletion.