### PR TITLE
expand restored volume before deploying to multiple nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - ControllerUnpublishVolume could fail if LINSTOR node was deleted before the detach operation was executed.
+- LINSTOR CSI now expands a restored or cloned volume (if required) before deploying to multiple nodes. A single
+  resource should always be in sync, so it is always safe to expand them.
 
 ## [0.17.0] - 2021-12-09
 

--- a/pkg/client/linstor.go
+++ b/pkg/client/linstor.go
@@ -898,16 +898,16 @@ func (s *Linstor) VolFromSnap(ctx context.Context, snap *csi.Snapshot, vol *volu
 		return err
 	}
 
-	logger.Debug("reconcile resource placement after restore")
+	logger.Debug("reconcile volume definition from request (may expand volume)")
 
-	err = s.reconcileResourcePlacement(ctx, vol, params, topologies)
+	_, err = s.reconcileVolumeDefinition(ctx, vol)
 	if err != nil {
 		return err
 	}
 
-	logger.Debug("reconcile volume definition from request (may expand volume)")
+	logger.Debug("reconcile resource placement after restore")
 
-	_, err = s.reconcileVolumeDefinition(ctx, vol)
+	err = s.reconcileResourcePlacement(ctx, vol, params, topologies)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Newer LINSTOR releases prevent expansion of volumes that are not in sync.
This prevents bugs when resizing DRBD devices while sync is in progress.

The CSI driver expands volume in two cases:

1. When the user requests an existing volume to be resized.
   In this case we can expect the resource to be in sync already, so there
   is no special consideration. In the worst case, the operation is simply
   retried a bit later.

2. When a snapshot is restored, or a volume cloned.
   In this case, right after we complete the restore operation, the volumes
   are likely still syncing. This is because we only clone the data from a
   single node and letting DRBD do the replication itself. This was introduced
   in cd699d661 in order to support changing parameters on restored volumes,
   and is also used for restoring from S3 backups, as there snapshot will
   generally only be available on a single node after download.

In order to prevent errors in case nr. 2, we slightly adjust the order of
operations when restoring:

1. restore the snapshot on a single node
2. expand the one existing volume as required
3. deploy remaining resource

Since the resource was just restored and is only available on that restored
node it should always be in sync.

Signed-off-by: Moritz "WanzenBug" Wanzenböck <moritz.wanzenboeck@linbit.com>