### PR TITLE
Bump golinstor to v0.34.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/piraeusdatastore/linstor-csi
 go 1.12
 
 require (
-	github.com/LINBIT/golinstor v0.34.2
+	github.com/LINBIT/golinstor v0.34.3
 	github.com/alvaroloes/enumer v1.1.2
 	github.com/container-storage-interface/spec v1.2.0
 	github.com/golang/protobuf v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/Azure/go-autorest/logger v0.1.0/go.mod h1:oExouG+K6PryycPJfVSxi/koC6L
 github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/LINBIT/golinstor v0.34.2 h1:ViRjpfR31Ck5lhlbN9UDebS1ewhWdPt6bVHsHBcET34=
-github.com/LINBIT/golinstor v0.34.2/go.mod h1:506Wb/BCd449g/u2IGXlsIKNdiEmAEsgyOPrIYjbKyg=
+github.com/LINBIT/golinstor v0.34.3 h1:2iNT/x+6U9lCM5fKrJqYzJknm4ZbtHwx9emFyGLuX4Q=
+github.com/LINBIT/golinstor v0.34.3/go.mod h1:506Wb/BCd449g/u2IGXlsIKNdiEmAEsgyOPrIYjbKyg=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=


### PR DESCRIPTION
A bug in previous golinstor versions meant that responses that
included Volume information always created errors. The broken
golinstor version was only included in 8653ba34f