### PR TITLE
Remove failed attempts at creating a snapshot

### DIFF
--- a/pkg/client/mock.go
+++ b/pkg/client/mock.go
@@ -137,13 +137,13 @@ func (s *MockStorage) ListSnaps(ctx context.Context, start, limit int) ([]*csi.S
 	return s.snapshots[start:end], nil
 }
 
-func (s *MockStorage) FindSnapByID(ctx context.Context, id string) (*csi.Snapshot, error) {
+func (s *MockStorage) FindSnapByID(ctx context.Context, id string) (*csi.Snapshot, bool, error) {
 	for _, snap := range s.snapshots {
 		if snap.GetSnapshotId() == id {
-			return snap, nil
+			return snap, true, nil
 		}
 	}
-	return nil, nil
+	return nil, false, nil
 }
 
 func (s *MockStorage) FindSnapsBySource(ctx context.Context, sourceVol *volume.Info, start, limit int) ([]*csi.Snapshot, error) {

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -476,7 +476,12 @@ type SnapshotCreateDeleter interface {
 	CompatibleSnapshotId(name string) string
 	SnapCreate(ctx context.Context, id string, sourceVol *Info) (*csi.Snapshot, error)
 	SnapDelete(ctx context.Context, snap *csi.Snapshot) error
-	FindSnapByID(ctx context.Context, id string) (*csi.Snapshot, error)
+	// FindSnapByID searches the snapshot in the backend
+	// It returns:
+	// * the snapshot, nil if not found
+	// * true, if the snapshot is either in progress or successful
+	// * any error encountered
+	FindSnapByID(ctx context.Context, id string) (*csi.Snapshot, bool, error)
 	FindSnapsBySource(ctx context.Context, sourceVol *Info, start, limit int) ([]*csi.Snapshot, error)
 	// List Snapshots should return a sorted list of snapshots.
 	ListSnaps(ctx context.Context, start, limit int) ([]*csi.Snapshot, error)

--- a/test/compat_test.go
+++ b/test/compat_test.go
@@ -110,12 +110,14 @@ func TestCompatFindSnapByID(t *testing.T) {
 
 	compatClient := prepareFakeClient(t)
 
-	empty, err := compatClient.FindSnapByID(ctx, "none")
+	empty, ok, err := compatClient.FindSnapByID(ctx, "none")
 	assert.NoError(t, err)
+	assert.True(t, ok)
 	assert.Empty(t, empty)
 
-	actual, err := compatClient.FindSnapByID(ctx, snapshotA.SnapshotId)
+	actual, ok, err := compatClient.FindSnapByID(ctx, snapshotA.SnapshotId)
 	assert.NoError(t, err)
+	assert.True(t, ok)
 	assert.Equal(t, snapshotA, actual)
 }
 


### PR DESCRIPTION
In some cases snapshots are created but fail to become "successful",
for example when one of the satellite goes offline at the wrong moment.
In such cases, we want to delete the failed attempt, as otherwise
the CSI snapshotter will forever wait for the snapshot to get ready.
This then produces a lot (read: gigabytes) of logs, as it tries polling
the snapshot state again multiple times per second.

This commit adds logic to recognize such failed snapshots and remove+retry
them. Note that currently there is no way to tell the snapshot controller that
a snapshot can't ever succeed, for example when a storage driver without
snapshot support is used.