### PR TITLE
volume-source: fix restored volume size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- When using a volume source (snapshot or other volume), LINSTOR CSI now correctly resizes the volume to the new
+  requested size.
+
 ## [0.16.0] - 2021-10-15
 
 ### Changed


### PR DESCRIPTION
A volume using a snapshot or other volume as source was internally restored
to the size of the original source. This commit fixes this bug by:

1. Reconciling the requested volume size at the end of restoring from
  snapshots. Note that this also covers the volume clone case (for now)
  as we support volume cloning via a "hidden" snapshot.
2. On NodePublishVolume calls, we always try to expand the FS to the
  whole device.

Fixes one aspect of #137 