### PR TITLE
Revert to using normal volume create order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - When using a volume source (snapshot or other volume), LINSTOR CSI now correctly resizes the volume to the new
   requested size.
+- Switch back to `resource definition(rd) -> volume definition(vd) -> autoplace(ap)` provisioning instead of
+  `rd -> ap-> vd` as introduced in 0.16.0. This caused issues on non-thin storage pools and sometimes provisioning
+  failed even on thin storage pools.
 
 ## [0.16.0] - 2021-10-15
 

--- a/pkg/linstor/const.go
+++ b/pkg/linstor/const.go
@@ -27,6 +27,10 @@ const (
 	// are stored.
 	LegacyParameterPassKey = lc.NamespcAuxiliary + "/csi-volume-annotations"
 
+	// PropertyProvisioningCompletedBy is the Aux props key in LINSTOR intentifying this resource as
+	// fully provisioned by this plugin.
+	PropertyProvisioningCompletedBy = lc.NamespcAuxiliary + "/csi-provisioning-completed-by"
+
 	// PropertyCreatedFor is the Aux props key in linstor used to identify why a specific object (for example, a
 	// resource) exists.
 	PropertyCreatedFor = lc.NamespcAuxiliary + "/csi-created-for"

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -31,6 +31,7 @@ type Info struct {
 	ID            string
 	SizeBytes     int64
 	ResourceGroup string
+	Properties    map[string]string
 }
 
 // Assignment represents a volume situated on a particular node.


### PR DESCRIPTION
73c97a8 reworked the normal order of API calls when creating new volumes.
Instead of the traditional RD -> VD -> AP, it used RD -> AP -> VD. This
was done because we need a way to distinguish in-progress create requests from
those where the volume already exsists. Creating the VD in the last step made
it easy to check. Before 73c97a8, this was done by a specific aux property,
that was also used to pass volume parameters to later calls.

Creating the VD last proves to be problematic:
* On "thick" storage, it will generate inconsistent DRBD devices, as LINSTOR
  doesn't do it's forced primary trick for "late" volume additions.
* On "thin" storage, it will sometimes trigger a race condition, confusing
  LINSTOR into simultaneously not creating the volume and not deleting it.

This commit addresses this by re-introducing a aux property, but only using
it for the CreateVolume call. This makes the CSI spec happy, as we can detect
conflicting volume provision requests, while ignoring the property in every
other call means we can still just use preprovisioned volumes.