### PR TITLE
only delete resources on Detach if created in Attach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Add `nouuid` to default XFS mount options. This enables mounting restored snapshots on the same node as the original.
+- Detach() operations no longer delete existing diskless resources (i.e. TieBreaker resources), only those created by
+  Attach() operations.
 
 ## [0.11.0] - 2020-12-21
 

--- a/pkg/linstor/const.go
+++ b/pkg/linstor/const.go
@@ -18,6 +18,19 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 package linstor
 
-// AnnotationsKey is the Aux props key in linstor where serialized CSI volumes
-// are stored.
-const AnnotationsKey = "Aux/csi-volume-annotations"
+import lc "github.com/LINBIT/golinstor"
+
+
+const (
+	// AnnotationsKey is the Aux props key in linstor where serialized CSI volumes
+	// are stored.
+	AnnotationsKey = lc.NamespcAuxiliary + "/csi-volume-annotations"
+
+	// PropertyCreatedFor is the Aux props key in linstor used to identify why a specific object (for example, a
+	// resource) exists.
+	PropertyCreatedFor = lc.NamespcAuxiliary + "/csi-created-for"
+
+	// CreatedForTemporaryDisklessAttach marks a resource as temporary, i.e. it should be removed after it is no longer
+	// needed.
+	CreatedForTemporaryDisklessAttach = "temporary-diskless-attach"
+)


### PR DESCRIPTION
We want to delete resources that were only created to facilitate an Attach()
request. The way this was determined was by checking if the given resource is
diskless or not. This presents a problem, as there are a number of ways
diskless resources get created:
* Linstor creates a TieBreaker resource
* The user specified that a Diskless resource should be placed on that node
* Attach() was called for a node were the resource was not present

From the point of view of Detach(), all these above cases look the same, and
so the resources were deleted even if they did not originate from the Attach.

This commit adds a new property to resources generated by Attach. This way
Detach can later check for the presence of this property, and only delete
the resource if:
* The resource has the "Attach" property
* The resource is still diskless (there could be cases in which LINSTOR
  migrated some replicas from a evicted node) Since we don't want to mess
  with the replication factor, diskfull resources are off-limits.