### PR TITLE
node: add aux properties as additional topology info

### DIFF
--- a/pkg/client/linstor.go
+++ b/pkg/client/linstor.go
@@ -1459,6 +1459,18 @@ func (s *Linstor) GetNodeTopologies(ctx context.Context, nodename string) (*csi.
 		topo.Segments[label] = "true"
 	}
 
+	node, err := s.client.Nodes.Get(ctx, nodename)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get node: %w", err)
+	}
+
+	const auxPrefix = lapiconsts.NamespcAuxiliary + "/"
+	for k, v := range node.Props {
+		if strings.HasPrefix(k, auxPrefix) {
+			topo.Segments[k[len(auxPrefix):]] = v
+		}
+	}
+
 	return topo, nil
 }
 


### PR DESCRIPTION
In https://github.com/piraeusdatastore/piraeus-operator/commit/530c7aed27ea9640516d40b5095a6eb1248285fe the operator learned to sync node labels to LINSTOR properties. To make CSI (and kubernetes) aware that the linstor plugin is capable of scheduling based on these labels, we need to add them in the node info response.

The change requires some changes in the volume scheduler: now it is possible for a user to specify a general topology, which might not contain the previously assumed single-node identification. Instead of assuming that a segment contains exactly one node, the scheduler now deals with multiple nodes per segment by fetching matching nodes from LINSTOR.