### PR TITLE
Add bearer authentication for HTTP API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Option to send a bearer token for authentication. This can be used when the API is secured by a project like
+  `kube-rbac-proxy`.
+
 ## [0.13.1] - 2021-06-10
 
 ### Added


### PR DESCRIPTION
If the LINSTOR HTTP API is secured by a project like kube-rbac-proxy, which
secures an endpoint by delegating authentication to the kubernetes built-ins,
namely serviceaccounts and RBAC rules, we need a way to send our
authentication in the form of a bearer token.

On start-up, the token is read from a file specified on the command line. The
Header is added in a specialized http.RoundTripper implementation, since
golinstor currently does not support setting default headers.

This implementation even has the benefit of not logging the token on every
request.

Signed-off-by: Moritz "WanzenBug" Wanzenböck <moritz.wanzenboeck@linbit.com>