### PR TITLE
Fix mtab warning for mkfs commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,8 @@ ARG LINSTOR_WAIT_UNTIL
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
       xfsprogs e2fsprogs \
-      && apt-get clean && rm -rf /var/lib/apt/lists/*
+      && apt-get clean && rm -rf /var/lib/apt/lists/* \
+      && ln -sf /proc/mounts /etc/mtab
 
 COPY --from=builder /linstor-csi /
 COPY --from=downloader /linstor-wait-until /linstor-wait-until


### PR DESCRIPTION
Docker image `debian:bullseye-slim` does not contain `/etc/mtab` symlink. While docker is setting it [automatically](https://github.com/moby/moby/blob/master/daemon/initlayer/setup_unix.go#L25-L36) for every container, containerd is not doing this.

This affects Kubernetes deployments with containerd, which are report the following warning every time when attaching a new volume to pod:
```
mke2fs 1.44.5 (15-Dec-2018)
ext2fs_check_if_mount: Can't check if filesystem is mounted due to missing mtab file while determining whether /dev/drbd1000 is mounted.
```

This confuses the end users of linstor-csi plugin.