### PR TITLE
attach: ignore replicasOn... parameters if required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `allowRemoteVolumeAccess` supports new values, allowing a more fine-grained controlled on diskless access.
 
+### Fixed
+
+- ControllerPublishVolume will attach a new volume on the selected node, even if it violates the replicasOn...
+  parameters. This prevented `allowRemoteVolumeAccess` from working as expected.
+
 ## [0.16.1] - 2021-11-08
 
 ### Changed


### PR DESCRIPTION
replicasOn... parameters are intended for spreading the intial set of replicas.
For volume use, it might be required to attach the volume to a node that would
violate the requirements. As a high level argument, you could say that these
temporary attached volumes are not really replicas in the sense implied by
replicasOn... parameters.

The fix is to fall back to manual resource creation if required. Note that we
do not always use this manual creation, as in some cases it is advantageous
to try make-available first. For example, in a shared storage pool scenario
make-available will pick a new shared resource over diskless attachment.

Signed-off-by: Moritz "WanzenBug" Wanzenböck <moritz.wanzenboeck@linbit.com>