### PR TITLE
Add new default "AutoPlaceTopology" scheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New default volume scheduler `AutoPlaceTopology`. This new scheduler is a topology aware version of the old
+  `AutoPlace` scheduler. Since it is topology aware, it can be used to optimize volume placement when using
+  `WaitForFirstConsumer` volume binding or restricting placement via `allowedTopologies`, while still respecting
+  user-defined placement options such as `replicasOnSame` or `replicasOnDifferent`.
+
 ## [0.14.1] - 2021-09-02
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/piraeusdatastore/linstor-csi
 go 1.12
 
 require (
-	github.com/LINBIT/golinstor v0.34.4
+	github.com/LINBIT/golinstor v0.35.1
 	github.com/alvaroloes/enumer v1.1.2
 	github.com/container-storage-interface/spec v1.4.0
 	github.com/golang/protobuf v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,8 @@ github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBp
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/LINBIT/golinstor v0.34.4 h1:O+C2/r5pwyoERQkARgxWRdnaV7tFtL95AzFREVQuV6c=
-github.com/LINBIT/golinstor v0.34.4/go.mod h1:506Wb/BCd449g/u2IGXlsIKNdiEmAEsgyOPrIYjbKyg=
+github.com/LINBIT/golinstor v0.35.1 h1:W4TSkAdMuc4pmnjR7axCnLg4fbrUFx5dQseqg3V2P68=
+github.com/LINBIT/golinstor v0.35.1/go.mod h1:506Wb/BCd449g/u2IGXlsIKNdiEmAEsgyOPrIYjbKyg=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=

--- a/pkg/topology/placementpolicy_enumer.go
+++ b/pkg/topology/placementpolicy_enumer.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 )
 
-const _PlacementPolicyName = "UnknownManualAutoPlaceFollowTopologyBalanced"
+const _PlacementPolicyName = "UnknownManualAutoPlaceFollowTopologyBalancedAutoPlaceTopology"
 
-var _PlacementPolicyIndex = [...]uint8{0, 7, 13, 22, 36, 44}
+var _PlacementPolicyIndex = [...]uint8{0, 7, 13, 22, 36, 44, 61}
 
 func (i PlacementPolicy) String() string {
 	if i < 0 || i >= PlacementPolicy(len(_PlacementPolicyIndex)-1) {
@@ -18,7 +18,7 @@ func (i PlacementPolicy) String() string {
 	return _PlacementPolicyName[_PlacementPolicyIndex[i]:_PlacementPolicyIndex[i+1]]
 }
 
-var _PlacementPolicyValues = []PlacementPolicy{0, 1, 2, 3, 4}
+var _PlacementPolicyValues = []PlacementPolicy{0, 1, 2, 3, 4, 5}
 
 var _PlacementPolicyNameToValueMap = map[string]PlacementPolicy{
 	_PlacementPolicyName[0:7]:   0,
@@ -26,6 +26,7 @@ var _PlacementPolicyNameToValueMap = map[string]PlacementPolicy{
 	_PlacementPolicyName[13:22]: 2,
 	_PlacementPolicyName[22:36]: 3,
 	_PlacementPolicyName[36:44]: 4,
+	_PlacementPolicyName[44:61]: 5,
 }
 
 // PlacementPolicyString retrieves an enum value from the enum constants string name.

--- a/pkg/topology/scheduler/autoplace/autoplace.go
+++ b/pkg/topology/scheduler/autoplace/autoplace.go
@@ -21,6 +21,7 @@ package autoplace
 import (
 	"context"
 
+	"github.com/LINBIT/golinstor/client"
 	"github.com/container-storage-interface/spec/lib/go/csi"
 
 	lc "github.com/piraeusdatastore/linstor-csi/pkg/linstor/highlevelclient"
@@ -37,11 +38,7 @@ func NewScheduler(c *lc.HighLevelClient) *Scheduler {
 }
 
 func (s *Scheduler) Create(ctx context.Context, vol *volume.Info, req *csi.CreateVolumeRequest) error {
-	apRequest, err := vol.ToAutoPlace()
-	if err != nil {
-		return err
-	}
-	return s.Resources.Autoplace(ctx, vol.ID, apRequest)
+	return s.Resources.Autoplace(ctx, vol.ID, client.AutoPlaceRequest{})
 }
 
 func (s *Scheduler) AccessibleTopologies(ctx context.Context, vol *volume.Info) ([]*csi.Topology, error) {

--- a/pkg/topology/scheduler/autoplacetopology/autoplacetopology.go
+++ b/pkg/topology/scheduler/autoplacetopology/autoplacetopology.go
@@ -1,0 +1,146 @@
+package autoplacetopology
+
+import (
+	"context"
+	"fmt"
+
+	linstor "github.com/LINBIT/golinstor"
+	lapi "github.com/LINBIT/golinstor/client"
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	lc "github.com/piraeusdatastore/linstor-csi/pkg/linstor/highlevelclient"
+	"github.com/piraeusdatastore/linstor-csi/pkg/topology"
+	"github.com/piraeusdatastore/linstor-csi/pkg/topology/scheduler"
+	"github.com/piraeusdatastore/linstor-csi/pkg/volume"
+)
+
+// Scheduler places volumes according to both CSI Topology and user-provided autoplace parameters.
+//
+// This scheduler works like autoplace.Scheduler with a few key differences:
+// * If a `Requisite` topology is requested, all placement will be restricted onto those nodes.
+// * If a `Preferred` topology is requested, this scheduler will try to place at least one volume on those nodes.
+// This scheduler complies with the CSI spec for topology:
+//   https://github.com/container-storage-interface/spec/blob/v1.4.0/csi.proto#L523
+type Scheduler struct {
+	*lc.HighLevelClient
+	log *logrus.Entry
+}
+
+// Ensure Scheduler conforms to scheduler.Interface.
+var _ scheduler.Interface = &Scheduler{}
+
+func (s *Scheduler) Create(ctx context.Context, vol *volume.Info, req *csi.CreateVolumeRequest) error {
+	log := s.log.WithField("volume", vol.ID)
+
+	params, err := volume.NewParameters(vol.Parameters)
+	if err != nil {
+		return fmt.Errorf("unable to determine volume parameters: %w", err)
+	}
+
+	// The CSI spec mandates:
+	// * If `Requisite` exists, we _have_ to use those up first.
+	// * If `Requisite` and `Preferred` exists, we have `Preferred` ⊆ `Requisite`, and `Preferred` SHOULD be used first.
+	// * If `Requisite` does not exist and `Preferred` exists, we SHOULD use `Preferred`.
+	// * If both `Requisite` and `Preferred` do not exist, we can do what ever.
+	//
+	// Making this compatible with LINSTOR autoplace parameters can be quite tricky. For example, a "DoNotPlaceWith"
+	// constraint could mean we are not able to place the volume on the first preferred node.
+	//
+	// This scheduler works by first trying to place a volume on one of the preferred nodes. This should optimize
+	// placement in case of late volume binding (where the first preferred node is the node starting the pod).
+	// Then, normal autoplace happens, restricted to the requisite nodes. If there are still replicas to schedule, use
+	// autoplace again, this time without extra placement constraints from topology.
+
+	topos := req.GetAccessibilityRequirements()
+	log.WithField("requirements", topos).Trace("got topology requirement")
+
+	for _, preferred := range topos.GetPreferred() {
+		node, ok := preferred.GetSegments()[topology.LinstorNodeKey]
+		if !ok {
+			log.WithField("segment", preferred.GetSegments()).Trace("segment without node name, skipping")
+			continue
+		}
+
+		log.WithField("preferred", node).Trace("try initial placement on a preferred node")
+
+		// Just try a single autoplace request on one of the preferred nodes if possible. We use AutoPlace instead
+		// of MakeAvailable to ensure we respect the user-defined constraint from the storage class.
+		err := s.Resources.Autoplace(ctx, vol.ID, lapi.AutoPlaceRequest{
+			SelectFilter: lapi.AutoSelectFilter{PlaceCount: 1, NodeNameList: []string{node}},
+		})
+		if err != nil {
+			log.WithError(err).WithField("preferred", node).Trace("failed to autoplace")
+		} else {
+			log.WithField("preferred", node).Trace("successfully placed on preferred node")
+			break
+		}
+	}
+
+	// By now we should have placed a volume on one of the preferred nodes (or there were no preferred nodes). Now
+	// we can try autoplacing the rest. Initially, we want to restrict ourselves to just the requisite nodes.
+	var requisiteNodes []string
+
+	for _, requisite := range topos.GetRequisite() {
+		node, ok := requisite.GetSegments()[topology.LinstorNodeKey]
+		if !ok {
+			log.WithField("segment", requisite.GetSegments()).Trace("segment without node name, skipping")
+			continue
+		}
+
+		requisiteNodes = append(requisiteNodes, node)
+	}
+
+	log.WithField("requisite", requisiteNodes).Trace("got requisite nodes")
+
+	if len(requisiteNodes) > 0 {
+		// We do have requisite nodes, so we need to autoplace just on those nodes.
+		req := lapi.AutoPlaceRequest{
+			SelectFilter: lapi.AutoSelectFilter{NodeNameList: requisiteNodes},
+		}
+
+		// We might need to restrict autoplace here. We could have just one requisite node, but a placement count of 3.
+		// In this scenario, we want to autoplace on the requisite node, then run another autoplace with no restriction
+		// to place the remaining replicas.
+		if len(requisiteNodes) < int(params.PlacementCount) {
+			req.SelectFilter.PlaceCount = int32(len(requisiteNodes))
+		}
+
+		log.WithField("requisite", requisiteNodes).Trace("try placement on requisite nodes")
+
+		err := s.Resources.Autoplace(ctx, vol.ID, req)
+		if err != nil {
+			if lapi.IsApiCallError(err, linstor.FailNotEnoughNodes) {
+				// We need a special return code when the requisite could not be fulfilled
+				return status.Errorf(codes.ResourceExhausted, "failed to enough replicas on requisite nodes: %v", err)
+			}
+
+			return fmt.Errorf("failed to autoplace constraint replicas: %w", err)
+		}
+	}
+
+	if len(requisiteNodes) < int(params.PlacementCount) {
+		// By now we should have replicas on all requisite nodes (if any). Any remaining replicas we can place
+		// independent of topology constraints, so we just run an unconstraint autoplace.
+		log.Trace("try placement without topology constraints")
+
+		err := s.Resources.Autoplace(ctx, vol.ID, lapi.AutoPlaceRequest{})
+		if err != nil {
+			return fmt.Errorf("failed to autoplace unconstraint replicas: %w", err)
+		}
+	}
+
+	log.Trace("placement successful")
+
+	return nil
+}
+
+func (s *Scheduler) AccessibleTopologies(ctx context.Context, vol *volume.Info) ([]*csi.Topology, error) {
+	return s.GenericAccessibleTopologies(ctx, vol)
+}
+
+func NewScheduler(c *lc.HighLevelClient, l *logrus.Entry) *Scheduler {
+	return &Scheduler{HighLevelClient: c, log: l.WithField("scheduler", "autoplacetopology")}
+}

--- a/pkg/topology/scheduler/autoplacetopology/autoplacetopology_test.go
+++ b/pkg/topology/scheduler/autoplacetopology/autoplacetopology_test.go
@@ -1,0 +1,179 @@
+package autoplacetopology_test
+
+import (
+	"context"
+	"testing"
+
+	linstor "github.com/LINBIT/golinstor"
+	lapi "github.com/LINBIT/golinstor/client"
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/piraeusdatastore/linstor-csi/pkg/client/mocks"
+	lc "github.com/piraeusdatastore/linstor-csi/pkg/linstor/highlevelclient"
+	"github.com/piraeusdatastore/linstor-csi/pkg/topology"
+	"github.com/piraeusdatastore/linstor-csi/pkg/topology/scheduler/autoplacetopology"
+	"github.com/piraeusdatastore/linstor-csi/pkg/volume"
+)
+
+var (
+	volumeId = "test-volume"
+	vol      = volume.Info{ID: volumeId, Parameters: map[string]string{"AutoPlace": "3"}}
+	// NB: we need this weird casting to make go happy.
+	n              = uint64(linstor.FailNotEnoughNodes)
+	autoplaceError = lapi.ApiCallError{lapi.ApiCallRc{RetCode: int64(n)}}
+)
+
+func TestScheduler_Create(t *testing.T) {
+	ctx := context.Background()
+
+	m := mocks.ResourceProvider{}
+	sched := autoplacetopology.NewScheduler(&lc.HighLevelClient{Client: &lapi.Client{Resources: &m}}, logrus.WithField("test", t.Name()))
+
+	t.Run("no requirements", func(t *testing.T) {
+		// Asserts that if no requirement is given, normal autoplace is performed
+		m.Calls = nil
+		m.ExpectedCalls = []*mock.Call{
+			{Method: "Autoplace", Arguments: mock.Arguments{mock.Anything, volumeId, lapi.AutoPlaceRequest{}}, ReturnArguments: mock.Arguments{nil}},
+		}
+
+		err := sched.Create(ctx, &vol, &csi.CreateVolumeRequest{})
+		assert.NoError(t, err)
+		m.AssertExpectations(t)
+	})
+
+	t.Run("preferred", func(t *testing.T) {
+		// Asserts that, if only preferred topologies are given, one is created first
+		m.Calls = nil
+		m.ExpectedCalls = []*mock.Call{
+			{Method: "Autoplace", Arguments: mock.Arguments{mock.Anything, volumeId, lapi.AutoPlaceRequest{SelectFilter: lapi.AutoSelectFilter{PlaceCount: 1, NodeNameList: []string{"node3"}}}}, ReturnArguments: mock.Arguments{nil}},
+			{Method: "Autoplace", Arguments: mock.Arguments{mock.Anything, volumeId, lapi.AutoPlaceRequest{SelectFilter: lapi.AutoSelectFilter{}}}, ReturnArguments: mock.Arguments{nil}},
+		}
+
+		err := sched.Create(ctx, &vol, &csi.CreateVolumeRequest{
+			AccessibilityRequirements: &csi.TopologyRequirement{
+				Preferred: []*csi.Topology{
+					{Segments: map[string]string{topology.LinstorNodeKey: "node3"}},
+					{Segments: map[string]string{topology.LinstorNodeKey: "node2"}},
+					{Segments: map[string]string{topology.LinstorNodeKey: "node1"}},
+				},
+			},
+		})
+		assert.NoError(t, err)
+		m.AssertExpectations(t)
+	})
+
+	t.Run("preferred with failure", func(t *testing.T) {
+		// Asserts that, if only preferred topologies are given, one is created first
+		m.Calls = nil
+		m.ExpectedCalls = []*mock.Call{
+			{Method: "Autoplace", Arguments: mock.Arguments{mock.Anything, volumeId, lapi.AutoPlaceRequest{SelectFilter: lapi.AutoSelectFilter{PlaceCount: 1, NodeNameList: []string{"node3"}}}}, ReturnArguments: mock.Arguments{autoplaceError}},
+			{Method: "Autoplace", Arguments: mock.Arguments{mock.Anything, volumeId, lapi.AutoPlaceRequest{SelectFilter: lapi.AutoSelectFilter{PlaceCount: 1, NodeNameList: []string{"node1"}}}}, ReturnArguments: mock.Arguments{nil}},
+			{Method: "Autoplace", Arguments: mock.Arguments{mock.Anything, volumeId, lapi.AutoPlaceRequest{SelectFilter: lapi.AutoSelectFilter{}}}, ReturnArguments: mock.Arguments{nil}},
+		}
+
+		err := sched.Create(ctx, &vol, &csi.CreateVolumeRequest{
+			AccessibilityRequirements: &csi.TopologyRequirement{
+				Preferred: []*csi.Topology{
+					{Segments: map[string]string{topology.LinstorNodeKey: "node3"}},
+					{Segments: map[string]string{topology.LinstorNodeKey: "node1"}},
+				},
+			},
+		})
+		assert.NoError(t, err)
+		m.AssertExpectations(t)
+	})
+
+	t.Run("requisite + preferred", func(t *testing.T) {
+		// Asserts that, if both requisite and preferred are given, first we try to place the preferred, then pick from
+		// the remaining requisites
+		m.Calls = nil
+		m.ExpectedCalls = []*mock.Call{
+			{Method: "Autoplace", Arguments: mock.Arguments{mock.Anything, volumeId, lapi.AutoPlaceRequest{SelectFilter: lapi.AutoSelectFilter{PlaceCount: 1, NodeNameList: []string{"node2"}}}}, ReturnArguments: mock.Arguments{nil}},
+			{Method: "Autoplace", Arguments: mock.Arguments{mock.Anything, volumeId, lapi.AutoPlaceRequest{SelectFilter: lapi.AutoSelectFilter{NodeNameList: []string{"node1", "node2", "node3", "node4"}}}}, ReturnArguments: mock.Arguments{nil}},
+		}
+
+		err := sched.Create(ctx, &vol, &csi.CreateVolumeRequest{
+			AccessibilityRequirements: &csi.TopologyRequirement{
+				Requisite: []*csi.Topology{
+					{Segments: map[string]string{topology.LinstorNodeKey: "node1"}},
+					{Segments: map[string]string{topology.LinstorNodeKey: "node2"}},
+					{Segments: map[string]string{topology.LinstorNodeKey: "node3"}},
+					{Segments: map[string]string{topology.LinstorNodeKey: "node4"}},
+				},
+				Preferred: []*csi.Topology{
+					{Segments: map[string]string{topology.LinstorNodeKey: "node2"}},
+					{Segments: map[string]string{topology.LinstorNodeKey: "node4"}},
+				},
+			},
+		})
+		assert.NoError(t, err)
+		m.AssertExpectations(t)
+	})
+
+	t.Run("requisite", func(t *testing.T) {
+		// Asserts that using only requisites will require placement on (one of) these nodes
+		m.Calls = nil
+		m.ExpectedCalls = []*mock.Call{
+			{Method: "Autoplace", Arguments: mock.Arguments{mock.Anything, volumeId, lapi.AutoPlaceRequest{SelectFilter: lapi.AutoSelectFilter{NodeNameList: []string{"node2", "node3", "node4"}}}}, ReturnArguments: mock.Arguments{nil}},
+		}
+
+		err := sched.Create(ctx, &vol, &csi.CreateVolumeRequest{
+			AccessibilityRequirements: &csi.TopologyRequirement{
+				Requisite: []*csi.Topology{
+					{Segments: map[string]string{topology.LinstorNodeKey: "node2"}},
+					{Segments: map[string]string{topology.LinstorNodeKey: "node3"}},
+					{Segments: map[string]string{topology.LinstorNodeKey: "node4"}},
+				},
+			},
+		})
+		assert.NoError(t, err)
+		m.AssertExpectations(t)
+	})
+
+	t.Run("requisite impossible", func(t *testing.T) {
+		// Asserts that scheduling reports an error in case non of the requisites could be fulfilled
+		m.Calls = nil
+
+		m.ExpectedCalls = []*mock.Call{
+			{Method: "Autoplace", Arguments: mock.Arguments{mock.Anything, volumeId, lapi.AutoPlaceRequest{SelectFilter: lapi.AutoSelectFilter{NodeNameList: []string{"node2", "node3", "node4"}}}}, ReturnArguments: mock.Arguments{autoplaceError}},
+		}
+
+		err := sched.Create(ctx, &vol, &csi.CreateVolumeRequest{
+			AccessibilityRequirements: &csi.TopologyRequirement{
+				Requisite: []*csi.Topology{
+					{Segments: map[string]string{topology.LinstorNodeKey: "node2"}},
+					{Segments: map[string]string{topology.LinstorNodeKey: "node3"}},
+					{Segments: map[string]string{topology.LinstorNodeKey: "node4"}},
+				},
+			},
+		})
+		assert.Error(t, err)
+		assert.IsType(t, status.Error(codes.ResourceExhausted, ""), err)
+		m.AssertExpectations(t)
+	})
+
+	t.Run("requisite + autoplace", func(t *testing.T) {
+		// Asserts that after filling requisites, the remaining replicas are placed using autoplace.
+		m.Calls = nil
+		m.ExpectedCalls = []*mock.Call{
+			{Method: "Autoplace", Arguments: mock.Arguments{mock.Anything, volumeId, lapi.AutoPlaceRequest{SelectFilter: lapi.AutoSelectFilter{PlaceCount: 2, NodeNameList: []string{"node1", "node2"}}}}, ReturnArguments: mock.Arguments{nil}},
+			{Method: "Autoplace", Arguments: mock.Arguments{mock.Anything, volumeId, lapi.AutoPlaceRequest{SelectFilter: lapi.AutoSelectFilter{}}}, ReturnArguments: mock.Arguments{nil}},
+		}
+
+		err := sched.Create(ctx, &vol, &csi.CreateVolumeRequest{
+			AccessibilityRequirements: &csi.TopologyRequirement{
+				Requisite: []*csi.Topology{
+					{Segments: map[string]string{topology.LinstorNodeKey: "node1"}},
+					{Segments: map[string]string{topology.LinstorNodeKey: "node2"}},
+				},
+			},
+		})
+		assert.NoError(t, err)
+		m.AssertExpectations(t)
+	})
+}

--- a/pkg/topology/scheduler/followtopology/follow_topology.go
+++ b/pkg/topology/scheduler/followtopology/follow_topology.go
@@ -101,14 +101,7 @@ func (s *Scheduler) Create(ctx context.Context, vol *volume.Info, req *csi.Creat
 	}
 
 	if placed < remainingAssignments {
-		// If params.placementCount is higher than the number of assigned nodes,
-		// let autoplace the rest.
-		apRequest, err := vol.ToAutoPlace()
-		if err != nil {
-			return err
-		}
-
-		err = s.Resources.Autoplace(ctx, vol.ID, apRequest)
+		err = s.Resources.Autoplace(ctx, vol.ID, client.AutoPlaceRequest{})
 		if err != nil {
 			return err
 		}

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -36,9 +36,12 @@ const (
 	// FollowTopology place volumes local to topology preferences, in order
 	// of those preferences.
 	FollowTopology
-	// BalancedTopology places remote volumes in the same zone(Rack)
+	// Balanced places remote volumes in the same zone(Rack)
 	// and pick Node, StoragePool, PrefNic based on utilization
 	Balanced
+	// AutoPlaceTopology places volumes based on topology parameters and LINSTOR
+	// autoplace selection in the storage class.
+	AutoPlaceTopology
 )
 
 const (

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -137,7 +137,7 @@ func NewParameters(params map[string]string) (Parameters, error) {
 		PlacementCount:          1,
 		DisklessStoragePool:     DefaultDisklessStoragePoolName,
 		Encryption:              false,
-		PlacementPolicy:         topology.AutoPlace,
+		PlacementPolicy:         topology.AutoPlaceTopology,
 		AllowRemoteVolumeAccess: true,
 		Properties:              make(map[string]string),
 	}
@@ -472,19 +472,6 @@ func (i *Info) toGenericResourceCreate(params Parameters, node string) lapi.Reso
 		},
 		LayerList: params.LayerList,
 	}
-}
-
-// ToAutoPlace prepares a Info to be deployed by linstor via autoplace.
-func (i *Info) ToAutoPlace() (lapi.AutoPlaceRequest, error) {
-	// Workaround for LINSTOR bug prior to v1.8.0. The default layer list for auto-place requests was '[]',
-	// which is then defaulted to drbd,storage. This would override any layer list specified in the resource group.
-	// This workaround alleviates the issue by setting the layer list on the auto-place request explicitly.
-	params, err := NewParameters(i.Parameters)
-	if err != nil {
-		return lapi.AutoPlaceRequest{}, err
-	}
-
-	return lapi.AutoPlaceRequest{LayerList: params.LayerList}, nil
 }
 
 // Assignment represents a volume situated on a particular node.


### PR DESCRIPTION
This new scheduler is a topology aware version of the old `AutoPlace`
scheduler. Since it is topology aware, it can be used to optimize volume
placement when using `WaitForFirstConsumer` volume binding or restricting
placement via `allowedTopologies`, while still respecting user-defined
placement options such as `replicasOnSame` or `replicasOnDifferent`.

This scheduler was added as all alternatives have some issue:
* `AutoPlace` completely ignored topology information, making it a bad fit for optimized volume placement based on Pod scheduling.
* `FollowTopology` ignored user set constraints  like `replicasOnSame` and `replicasOnDifferent`
