### PR TITLE
order snapshot restore based on preferred nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Snapshots from S3 are now restored by preferred topology, if possible. Previously, all admissible nodes based
+  on the provided cluster topology were considered in random order. Now the order is fixed to be based on the
+  preferred topology instead.
+
 ### Breaking
 
 - An empty filesystem volume that was provisioned with 0.18.0, but never attached will not be attachable. It is missing


### PR DESCRIPTION
When restoring a snapshot from S3 backup, LINSTOR CSI will have to select
a node on which to download the backup. This should have always been the
preferred node (which was likely chosen by the workload scheduler). However,
we only considered the requisite topology, which is not always good enough.

With this commit we sort the requisite nodes by their preference, so in the
ideal case, the snapshot is downloaded directly on the node that will consume
the new volume.