### PR TITLE
Advanced volume access rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `allowRemoteVolumeAccess` supports new values, allowing a more fine-grained controlled on diskless access.
+
 ## [0.16.1] - 2021-11-08
 
 ### Changed

--- a/cmd/linstor-csi/linstor-csi.go
+++ b/cmd/linstor-csi/linstor-csi.go
@@ -35,6 +35,7 @@ import (
 	"github.com/piraeusdatastore/linstor-csi/pkg/client"
 	"github.com/piraeusdatastore/linstor-csi/pkg/driver"
 	lc "github.com/piraeusdatastore/linstor-csi/pkg/linstor/highlevelclient"
+	"github.com/piraeusdatastore/linstor-csi/pkg/volume"
 )
 
 func main() {
@@ -48,6 +49,9 @@ func main() {
 		burst                 = flag.Int("linstor-api-burst", 1, "Maximum number of API requests allowed before being limited by requests-per-second. Default: 1 (no bursting)")
 		bearerTokenFile       = flag.String("bearer-token", "", "Read the bearer token from the given file and use it for authentication.")
 	)
+
+	flag.Var(&volume.DefaultRemoteAccessPolicy, "default-remote-access-policy", "")
+
 	flag.Parse()
 
 	// TODO: Take log outputs and options from the command line.

--- a/examples/k8s/class.yaml
+++ b/examples/k8s/class.yaml
@@ -1,3 +1,4 @@
+# Volumes with 2 replicas.
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -6,6 +7,48 @@ provisioner: linstor.csi.linbit.com
 allowVolumeExpansion: true
 parameters:
   linstor.csi.linbit.com/placementCount: "2"
-  linstor.csi.linbit.com/storagePool: "my-storage-pool"
-  linstor.csi.linbit.com/resourceGroup: "linstor-basic-storage"
-  csi.storage.k8s.io/fstype: xfs
+  linstor.csi.linbit.com/storagePool: my-storage-pool
+  linstor.csi.linbit.com/resourceGroup: linstor-basic-storage
+---
+# Volumes with 2 replicas, spread over cluster zones
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: linstor-spread-zone
+provisioner: linstor.csi.linbit.com
+allowVolumeExpansion: true
+parameters:
+  linstor.csi.linbit.com/placementCount: "2"
+  linstor.csi.linbit.com/storagePool: my-storage-pool
+  linstor.csi.linbit.com/resourceGroup: linstor-spread-zone
+  linstor.csi.linbit.com/replicasOnDifferent: topology.kubernetes.io/zone
+---
+# Volumes with 2 replicas, spread over zones, but confined to same region.
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: linstor-spread-zone-same-region
+provisioner: linstor.csi.linbit.com
+allowVolumeExpansion: true
+parameters:
+  linstor.csi.linbit.com/placementCount: "2"
+  linstor.csi.linbit.com/storagePool: my-storage-pool
+  linstor.csi.linbit.com/resourceGroup: linstor-spread-zone-same-region
+  linstor.csi.linbit.com/replicasOnSame: topology.kubernetes.io/region
+  linstor.csi.linbit.com/replicasOnDifferent: topology.kubernetes.io/zone
+---
+# Volumes with 2 replicas, spread over zones, allowing access from any node in a zone with replicas
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: linstor-spread-zone-access-any-node
+provisioner: linstor.csi.linbit.com
+allowVolumeExpansion: true
+parameters:
+  linstor.csi.linbit.com/placementCount: "2"
+  linstor.csi.linbit.com/storagePool: my-storage-pool
+  linstor.csi.linbit.com/resourceGroup: linstor-spread-zone-access-any-node
+  linstor.csi.linbit.com/replicasOnDifferent: topology.kubernetes.io/zone
+  linstor.csi.linbit.com/allowRemoteVolumeAccess: |
+    - fromSame:
+      - topology.kubernetes.io/zone

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	golang.org/x/sys v0.0.0-20210426230700-d19ff857e887
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba
 	google.golang.org/grpc v1.34.0
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
 	k8s.io/api v0.21.2
 	k8s.io/apimachinery v0.21.2
 	k8s.io/client-go v0.21.2

--- a/pkg/topology/scheduler/autoplace/autoplace.go
+++ b/pkg/topology/scheduler/autoplace/autoplace.go
@@ -41,6 +41,6 @@ func (s *Scheduler) Create(ctx context.Context, volId string, _ *volume.Paramete
 	return s.Resources.Autoplace(ctx, volId, client.AutoPlaceRequest{})
 }
 
-func (s *Scheduler) AccessibleTopologies(ctx context.Context, volId string, allowDisklessAccess bool) ([]*csi.Topology, error) {
-	return s.GenericAccessibleTopologies(ctx, volId, allowDisklessAccess)
+func (s *Scheduler) AccessibleTopologies(ctx context.Context, volId string, remoteAccessPolicy volume.RemoteAccessPolicy) ([]*csi.Topology, error) {
+	return s.GenericAccessibleTopologies(ctx, volId, remoteAccessPolicy)
 }

--- a/pkg/topology/scheduler/autoplacetopology/autoplacetopology.go
+++ b/pkg/topology/scheduler/autoplacetopology/autoplacetopology.go
@@ -3,6 +3,7 @@ package autoplacetopology
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	linstor "github.com/LINBIT/golinstor"
 	lapi "github.com/LINBIT/golinstor/client"
@@ -51,49 +52,51 @@ func (s *Scheduler) Create(ctx context.Context, volId string, params *volume.Par
 	log.WithField("requirements", topologies).Trace("got topology requirement")
 
 	for _, preferred := range topologies.GetPreferred() {
-		log := log.WithField("segments", preferred.GetSegments())
-
-		nodes, err := s.NodesForTopology(ctx, preferred.GetSegments())
+		err := s.PlaceAccessibleToSegment(ctx, volId, preferred.GetSegments(), params.AllowRemoteVolumeAccess)
 		if err != nil {
-			return fmt.Errorf("failed to get preferred node list from segments: %w", err)
-		}
-
-		log.WithField("nodes", nodes).Trace("try initial placement on preferred nodes")
-
-		apRequest := lapi.AutoPlaceRequest{SelectFilter: lapi.AutoSelectFilter{NodeNameList: nodes}}
-
-		if len(nodes) < int(params.PlacementCount) {
-			apRequest.SelectFilter.PlaceCount = int32(len(nodes))
-		}
-
-		err = s.Resources.Autoplace(ctx, volId, apRequest)
-		if err != nil {
-			log.WithError(err).Trace("failed to autoplace")
+			log.WithError(err).Debug("failed to place on preferred segment")
 		} else {
-			log.Trace("successfully placed on preferred node")
+			log.Debug("placed accessible to preferred segment")
 			break
 		}
 	}
 
 	// By now we should have placed a volume on one of the preferred nodes (or there were no preferred nodes). Now
 	// we can try autoplacing the rest. Initially, we want to restrict ourselves to just the requisite nodes.
-	var requisiteNodes []string
+	// However, we _can_ always expand to the accessible volumes as per remote volume policy.
+	requisiteNodes := make(map[string]struct{})
 
 	for _, requisite := range topologies.GetRequisite() {
-		nodes, err := s.NodesForTopology(ctx, requisite.GetSegments())
-		if err != nil {
-			return fmt.Errorf("failed to get preferred node list from segments: %w", err)
-		}
+		for _, seg := range params.AllowRemoteVolumeAccess.AccessibleSegments(requisite.GetSegments()) {
+			log := log.WithField("segments", seg)
 
-		requisiteNodes = append(requisiteNodes, nodes...)
+			nodes, err := s.NodesForTopology(ctx, seg)
+			if err != nil {
+				return fmt.Errorf("failed to get preferred node list from segments: %w", err)
+			}
+
+			log.WithField("nodes", nodes).Trace("got nodes for segment")
+
+			for i := range nodes {
+				requisiteNodes[nodes[i]] = struct{}{}
+			}
+		}
 	}
 
 	log.WithField("requisite", requisiteNodes).Trace("got requisite nodes")
 
 	if len(requisiteNodes) > 0 {
+		requisiteNodesList := make([]string, 0, len(requisiteNodes))
+		for k := range requisiteNodes {
+			requisiteNodesList = append(requisiteNodesList, k)
+		}
+
+		// Sort, for testing
+		sort.Strings(requisiteNodesList)
+
 		// We do have requisite nodes, so we need to autoplace just on those nodes.
 		req := lapi.AutoPlaceRequest{
-			SelectFilter: lapi.AutoSelectFilter{NodeNameList: requisiteNodes},
+			SelectFilter: lapi.AutoSelectFilter{NodeNameList: requisiteNodesList},
 		}
 
 		// We might need to restrict autoplace here. We could have just one requisite node, but a placement count of 3.
@@ -132,8 +135,66 @@ func (s *Scheduler) Create(ctx context.Context, volId string, params *volume.Par
 	return nil
 }
 
-func (s *Scheduler) AccessibleTopologies(ctx context.Context, volId string, allowDisklessAccess bool) ([]*csi.Topology, error) {
-	return s.GenericAccessibleTopologies(ctx, volId, allowDisklessAccess)
+// PlaceAccessibleToSegment tries to place a replica accessible to the given segment.
+//
+// Initially, placement on an exactly matching node is tried. If that is not possible, the remoteAccessPolicy is
+// used to determine other nodes that would grant the given segment access.
+func (s *Scheduler) PlaceAccessibleToSegment(ctx context.Context, volId string, segments map[string]string, remoteAccessPolicy volume.RemoteAccessPolicy) error {
+	log := s.log.WithField("volume", volId).WithField("segments", segments)
+
+	nodes, err := s.NodesForTopology(ctx, segments)
+	if err != nil {
+		return fmt.Errorf("failed to get preferred node list from segments: %w", err)
+	}
+
+	log.WithField("nodes", nodes).Trace("try initial placement on preferred nodes")
+
+	apRequest := lapi.AutoPlaceRequest{SelectFilter: lapi.AutoSelectFilter{NodeNameList: nodes, PlaceCount: 1}}
+
+	err = s.Resources.Autoplace(ctx, volId, apRequest)
+	if err != nil {
+		log.WithError(err).Trace("failed to autoplace")
+	} else {
+		log.Trace("successfully placed on preferred node")
+		return nil
+	}
+
+	log.Trace("exact segments match failed, try with remote access policy")
+
+	accessibleSegments := remoteAccessPolicy.AccessibleSegments(segments)
+
+	log.WithField("accessibleSegments", accessibleSegments).Trace("got accessible segments")
+
+	for _, seg := range accessibleSegments {
+		log := log.WithField("segments", seg)
+
+		nodes, err := s.NodesForTopology(ctx, seg)
+		if err != nil {
+			log.WithError(err).Warn("failed to get preferred node list from segments")
+			continue
+		}
+
+		if len(nodes) == 0 {
+			log.Trace("no matching node")
+			continue
+		}
+
+		apRequest := lapi.AutoPlaceRequest{SelectFilter: lapi.AutoSelectFilter{NodeNameList: nodes, PlaceCount: 1}}
+
+		err = s.Resources.Autoplace(ctx, volId, apRequest)
+		if err != nil {
+			log.WithError(err).Trace("failed to autoplace")
+		} else {
+			log.Trace("successfully placed reachable for preferred node")
+			return nil
+		}
+	}
+
+	return fmt.Errorf("failed to place resource")
+}
+
+func (s *Scheduler) AccessibleTopologies(ctx context.Context, volId string, remoteAccessPolicy volume.RemoteAccessPolicy) ([]*csi.Topology, error) {
+	return s.GenericAccessibleTopologies(ctx, volId, remoteAccessPolicy)
 }
 
 func NewScheduler(c *lc.HighLevelClient, l *logrus.Entry) *Scheduler {

--- a/pkg/topology/scheduler/balancer/balancer.go
+++ b/pkg/topology/scheduler/balancer/balancer.go
@@ -324,9 +324,8 @@ func (b BalanceScheduler) Create(ctx context.Context, volId string, params *volu
 		return fmt.Errorf("placementPolicyBalance does not support choosing StoragePool, it should be picked automatically")
 	}
 
-	if !params.AllowRemoteVolumeAccess {
-		return fmt.Errorf("placementPolicyBalance cannot work on on local storage")
-	}
+	// TODO: There was a check once for remote volume access. Should be reintroduces, or preferrably, this whole
+	// scheduler should be nuked from orbit.
 
 	// For now we do not support more than one Diskfull Resources so set remainingAssignments to 1
 	remainingAssignments := 1
@@ -377,7 +376,7 @@ func (b BalanceScheduler) Create(ctx context.Context, volId string, params *volu
 	return nil
 }
 
-func (b BalanceScheduler) AccessibleTopologies(ctx context.Context, volId string, allowDisklessAccess bool) ([]*csi.Topology, error) {
+func (b BalanceScheduler) AccessibleTopologies(ctx context.Context, volId string, remoteAccessPolicy volume.RemoteAccessPolicy) ([]*csi.Topology, error) {
 	r, err := b.Resources.GetAll(ctx, volId)
 	if err != nil {
 		return nil, fmt.Errorf("unable to determine AccessibleTopologies: %v", err)

--- a/pkg/topology/scheduler/followtopology/follow_topology.go
+++ b/pkg/topology/scheduler/followtopology/follow_topology.go
@@ -113,6 +113,6 @@ func deleteSegment(topos []*csi.Topology, segment map[string]string) []*csi.Topo
 	return topos
 }
 
-func (s *Scheduler) AccessibleTopologies(ctx context.Context, volId string, allowDisklessAccess bool) ([]*csi.Topology, error) {
-	return s.GenericAccessibleTopologies(ctx, volId, allowDisklessAccess)
+func (s *Scheduler) AccessibleTopologies(ctx context.Context, volId string, remoteAccessPolicy volume.RemoteAccessPolicy) ([]*csi.Topology, error) {
+	return s.GenericAccessibleTopologies(ctx, volId, remoteAccessPolicy)
 }

--- a/pkg/topology/scheduler/manual/manual.go
+++ b/pkg/topology/scheduler/manual/manual.go
@@ -51,6 +51,6 @@ func (s *Scheduler) Create(ctx context.Context, volId string, params *volume.Par
 	return nil
 }
 
-func (s *Scheduler) AccessibleTopologies(ctx context.Context, volId string, allowDisklessAccess bool) ([]*csi.Topology, error) {
-	return s.GenericAccessibleTopologies(ctx, volId, allowDisklessAccess)
+func (s *Scheduler) AccessibleTopologies(ctx context.Context, volId string, remoteAccessPolicy volume.RemoteAccessPolicy) ([]*csi.Topology, error) {
+	return s.GenericAccessibleTopologies(ctx, volId, remoteAccessPolicy)
 }

--- a/pkg/topology/scheduler/scheduler.go
+++ b/pkg/topology/scheduler/scheduler.go
@@ -29,5 +29,5 @@ import (
 // Interface determines where to place volumes and where they are accessible from.
 type Interface interface {
 	Create(ctx context.Context, volId string, params *volume.Parameters, topologies *csi.TopologyRequirement) error
-	AccessibleTopologies(ctx context.Context, volId string, allowRemoteAccess bool) ([]*csi.Topology, error)
+	AccessibleTopologies(ctx context.Context, volId string, remoteAccessPolicy volume.RemoteAccessPolicy) ([]*csi.Topology, error)
 }

--- a/pkg/volume/parameter.go
+++ b/pkg/volume/parameter.go
@@ -76,7 +76,7 @@ type Parameters struct {
 	// Encrypt volumes if true.
 	Encryption bool
 	// AllowRemoteVolumeAccess if true, volumes may be accessed over the network.
-	AllowRemoteVolumeAccess bool
+	AllowRemoteVolumeAccess RemoteAccessPolicy
 	// LayerList is a list that corresponds to the `linstor resource create`
 	// option of the same name.
 	LayerList []devicelayerkind.DeviceLayerKind
@@ -92,6 +92,9 @@ type Parameters struct {
 
 const DefaultDisklessStoragePoolName = "DfltDisklessStorPool"
 
+// DefaultRemoteAccessPolicy is the access policy used by default when none is specified.
+var DefaultRemoteAccessPolicy = RemoteAccessPolicyAnywhere
+
 // NewParameters parses out the raw parameters we get and sets appropriate
 // zero values
 func NewParameters(params map[string]string) (Parameters, error) {
@@ -102,7 +105,7 @@ func NewParameters(params map[string]string) (Parameters, error) {
 		DisklessStoragePool:     DefaultDisklessStoragePoolName,
 		Encryption:              false,
 		PlacementPolicy:         topology.AutoPlaceTopology,
-		AllowRemoteVolumeAccess: true,
+		AllowRemoteVolumeAccess: DefaultRemoteAccessPolicy,
 		Properties:              make(map[string]string),
 	}
 
@@ -188,12 +191,13 @@ func NewParameters(params map[string]string) (Parameters, error) {
 
 			p.Disklessonremaining = d
 		case allowremotevolumeaccess:
-			a, err := strconv.ParseBool(v)
+			var policy RemoteAccessPolicy
+			err := policy.UnmarshalText([]byte(v))
 			if err != nil {
 				return p, err
 			}
 
-			p.AllowRemoteVolumeAccess = a
+			p.AllowRemoteVolumeAccess = policy
 		case clientlist:
 			p.ClientList = strings.Split(v, " ")
 		case placementpolicy:

--- a/pkg/volume/remoteaccess.go
+++ b/pkg/volume/remoteaccess.go
@@ -1,0 +1,139 @@
+package volume
+
+import (
+	"reflect"
+	"sort"
+	"strconv"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/piraeusdatastore/linstor-csi/pkg/topology"
+)
+
+// RemoteAccessPolicy represents a policy for allowing diskless access.
+type RemoteAccessPolicy []RemoteAccessPolicyRule
+
+type RemoteAccessPolicyRule struct {
+	FromSame []string `yaml:"fromSame,omitempty"`
+}
+
+// AccessibleSegments applies the policy to a specific cluster segment.
+func (r RemoteAccessPolicy) AccessibleSegments(segments map[string]string) []map[string]string {
+	var result []map[string]string
+
+	for _, rule := range r {
+		m := make(map[string]string)
+
+		for _, propName := range rule.FromSame {
+			val, ok := segments[propName]
+			if !ok {
+				continue
+			}
+
+			m[propName] = val
+		}
+
+		result = append(result, m)
+	}
+
+	return PrunePattern(result...)
+}
+
+func (r *RemoteAccessPolicy) UnmarshalText(text []byte) error {
+	// Handle legacy values: "true" allows access from any node, "false" allows access only on replicas
+	b, err := strconv.ParseBool(string(text))
+	if err == nil {
+		if b {
+			*r = RemoteAccessPolicyAnywhere
+		} else {
+			*r = RemoteAccessPolicyLocalOnly
+		}
+
+		return nil
+	}
+
+	// Cast is needed for reflect to pick up on the fact it's dealing with a pointer to a slice.
+	return yaml.Unmarshal(text, (*[]RemoteAccessPolicyRule)(r))
+}
+
+func (r RemoteAccessPolicy) MarshalText() (text []byte, err error) {
+	if reflect.DeepEqual(r, RemoteAccessPolicyLocalOnly) {
+		return []byte("false"), nil
+	} else if reflect.DeepEqual(r, RemoteAccessPolicyAnywhere) {
+		return []byte("true"), nil
+	}
+
+	return yaml.Marshal([]RemoteAccessPolicyRule(r))
+}
+
+// String is used for settings a RemoteAccessPolicy via cli args.
+func (r *RemoteAccessPolicy) String() string {
+	text, err := r.MarshalText()
+	if err != nil {
+		panic(err)
+	}
+
+	return string(text)
+}
+
+// Set is used for setting a RemoteAccessPolicy via cli args.
+func (r *RemoteAccessPolicy) Set(s string) error {
+	return r.UnmarshalText([]byte(s))
+}
+
+var (
+	// RemoteAccessPolicyAnywhere allows remote access from anywhere
+	RemoteAccessPolicyAnywhere = RemoteAccessPolicy{{}}
+	// RemoteAccessPolicyLocalOnly allows access only to the local node, effectively disabling diskless access.
+	RemoteAccessPolicyLocalOnly = RemoteAccessPolicy{{FromSame: []string{topology.LinstorNodeKey}}}
+)
+
+// subsetOf returns true if the first argument is a subset of the second argument.
+func subsetOf(a, b map[string]string) bool {
+	for k, v := range a {
+		other, ok := b[k]
+		if !ok || v != other {
+			return false
+		}
+	}
+
+	return true
+}
+
+// PrunePattern returns the given list of pattern, removed of any duplicates or patterns which are already covered by
+// a more general pattern.
+//
+// Some examples
+//   [{a:1}, {a:1}] => [{a:1}]
+//   [{a:1}, {a:2}] => [{a:1}, {a:2}]
+//   [{a:1, b:1}, {a:1}] => [{a:1}]
+//   [{a:1, b:1}, {a:1, b:2}] => [{a:1, b:1}, {a:1, b:2}]
+//   [{a:1}, {a:1, b:1}, {a:1, b:2}] => [{a:1}]
+func PrunePattern(sources ...map[string]string) []map[string]string {
+	var result []map[string]string
+
+	// This sort ensures that broad segments, i.e. those with less "rules", are inserted into the result first.
+	// The reason you want that is you can avoid situations were a policy you are currently inspecting
+	// would replace multiple existing ones. Basically, you don't want a situation where:
+	//   toCheck ⊂ existing1 and toCheck ⊂ existing2
+	// which would mean we would remove multiple existing elements and replace them with toCheck. By sorting we can
+	// ensure that toCheck ⊂ existing1 => toCheck == existing1, so we can just skip insertion. This makes the actual
+	// prune loop much easier.
+	sort.Slice(sources, func(i, j int) bool {
+		return len(sources[i]) < len(sources[j])
+	})
+
+outer:
+	for _, source := range sources {
+		for i := range result {
+			if subsetOf(result[i], source) {
+				// we already have the less strict variant in the results, no need to add a stricter variant
+				continue outer
+			}
+		}
+
+		result = append(result, source)
+	}
+
+	return result
+}

--- a/pkg/volume/remoteaccess_test.go
+++ b/pkg/volume/remoteaccess_test.go
@@ -1,0 +1,218 @@
+package volume_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/piraeusdatastore/linstor-csi/pkg/volume"
+)
+
+func TestRemoteAccessPolicy(t *testing.T) {
+	t.Parallel()
+
+	exampleSegments := map[string]string{
+		"linbit.com/hostname":           "host-1",
+		"linbit.com/sp-storage-pool":    "true",
+		"topology.kubernetes.io/region": "region-1",
+		"topology.kubernetes.io/zone":   "region-1-zone-1",
+	}
+
+	cases := []struct {
+		name             string
+		policy           volume.RemoteAccessPolicy
+		segments         map[string]string
+		expectedSegments []map[string]string
+	}{
+		{
+			name:     "access-everywhere",
+			policy:   volume.RemoteAccessPolicyAnywhere,
+			segments: exampleSegments,
+			expectedSegments: []map[string]string{
+				{},
+			},
+		},
+		{
+			name:     "access-local",
+			policy:   volume.RemoteAccessPolicyLocalOnly,
+			segments: exampleSegments,
+			expectedSegments: []map[string]string{
+				{"linbit.com/hostname": "host-1"},
+			},
+		},
+		{
+			name:             "access-unknown-label",
+			policy:           volume.RemoteAccessPolicy{{FromSame: []string{"some-new-label"}}},
+			segments:         exampleSegments,
+			expectedSegments: []map[string]string{{}},
+		},
+		{
+			name:     "access-multi-rule",
+			policy:   volume.RemoteAccessPolicy{{FromSame: []string{"topology.kubernetes.io/region"}}, {FromSame: []string{"topology.kubernetes.io/zone"}}},
+			segments: exampleSegments,
+			expectedSegments: []map[string]string{
+				{"topology.kubernetes.io/region": "region-1"},
+				{"topology.kubernetes.io/zone": "region-1-zone-1"},
+			},
+		},
+	}
+
+	for i := range cases {
+		tcase := &cases[i]
+
+		t.Run(tcase.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := tcase.policy.AccessibleSegments(tcase.segments)
+			assert.Equal(t, tcase.expectedSegments, actual)
+		})
+	}
+}
+
+func TestRemoteAccessPolicyUnmarshal(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		raw      string
+		expected volume.RemoteAccessPolicy
+	}{
+		{
+			name:     "legacy-true",
+			raw:      "true",
+			expected: volume.RemoteAccessPolicyAnywhere,
+		},
+		{
+			name:     "legacy-false",
+			raw:      "false",
+			expected: volume.RemoteAccessPolicyLocalOnly,
+		},
+		{
+			name: "parse-simple",
+			raw: `
+- fromSame:
+    - topology.kubernetes.io/zone
+    - topology.kubernetes.io/region
+`,
+			expected: volume.RemoteAccessPolicy{{FromSame: []string{"topology.kubernetes.io/zone", "topology.kubernetes.io/region"}}},
+		},
+		{
+			name: "parse-multiple-rules",
+			raw: `
+- fromSame:
+    - topology.kubernetes.io/zone
+    - topology.kubernetes.io/region
+- fromSame:
+    - some-other-zone-label
+`,
+			expected: volume.RemoteAccessPolicy{{FromSame: []string{"topology.kubernetes.io/zone", "topology.kubernetes.io/region"}}, {FromSame: []string{"some-other-zone-label"}}},
+		},
+	}
+
+	for i := range cases {
+		tcase := &cases[i]
+
+		t.Run(tcase.name, func(t *testing.T) {
+			t.Parallel()
+
+			var actual volume.RemoteAccessPolicy
+			err := actual.UnmarshalText([]byte(tcase.raw))
+			assert.NoError(t, err)
+			assert.Equal(t, tcase.expected, actual)
+		})
+	}
+}
+
+func TestRemoteAccessPolicyMarshal(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		original volume.RemoteAccessPolicy
+		expected string
+	}{
+		{
+			name:     "legacy-true",
+			original: volume.RemoteAccessPolicyAnywhere,
+			expected: "true",
+		},
+		{
+			name:     "legacy-false",
+			original: volume.RemoteAccessPolicyLocalOnly,
+			expected: "false",
+		},
+		{
+			name:     "marshal-simple",
+			original: volume.RemoteAccessPolicy{{FromSame: []string{"topology.kubernetes.io/zone", "topology.kubernetes.io/region"}}},
+			expected: `- fromSame:
+    - topology.kubernetes.io/zone
+    - topology.kubernetes.io/region
+`,
+		},
+		{
+			name:     "marshal-multiple-rules",
+			original: volume.RemoteAccessPolicy{{FromSame: []string{"topology.kubernetes.io/zone", "topology.kubernetes.io/region"}}, {FromSame: []string{"some-other-zone-label"}}},
+			expected: `- fromSame:
+    - topology.kubernetes.io/zone
+    - topology.kubernetes.io/region
+- fromSame:
+    - some-other-zone-label
+`,
+		},
+	}
+
+	for i := range cases {
+		tcase := &cases[i]
+
+		t.Run(tcase.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, err := tcase.original.MarshalText()
+			assert.NoError(t, err)
+			assert.Equal(t, tcase.expected, string(actual))
+		})
+	}
+}
+
+func TestPrunePattern(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		inp      []map[string]string
+		expected []map[string]string
+	}{
+		{
+			// nil -> nil
+		},
+		{
+			inp:      []map[string]string{{"a": "1"}, {"a": "1"}},
+			expected: []map[string]string{{"a": "1"}},
+		},
+		{
+			inp:      []map[string]string{{"a": "1"}, {"a": "2"}},
+			expected: []map[string]string{{"a": "1"}, {"a": "2"}},
+		},
+		{
+			inp:      []map[string]string{{"a": "1", "b": "1"}, {"a": "1"}},
+			expected: []map[string]string{{"a": "1"}},
+		},
+		{
+			inp:      []map[string]string{{"a": "1", "b": "1"}, {"a": "1", "b": "2"}},
+			expected: []map[string]string{{"a": "1", "b": "1"}, {"a": "1", "b": "2"}},
+		},
+		{
+			inp:      []map[string]string{{"a": "1"}, {"a": "1", "b": "1"}, {"a": "1", "b": "2"}},
+			expected: []map[string]string{{"a": "1"}},
+		},
+	}
+
+	for i := range cases {
+		tcase := &cases[i]
+
+		t.Run(fmt.Sprintf("%+v", tcase.inp), func(t *testing.T) {
+			actual := volume.PrunePattern(tcase.inp...)
+			assert.Equal(t, tcase.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
Up to now, using diskless volumes was an all-or-nothing affair: either allow
diskless resource from any node, or don't allow them at all. This was quite
limiting for more advanced cluster architectures.

For example, clusters spanning multiple zones could not restrict diskless
access to only nodes in the same zone. Similarly, if you had dedicated storage
hosts, you could not restrict diskless volumes to a specific subset.

Another issues was in the calculation of storage capacity. In case of dedicated
storage hosts, the storage capacity was effectively 0 on almost all nodes,
meaning pods were never scheduled on those nodes, even tough diskless access
from the dedicated storage was possible.

As a solution, introduce new values for the `allowRemoteVolumeAccess`
parameter. It now takes a list of matching rules, that are compared to the
topology segments provided by the CO.

For example, to allow access from nodes in the same zone, you could now use:

```yaml
allowRemoteVolumeAccess: |
  - fromSame:
    - topology.kubernetes.io/zone
```

For access from anywhere, you can still use the old "true", which desugars to

```yaml
allowRemoteVolumeAccess: |
  - fromSame: []
```

The old strict access "false" desugars to:

```yaml
allowRemoteVolumeAccess: |
  - fromSame:
    - linbit.com/hostname
```