### PR TITLE
Fix handling of DELETE flag on resource creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Controller no longer treats LINSTOR resource(-definitions) as ready when the DELETE flag is set. Operations are now
+  aborted early and tried again later when the LINSTOR resource is really gone.
+
 ## [0.12.0] - 2021-01-26
 
 ### Changed


### PR DESCRIPTION
Operations that should reconcile the creation of resource did not check
for the DELETE flag if a resource with matching ID was already created. This
meant that later stages potentially tried using resources that no longer exist.