### PR TITLE
unpublish: ignore errors generated by deleted nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Require golang 1.17 for `go generate`, removing the binary dependencies from go.mod.
 - Update CSI Spec to 1.5.0
 
+### Fixed
+
+- ControllerUnpublishVolume could fail if LINSTOR node was deleted before the detach operation was executed.
+
 ## [0.17.0] - 2021-12-09
 
 ### Added

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -654,7 +654,7 @@ func (d Driver) ControllerUnpublishVolume(ctx context.Context, req *csi.Controll
 
 	if err := d.Assignments.Detach(ctx, req.GetVolumeId(), req.GetNodeId()); err != nil {
 		return nil, status.Errorf(codes.Internal,
-			"ControllerpublishVolume failed for %s: %v", req.GetVolumeId(), err)
+			"ControllerUnpublishVolume failed for %s: %v", req.GetVolumeId(), err)
 	}
 
 	return &csi.ControllerUnpublishVolumeResponse{}, nil


### PR DESCRIPTION
If a node is deleted from k8s and LINSTOR, the volume attachments might
still hang around, triggering ControllerUnpublishVolume calls on nodes
that no long exist.

This commit ensures we handle this case gracefully, detaching from the "lost"
node. Since the node was already deleted from LINSTOR, there isn't actually
anything for us to-do on detach.