### PR TITLE
support for external components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Store access policy in volume context, enabling volume context parsing without access to the storage class.
+  This improves the situation for LINSTOR Scheduler and Affinity Controller, which need to access this value.
+
 ## [0.19.0] - 2022-05-09
 
 ### Added

--- a/pkg/client/linstor.go
+++ b/pkg/client/linstor.go
@@ -272,7 +272,7 @@ func (s *Linstor) CompatibleVolumeId(name, pvcNamespace, pvcName string) string 
 
 	s.log.WithField("reason", invalid).Debug("volume name is invalid, will generate fallback")
 
-	uuidv5 := uuid.NewSHA1([]byte("linstor.csi.linbit.com"), []byte(name))
+	uuidv5 := uuid.NewSHA1([]byte(linstor.DriverName), []byte(name))
 
 	return fmt.Sprintf("vol-%s", uuidv5.String())
 }
@@ -700,7 +700,7 @@ func (s *Linstor) CompatibleSnapshotId(name string) string {
 
 	s.log.WithField("reason", invalid).Debug("snapshot name is invalid, will generate fallback")
 
-	uuidv5 := uuid.NewSHA1([]byte("linstor.csi.linbit.com"), []byte(name))
+	uuidv5 := uuid.NewSHA1([]byte(linstor.DriverName), []byte(name))
 
 	return fmt.Sprintf("snapshot-%s", uuidv5.String())
 }

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -74,7 +74,7 @@ func NewDriver(options ...func(*Driver) error) (*Driver, error) {
 	mockStorage := client.NewMockStorage()
 
 	d := &Driver{
-		name:          "linstor.csi.linbit.com",
+		name:          linstor.DriverName,
 		version:       Version,
 		nodeID:        "localhost",
 		Storage:       mockStorage,

--- a/pkg/driver/volume_context.go
+++ b/pkg/driver/volume_context.go
@@ -1,6 +1,7 @@
 package driver
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/piraeusdatastore/linstor-csi/pkg/linstor"
@@ -8,15 +9,17 @@ import (
 )
 
 const (
-	VolumeContextMarker = linstor.ParameterNamespace + "/uses-volume-context"
-	MountOptions        = linstor.ParameterNamespace + "/mount-options"
-	PostMountXfsOpts    = linstor.ParameterNamespace + "/post-mount-xfs-opts"
+	VolumeContextMarker    = linstor.ParameterNamespace + "/uses-volume-context"
+	MountOptions           = linstor.ParameterNamespace + "/mount-options"
+	PostMountXfsOpts       = linstor.ParameterNamespace + "/post-mount-xfs-opts"
+	RemoteAccessPolicyOpts = linstor.ParameterNamespace + "/remote-access-policy"
 )
 
 // VolumeContext stores the context parameters required to mount a volume.
 type VolumeContext struct {
 	MountOptions        []string
 	PostMountXfsOptions string
+	RemoteAccessPolicy  volume.RemoteAccessPolicy
 }
 
 // NewVolumeContext creates a new default volume context, which does not specify any fancy mkfs/mount/post-mount options
@@ -30,29 +33,44 @@ func VolumeContextFromParameters(params *volume.Parameters) *VolumeContext {
 	return &VolumeContext{
 		MountOptions:        mountOpts,
 		PostMountXfsOptions: params.PostMountXfsOpts,
+		RemoteAccessPolicy:  params.AllowRemoteVolumeAccess,
 	}
 }
 
-func VolumeContextFromMap(ctx map[string]string) *VolumeContext {
+func VolumeContextFromMap(ctx map[string]string) (*VolumeContext, error) {
 	_, ok := ctx[VolumeContextMarker]
 	if !ok {
-		return nil
+		return nil, nil
 	}
 
 	mountOpts := parseMountOpts(ctx[MountOptions])
 
+	var policy volume.RemoteAccessPolicy
+
+	err := policy.UnmarshalText([]byte(ctx[RemoteAccessPolicyOpts]))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse volume context: %w", err)
+	}
+
 	return &VolumeContext{
 		MountOptions:        mountOpts,
 		PostMountXfsOptions: ctx[PostMountXfsOpts],
-	}
+		RemoteAccessPolicy:  policy,
+	}, nil
 }
 
-func (v *VolumeContext) ToMap() map[string]string {
-	return map[string]string{
-		VolumeContextMarker: "true",
-		MountOptions:        encodeMountOpts(v.MountOptions),
-		PostMountXfsOpts:    v.PostMountXfsOptions,
+func (v *VolumeContext) ToMap() (map[string]string, error) {
+	policy, err := v.RemoteAccessPolicy.MarshalText()
+	if err != nil {
+		return nil, fmt.Errorf("failed to ecnode remote policy: %w", err)
 	}
+
+	return map[string]string{
+		VolumeContextMarker:    "true",
+		MountOptions:           encodeMountOpts(v.MountOptions),
+		PostMountXfsOpts:       v.PostMountXfsOptions,
+		RemoteAccessPolicyOpts: string(policy),
+	}, nil
 }
 
 func parseMountOpts(opts string) []string {

--- a/pkg/linstor/const.go
+++ b/pkg/linstor/const.go
@@ -23,6 +23,9 @@ import (
 )
 
 const (
+	// DriverName is the name used in CSI calls for this driver.
+	DriverName = "linstor.csi.linbit.com"
+
 	// LegacyParameterPassKey is the Aux props key in linstor where serialized CSI parameters
 	// are stored.
 	LegacyParameterPassKey = lc.NamespcAuxiliary + "/csi-volume-annotations"
@@ -42,14 +45,14 @@ const (
 	PublishedReadOnlyKey = lc.NamespcAuxiliary + "/csi-publish-readonly"
 
 	// ParameterNamespace is the preferred namespace when setting parameters in
-	ParameterNamespace = "linstor.csi.linbit.com"
+	ParameterNamespace = DriverName
 
 	// SnapshotParameterNamespace is the namespace when setting snapshot parameters in storage and snapshot classes.
-	SnapshotParameterNamespace = "snap.linstor.csi.linbit.com"
+	SnapshotParameterNamespace = "snap." + DriverName
 
 	// PropertyNamespace is the namespace for LINSTOR properties in kubernetes storage class parameters.
-	PropertyNamespace = "property.linstor.csi.linbit.com"
+	PropertyNamespace = "property." + DriverName
 
 	// ResourceGroupNamespace is the UUID namespace for generated resource groups
-	ResourceGroupNamespace = "resourcegroup.linstor.csi.linbit.com"
+	ResourceGroupNamespace = "resourcegroup." + DriverName
 )


### PR DESCRIPTION
This PR is focused on improving support for external components that need to interact with LINSTOR CSI resources:

* Export the CSI driver name. This was a tiny papercut, but having to specify the full driver name every time sucked.
* Export the remote access policy parameter. This value is important for some external components such as LINSTOR Scheduler and LINSTOR Affinity Controller. Having to parse the storage class just for that is pretty error-prone, as there is no guarantee that the storage class still exists or that is the same storage class used during provisioning.