### PR TITLE
Make "FollowTopology" adhere strictly to CSI spec

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/piraeusdatastore/linstor-csi
 go 1.12
 
 require (
-	github.com/LINBIT/golinstor v0.34.3
+	github.com/LINBIT/golinstor v0.34.4
 	github.com/alvaroloes/enumer v1.1.2
 	github.com/container-storage-interface/spec v1.4.0
 	github.com/golang/protobuf v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbt
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/LINBIT/golinstor v0.34.3 h1:2iNT/x+6U9lCM5fKrJqYzJknm4ZbtHwx9emFyGLuX4Q=
-github.com/LINBIT/golinstor v0.34.3/go.mod h1:506Wb/BCd449g/u2IGXlsIKNdiEmAEsgyOPrIYjbKyg=
+github.com/LINBIT/golinstor v0.34.4 h1:O+C2/r5pwyoERQkARgxWRdnaV7tFtL95AzFREVQuV6c=
+github.com/LINBIT/golinstor v0.34.4/go.mod h1:506Wb/BCd449g/u2IGXlsIKNdiEmAEsgyOPrIYjbKyg=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=

--- a/pkg/topology/scheduler/followtopology/follow_topology_test.go
+++ b/pkg/topology/scheduler/followtopology/follow_topology_test.go
@@ -1,0 +1,150 @@
+package followtopology_test
+
+import (
+	"context"
+	"testing"
+
+	lapi "github.com/LINBIT/golinstor/client"
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/piraeusdatastore/linstor-csi/pkg/client/mocks"
+	lc "github.com/piraeusdatastore/linstor-csi/pkg/linstor/highlevelclient"
+	"github.com/piraeusdatastore/linstor-csi/pkg/topology"
+	"github.com/piraeusdatastore/linstor-csi/pkg/topology/scheduler/followtopology"
+	"github.com/piraeusdatastore/linstor-csi/pkg/volume"
+)
+
+var (
+	volumeId   = "test-volume"
+	vol        = volume.Info{ID: volumeId, Parameters: map[string]string{"AutoPlace": "2"}}
+	brokenNode = "node2"
+)
+
+type fakeError struct{}
+
+func (f *fakeError) Error() string {
+	return "fake"
+}
+
+func TestScheduler_Create(t *testing.T) {
+	ctx := context.Background()
+
+	m := mocks.ResourceProvider{}
+	m.On("MakeAvailable", mock.Anything, volumeId, brokenNode, mock.Anything).Return(&fakeError{})
+	m.On("MakeAvailable", mock.Anything, volumeId, mock.Anything, mock.Anything).Return(nil)
+	m.On("Autoplace", mock.Anything, volumeId, mock.Anything).Return(nil)
+
+	sched := followtopology.NewScheduler(&lc.HighLevelClient{Client: &lapi.Client{Resources: &m}}, logrus.WithField("test", t.Name()))
+
+	t.Run("no requirements", func(t *testing.T) {
+		// Asserts that if no requirement is given, normal autoplace is performed
+		m.Calls = nil
+
+		err := sched.Create(ctx, &vol, &csi.CreateVolumeRequest{})
+		assert.NoError(t, err)
+		m.AssertCalled(t, "Autoplace", mock.Anything, volumeId, mock.Anything)
+		m.AssertNotCalled(t, "MakeAvailable", mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	t.Run("preferred", func(t *testing.T) {
+		// Asserts that, if only preferred topologies are given, they are created first
+		m.Calls = nil
+
+		err := sched.Create(ctx, &vol, &csi.CreateVolumeRequest{
+			AccessibilityRequirements: &csi.TopologyRequirement{
+				Preferred: []*csi.Topology{
+					{Segments: map[string]string{topology.LinstorNodeKey: "node1"}},
+					{Segments: map[string]string{topology.LinstorNodeKey: "node2"}},
+					{Segments: map[string]string{topology.LinstorNodeKey: "node3"}},
+				},
+			},
+		})
+		assert.NoError(t, err)
+		m.AssertNotCalled(t, "Autoplace", mock.Anything, volumeId, mock.Anything)
+		m.AssertCalled(t, "MakeAvailable", mock.Anything, volumeId, "node1", mock.Anything)
+		m.AssertCalled(t, "MakeAvailable", mock.Anything, volumeId, "node2", mock.Anything)
+		m.AssertCalled(t, "MakeAvailable", mock.Anything, volumeId, "node3", mock.Anything)
+	})
+
+	t.Run("requisite + preferred", func(t *testing.T) {
+		// Asserts that, if both requisite and preferred are given, first we try to place the preferred, then pick from
+		// the remaining requisites
+		m.Calls = nil
+
+		err := sched.Create(ctx, &vol, &csi.CreateVolumeRequest{
+			AccessibilityRequirements: &csi.TopologyRequirement{
+				Requisite: []*csi.Topology{
+					{Segments: map[string]string{topology.LinstorNodeKey: "node1"}},
+					{Segments: map[string]string{topology.LinstorNodeKey: "node2"}},
+					{Segments: map[string]string{topology.LinstorNodeKey: "node3"}},
+					{Segments: map[string]string{topology.LinstorNodeKey: "node4"}},
+				},
+				Preferred: []*csi.Topology{
+					{Segments: map[string]string{topology.LinstorNodeKey: "node2"}},
+					{Segments: map[string]string{topology.LinstorNodeKey: "node4"}},
+				},
+			},
+		})
+		assert.NoError(t, err)
+		m.AssertNotCalled(t, "Autoplace", mock.Anything, volumeId, mock.Anything)
+		m.AssertCalled(t, "MakeAvailable", mock.Anything, volumeId, "node1", mock.Anything)
+		m.AssertCalled(t, "MakeAvailable", mock.Anything, volumeId, "node2", mock.Anything)
+		m.AssertNotCalled(t, "MakeAvailable", mock.Anything, volumeId, "node3", mock.Anything)
+		m.AssertCalled(t, "MakeAvailable", mock.Anything, volumeId, "node4", mock.Anything)
+	})
+
+	t.Run("requisite", func(t *testing.T) {
+		// Asserts that using only requisites will require placement on (one of) these nodes
+		m.Calls = nil
+
+		err := sched.Create(ctx, &vol, &csi.CreateVolumeRequest{
+			AccessibilityRequirements: &csi.TopologyRequirement{
+				Requisite: []*csi.Topology{
+					{Segments: map[string]string{topology.LinstorNodeKey: "node2"}},
+					{Segments: map[string]string{topology.LinstorNodeKey: "node3"}},
+					{Segments: map[string]string{topology.LinstorNodeKey: "node4"}},
+				},
+			},
+		})
+		assert.NoError(t, err)
+		m.AssertNotCalled(t, "Autoplace", mock.Anything, volumeId, mock.Anything)
+		m.AssertCalled(t, "MakeAvailable", mock.Anything, volumeId, "node2", mock.Anything)
+		m.AssertCalled(t, "MakeAvailable", mock.Anything, volumeId, "node3", mock.Anything)
+		m.AssertCalled(t, "MakeAvailable", mock.Anything, volumeId, "node4", mock.Anything)
+	})
+
+	t.Run("requisite impossible", func(t *testing.T) {
+		// Asserts that scheduling reports an error in case non of the requisites could be fulfilled
+		m.Calls = nil
+
+		err := sched.Create(ctx, &vol, &csi.CreateVolumeRequest{
+			AccessibilityRequirements: &csi.TopologyRequirement{
+				Requisite: []*csi.Topology{
+					{Segments: map[string]string{topology.LinstorNodeKey: "node2"}},
+				},
+			},
+		})
+		assert.Error(t, err)
+		m.AssertNotCalled(t, "Autoplace", mock.Anything, volumeId, mock.Anything)
+		m.AssertCalled(t, "MakeAvailable", mock.Anything, volumeId, "node2", mock.Anything)
+	})
+
+	t.Run("requisite + autoplace", func(t *testing.T) {
+		// Asserts that after filling requisites, the remaining replicas are placed using autoplace
+		m.Calls = nil
+
+		err := sched.Create(ctx, &vol, &csi.CreateVolumeRequest{
+			AccessibilityRequirements: &csi.TopologyRequirement{
+				Requisite: []*csi.Topology{
+					{Segments: map[string]string{topology.LinstorNodeKey: "node1"}},
+				},
+			},
+		})
+		assert.NoError(t, err)
+		m.AssertCalled(t, "Autoplace", mock.Anything, volumeId, mock.Anything)
+		m.AssertCalled(t, "MakeAvailable", mock.Anything, volumeId, "node1", mock.Anything)
+	})
+}


### PR DESCRIPTION
The CSI spec requires very specific behaviour when using
AccessibilityRequirements/Topology.

A CreateVolumeRequest contains:
* A list of requisite topologies. The volume _has_ to be accessible
  from at least on of these. If the list is empty, any placement is allowed.
* A list of preferred topologies. If a list of requisites is also given,
  preferred is a subset of the requisite topologies. They should be considered
  first when placing volumes, but there is no requirement that a volume
  has to be accessible from a preferred topology.

This commit adds support for requisite and/or preferred topologies when using
the "FollowTopology" policy.