### PR TITLE
Fix make-available to ensure diskful deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- A bug introduced in 0.14.0 meant that using the "FollowTopology" policy would not create the requested amount
+  of volume replicas. Instead, only a single replica was created. This bug is now fixed. Existing volumes can be
+  updated by using `linstor rg adjust <resource group>`.
+
 ## [0.15.0] - 2021-09-23
 
 ### Added

--- a/pkg/topology/scheduler/followtopology/follow_topology.go
+++ b/pkg/topology/scheduler/followtopology/follow_topology.go
@@ -82,7 +82,7 @@ func (s *Scheduler) Create(ctx context.Context, vol *volume.Info, req *csi.Creat
 			continue
 		}
 
-		err = s.Resources.MakeAvailable(ctx, vol.ID, p, client.ResourceMakeAvailable{})
+		err = s.Resources.MakeAvailable(ctx, vol.ID, p, client.ResourceMakeAvailable{Diskful: true})
 		if err != nil {
 			s.log.WithFields(logrus.Fields{
 				"volumeID":     vol.ID,


### PR DESCRIPTION
The change to use the make-available API in the FollowTopology scheduler
introduced in b4daec3dca3ec3174e084fc744dd5d11c17ceb63 worked under
the assumption that make-available would deploy diskful resources
unless explicitly told to use diskless resources.

This assumption is the exact opposite of the actual behaviour. That meant
that all new FollowTopology resources were effectively only using 1 replica.

This commit explictily requests diskful resources during initial deployment,
fixing the above issue.

Signed-off-by: Moritz "WanzenBug" Wanzenböck <moritz.wanzenboeck@linbit.com>