### PR TITLE
Add support for CSI Storage Capacity queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Un-namespaced parameters are still supported, while explicitly namespaced
   parameters that with a foreign namespace are now ignored. These would produce "unknown parameter" errors previously.
 
+### Changed
+
+- Calls to `GetCapacity` now take topology information (if any) into account.
 
 ## [0.13.1] - 2021-06-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Option to send a bearer token for authentication. This can be used when the API is secured by a project like
   `kube-rbac-proxy`.
+- Add explicit namespace `linstor.csi.linbit.com` to volume parameters in storage class. This makes it easier to track
+  which parameter is handled by which component (for example: `csi.storage.k8s.io/fstype` is handled by the CSI
+  infrastructure, not the plugin itself).
+
+  Un-namespaced parameters are still supported, while explicitly namespaced
+  parameters that with a foreign namespace are now ignored. These would produce "unknown parameter" errors previously.
+
 
 ## [0.13.1] - 2021-06-10
 

--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ metadata:
 provisioner: linstor.csi.linbit.com
 allowVolumeExpansion: true
 parameters:
-  placementCount: "2"
-  storagePool: "my-storage-pool"
-  resourceGroup: "linstor-basic-storage"
+  linstor.csi.linbit.com/placementCount: "2"
+  linstor.csi.linbit.com/storagePool: "my-storage-pool"
+  linstor.csi.linbit.com/resourceGroup: "linstor-basic-storage"
   csi.storage.k8s.io/fstype: xfs
   # You can override LINSTOR properties by adding the property.linstor.csi.linbit.com prefix:
   property.linstor.csi.linbit.com/DrbdOptions/auto-quorum: suspend-io

--- a/examples/k8s/class.yaml
+++ b/examples/k8s/class.yaml
@@ -5,7 +5,7 @@ metadata:
 provisioner: linstor.csi.linbit.com
 allowVolumeExpansion: true
 parameters:
-  placementCount: "2"
-  storagePool: "my-storage-pool"
-  resourceGroup: "linstor-basic-storage"
+  linstor.csi.linbit.com/placementCount: "2"
+  linstor.csi.linbit.com/storagePool: "my-storage-pool"
+  linstor.csi.linbit.com/resourceGroup: "linstor-basic-storage"
   csi.storage.k8s.io/fstype: xfs

--- a/pkg/client/mock.go
+++ b/pkg/client/mock.go
@@ -212,7 +212,7 @@ func (s *MockStorage) GetAssignmentOnNode(ctx context.Context, vol *volume.Info,
 	return nil, nil
 }
 
-func (s *MockStorage) CapacityBytes(ctx context.Context, params map[string]string) (int64, error) {
+func (s *MockStorage) CapacityBytes(ctx context.Context, params, segments map[string]string) (int64, error) {
 	return 50000000, nil
 }
 

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -788,7 +788,7 @@ func (d Driver) ListVolumes(ctx context.Context, req *csi.ListVolumesRequest) (*
 
 // GetCapacity https://github.com/container-storage-interface/spec/blob/v1.4.0/spec.md#getcapacity
 func (d Driver) GetCapacity(ctx context.Context, req *csi.GetCapacityRequest) (*csi.GetCapacityResponse, error) {
-	bytes, err := d.Storage.CapacityBytes(ctx, req.GetParameters())
+	bytes, err := d.Storage.CapacityBytes(ctx, req.GetParameters(), req.GetAccessibleTopology().GetSegments())
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "%v", err)
 	}

--- a/pkg/linstor/const.go
+++ b/pkg/linstor/const.go
@@ -35,6 +35,9 @@ const (
 	// needed.
 	CreatedForTemporaryDisklessAttach = "temporary-diskless-attach"
 
+	// ParameterNamespace is the preferred namespace when setting parameters in
+	ParameterNamespace = "linstor.csi.linbit.com"
+
 	// PropertyNamespace is the namespace for LINSTOR properties in kubernetes storage class parameters.
 	PropertyNamespace = "property.linstor.csi.linbit.com"
 

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -48,13 +48,14 @@ const (
 
 	// LinstorStoragePoolKeyPrefix is the prefix used when specifying the available storage
 	// pools on a node via CSI topology keys.
-	LinstorStoragePoolKeyPrefix = "linbit.com"
+	LinstorStoragePoolKeyPrefix = "linbit.com/sp-"
 
-	// The value assigned to the storage pool label, given that the node has access to the storage pool.
+	// LinstorStoragePoolValue is the value assigned to the storage pool label, given that the node has access to the
+	// storage pool.
 	LinstorStoragePoolValue = "true"
 )
 
-// Converts the storage pool name into a CSI Topology compatible label.
+// ToStoragePoolLabel converts the storage pool name into a CSI Topology compatible label.
 //
 // There is an upper limit on the length of these keys (63 chars for prefix + 63 chars for the key) as per CSI Spec.
 // LINSTOR enforces a stricter limit of 48 characters for storage pools, so this should not be an issue.
@@ -62,5 +63,5 @@ func ToStoragePoolLabel(storagePoolName string) string {
 	// No additional checks since
 	// a. storage pool names should always expand to valid label names.
 	// b. invalid names are caught by the node-registrar sidecar in any case.
-	return fmt.Sprintf("%s/sp-%s", LinstorStoragePoolKeyPrefix, storagePoolName)
+	return fmt.Sprintf("%s%s", LinstorStoragePoolKeyPrefix, storagePoolName)
 }

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -545,8 +545,8 @@ type Querier interface {
 	FindByID(ctx context.Context, ID string) (*Info, error)
 	// AllocationSizeKiB returns the number of KiB required to provision required bytes.
 	AllocationSizeKiB(requiredBytes, limitBytes int64) (int64, error)
-	// CapacityBytes determines the capacity of the underlying storage in Bytes.
-	CapacityBytes(ctx context.Context, params map[string]string) (int64, error)
+	// CapacityBytes returns the amount of free space, in bytes, in the storage pool specified by the params and topology.
+	CapacityBytes(ctx context.Context, params, segments map[string]string) (int64, error)
 }
 
 // Mounter handles the filesystems located on volumes.

--- a/pkg/volume/volume_test.go
+++ b/pkg/volume/volume_test.go
@@ -23,6 +23,12 @@ func TestNewParameters(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "rg1", fixed.ResourceGroup)
 
+	fixedWithNamespace, err := volume.NewParameters(map[string]string{
+		linstor.ParameterNamespace + "/resourcegroup": "rg1",
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "rg1", fixedWithNamespace.ResourceGroup)
+
 	expected := map[string]string{
 		"DrbdOptions/auto-quorum":  "suspend-io",
 		"DrbdOptions/Net/protocol": "C",


### PR DESCRIPTION
While the `GetCapacity()` call was already implemented, it was not usable in practice:

1. The parameters from the storage class are passed 1:1 to the GetCapacity request. This is an issue when some "external" parameters are present in the storage class. The most obvious example of such a parameter is `csi.storage.k8s.io/fstype`, which we even include in our examples.

   When creating volumes, `csi.storage.k8s.io/fstype` seems to be removed from the request passed to the plugin by the provisioner, but for `GetCapacity`, the parameters seem the remain unchanged. Why that difference exists, I cannot say.

   In any case, to work around this, we ignore parameters with a foreign "namespace" section. For consistency, our own parameters can now also be namespaced using `linstor.csi.linbit.com`. Parameters with no namespace are still treated as "ours" to validate.

2. The internal `CapacityBytes()` call only worked on the parameters, ignoring topology information. The CSI controller will however query the capacity of specific segments (in our case: nodes) in the cluster topology.

   To that end, the call was expanded to include the topology information, which is then used to filter for a specific node and storage pool(s).