### PR TITLE
New "usePvcName" parameter for user-controlled names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- A new parameter `usePvcName` was added. When "true", the driver will (try to) use the PVC name + namespace instead
+  of the generated PV name as ID. Because this might generate name conflicts in certain scenarios, it remains disabled
+  by default.
+
 ### Changed
 
 - Require golang 1.17 for `go generate`, removing the binary dependencies from go.mod.

--- a/pkg/client/linstor.go
+++ b/pkg/client/linstor.go
@@ -250,7 +250,17 @@ func (s *Linstor) FindByID(ctx context.Context, id string) (*volume.Info, error)
 	}), nil
 }
 
-func (s *Linstor) CompatibleVolumeId(name string) string {
+func (s *Linstor) CompatibleVolumeId(name, pvcNamespace, pvcName string) string {
+	if pvcNamespace != "" && pvcName != "" {
+		s.log.Debug("try creating valid volume name based on PVC")
+
+		generatedName := fmt.Sprintf("%s-%s", pvcNamespace, pvcName)
+
+		if validResourceName(generatedName) == nil {
+			return generatedName
+		}
+	}
+
 	invalid := validResourceName(name)
 	if invalid == nil {
 		return name

--- a/pkg/client/mock.go
+++ b/pkg/client/mock.go
@@ -69,7 +69,7 @@ func (s *MockStorage) FindByID(ctx context.Context, id string) (*volume.Info, er
 	return nil, nil
 }
 
-func (s *MockStorage) CompatibleVolumeId(name string) string {
+func (s *MockStorage) CompatibleVolumeId(name, pvcNamespace, pvcName string) string {
 	return name
 }
 

--- a/pkg/volume/parameter.go
+++ b/pkg/volume/parameter.go
@@ -39,6 +39,7 @@ const (
 	storagepool
 	postmountxfsopts
 	resourcegroup
+	usepvcname
 )
 
 // Parameters configuration for linstor volumes.
@@ -88,6 +89,8 @@ type Parameters struct {
 	ResourceGroup string
 	// Properties are the properties to be set on the resource group.
 	Properties map[string]string
+	// UsePvcName derives the volume name from the PVC name+namespace, if that information is available.
+	UsePvcName bool
 }
 
 const DefaultDisklessStoragePoolName = "DfltDisklessStorPool"
@@ -215,6 +218,13 @@ func NewParameters(params map[string]string) (Parameters, error) {
 			p.PostMountXfsOpts = v
 		case resourcegroup:
 			p.ResourceGroup = v
+		case usepvcname:
+			u, err := strconv.ParseBool(v)
+			if err != nil {
+				return p, err
+			}
+
+			p.UsePvcName = u
 		case sizekib:
 			// This parameter was unused. It is just parsed to not break any old storage classes that might be using
 			// it. Storage sizes are handled via CSI requests directly.

--- a/pkg/volume/paramkey_enumer.go
+++ b/pkg/volume/paramkey_enumer.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 )
 
-const _paramKeyName = "allowremotevolumeaccessautoplaceclientlistdisklessonremainingdisklessstoragepooldonotplacewithregexencryptionfsoptslayerlistmountoptsnodelistplacementcountplacementpolicyreplicasondifferentreplicasonsamesizekibstoragepoolpostmountxfsoptsresourcegroup"
+const _paramKeyName = "allowremotevolumeaccessautoplaceclientlistdisklessonremainingdisklessstoragepooldonotplacewithregexencryptionfsoptslayerlistmountoptsnodelistplacementcountplacementpolicyreplicasondifferentreplicasonsamesizekibstoragepoolpostmountxfsoptsresourcegroupusepvcname"
 
-var _paramKeyIndex = [...]uint8{0, 23, 32, 42, 61, 80, 99, 109, 115, 124, 133, 141, 155, 170, 189, 203, 210, 221, 237, 250}
+var _paramKeyIndex = [...]uint16{0, 23, 32, 42, 61, 80, 99, 109, 115, 124, 133, 141, 155, 170, 189, 203, 210, 221, 237, 250, 260}
 
 func (i paramKey) String() string {
 	if i < 0 || i >= paramKey(len(_paramKeyIndex)-1) {
@@ -18,7 +18,7 @@ func (i paramKey) String() string {
 	return _paramKeyName[_paramKeyIndex[i]:_paramKeyIndex[i+1]]
 }
 
-var _paramKeyValues = []paramKey{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18}
+var _paramKeyValues = []paramKey{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19}
 
 var _paramKeyNameToValueMap = map[string]paramKey{
 	_paramKeyName[0:23]:    0,
@@ -40,6 +40,7 @@ var _paramKeyNameToValueMap = map[string]paramKey{
 	_paramKeyName[210:221]: 16,
 	_paramKeyName[221:237]: 17,
 	_paramKeyName[237:250]: 18,
+	_paramKeyName[250:260]: 19,
 }
 
 // paramKeyString retrieves an enum value from the enum constants string name.

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -47,7 +47,7 @@ type Assignment struct {
 // CreateDeleter handles the creation and deletion of volumes.
 type CreateDeleter interface {
 	Querier
-	CompatibleVolumeId(name string) string
+	CompatibleVolumeId(name, pvcNamespace, pvcName string) string
 	Create(ctx context.Context, vol *Info, params *Parameters, topologies *csi.TopologyRequirement) error
 	Delete(ctx context.Context, volId string) error
 


### PR DESCRIPTION
A new parameter `usePvcName` is added. When "true", the driver will (try to)
use the PVC name + namespace instead of the generated PV name as ID. Because
this might generate name conflicts in certain scenarios, it remains disabled
by default.