### PR TITLE
delegate mkfs to LINSTOR

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
         args:
           - --multi
       - id: check-added-large-files
-  - repo: git://github.com/dnephin/pre-commit-golang
+  - repo: https://github.com/dnephin/pre-commit-golang
     rev: v0.4.0
     hooks:
       - id: go-fmt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Breaking
+
+- An empty filesystem volume that was provisioned with 0.18.0, but never attached will not be attachable. It is missing
+  the filesystem, since LINSTOR CSI no longer creates it on attach. You have to recreate these volumes (by definition,
+  they hold no data).
+
+### Changed
+
+- Use LINSTOR native properties to provision filesystem volumes. This might slightly alter the default options used
+  when running `mkfs`, LINSTOR choses defaults optimized for DRBD. Previously filesystem creation was part of the usual
+  mount process. This could run into timeouts for very large volumes: as the process would be restarted from scratch
+  on every timeout, it would never complete.
+
 ## [0.18.0] - 2022-02-24
 
 ### Added

--- a/pkg/client/linstor_test.go
+++ b/pkg/client/linstor_test.go
@@ -23,7 +23,6 @@ package client
 import (
 	"context"
 	"encoding/json"
-	"reflect"
 	"testing"
 
 	lapiconsts "github.com/LINBIT/golinstor"
@@ -137,24 +136,6 @@ func TestLinstorifyResourceName(t *testing.T) {
 
 		if resName != test.out {
 			t.Fatalf("Expected that input '%s' transforms to '%s', but got '%s'\n", test.in, test.out, resName)
-		}
-	}
-}
-
-func TestMkfsArgs(t *testing.T) {
-	tableTests := []struct {
-		opts, source string
-		expected     []string
-	}{
-		{"-K", "/dev/path", []string{"-K", "/dev/path"}},
-		{"", "/dev/path", []string{"/dev/path"}},
-	}
-
-	for _, tt := range tableTests {
-		actual := mkfsArgs(tt.opts, tt.source)
-		if !reflect.DeepEqual(tt.expected, actual) {
-			t.Errorf("Expected that mkfsArgs(%q, %q) results in\n\t%v\nbut got\n\t%v\n",
-				tt.opts, tt.source, tt.expected, actual)
 		}
 	}
 }

--- a/pkg/client/mock.go
+++ b/pkg/client/mock.go
@@ -231,7 +231,7 @@ func (s *MockStorage) CapacityBytes(ctx context.Context, sp string, segments map
 	return 50000000, nil
 }
 
-func (s *MockStorage) Mount(ctx context.Context, source, target, fsType string, readonly bool, mntOpts, mkfsOpts []string) error {
+func (s *MockStorage) Mount(ctx context.Context, source, target, fsType string, readonly bool, mntOpts []string) error {
 	if _, err := os.Stat(target); os.IsNotExist(err) {
 		return os.MkdirAll(target, 0755)
 	}

--- a/pkg/driver/volume_context.go
+++ b/pkg/driver/volume_context.go
@@ -10,14 +10,12 @@ import (
 const (
 	VolumeContextMarker = linstor.ParameterNamespace + "/uses-volume-context"
 	MountOptions        = linstor.ParameterNamespace + "/mount-options"
-	MkfsOptions         = linstor.ParameterNamespace + "/mkfs-options"
 	PostMountXfsOpts    = linstor.ParameterNamespace + "/post-mount-xfs-opts"
 )
 
 // VolumeContext stores the context parameters required to mount a volume.
 type VolumeContext struct {
 	MountOptions        []string
-	MkfsOptions         []string
 	PostMountXfsOptions string
 }
 
@@ -28,11 +26,9 @@ func NewVolumeContext() *VolumeContext {
 
 func VolumeContextFromParameters(params *volume.Parameters) *VolumeContext {
 	mountOpts := parseMountOpts(params.MountOpts)
-	mkfsOpts := parseMkfsOpts(params.FSOpts)
 
 	return &VolumeContext{
 		MountOptions:        mountOpts,
-		MkfsOptions:         mkfsOpts,
 		PostMountXfsOptions: params.PostMountXfsOpts,
 	}
 }
@@ -44,11 +40,9 @@ func VolumeContextFromMap(ctx map[string]string) *VolumeContext {
 	}
 
 	mountOpts := parseMountOpts(ctx[MountOptions])
-	mkfsOpts := parseMkfsOpts(ctx[MkfsOptions])
 
 	return &VolumeContext{
 		MountOptions:        mountOpts,
-		MkfsOptions:         mkfsOpts,
 		PostMountXfsOptions: ctx[PostMountXfsOpts],
 	}
 }
@@ -57,7 +51,6 @@ func (v *VolumeContext) ToMap() map[string]string {
 	return map[string]string{
 		VolumeContextMarker: "true",
 		MountOptions:        encodeMountOpts(v.MountOptions),
-		MkfsOptions:         encodeMkfsOpts(v.MkfsOptions),
 		PostMountXfsOpts:    v.PostMountXfsOptions,
 	}
 }
@@ -72,16 +65,4 @@ func parseMountOpts(opts string) []string {
 
 func encodeMountOpts(opts []string) string {
 	return strings.Join(opts, ",")
-}
-
-func parseMkfsOpts(opts string) []string {
-	if opts == "" {
-		return nil
-	}
-
-	return strings.Split(opts, " ")
-}
-
-func encodeMkfsOpts(opts []string) string {
-	return strings.Join(opts, " ")
 }

--- a/pkg/volume/parameter.go
+++ b/pkg/volume/parameter.go
@@ -62,7 +62,7 @@ type Parameters struct {
 	// DoNotPlaceWithRegex corresponds to the `linstor resource create`
 	// option of the same name.
 	DoNotPlaceWithRegex string
-	// FSOpts is a string of filesystem options passed at mount time.
+	// FSOpts is a string of filesystem options passed at creation time.
 	FSOpts string
 	// MountOpts is a string of mount options passed at mount time. Comma
 	// separated like in /etc/fstab.

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -31,6 +31,7 @@ type Info struct {
 	ID            string
 	SizeBytes     int64
 	ResourceGroup string
+	FsType        string
 	Properties    map[string]string
 }
 
@@ -101,7 +102,7 @@ type Querier interface {
 
 // Mounter handles the filesystems located on volumes.
 type Mounter interface {
-	Mount(ctx context.Context, source, target, fsType string, readonly bool, mntOpts, mkfsOpts []string) error
+	Mount(ctx context.Context, source, target, fsType string, readonly bool, mntOpts []string) error
 	Unmount(target string) error
 	IsNotMountPoint(target string) (bool, error)
 }


### PR DESCRIPTION
Replaces custom mkfs formatting code with LINSTOR built-ins. This replaces
the formatAndMount check at node attach time with simply setting properties
on the ResourceDefinition.

Note that we do not set it on the ResourceGroup (~ StorageClass) level, as
filesystem is determined by the PersistentVolumeClaim (~ ResourceDefinition)
being created.

Signed-off-by: Moritz "WanzenBug" Wanzenböck <moritz.wanzenboeck@linbit.com>