### PR TITLE
Add option to configure which topology keys are exported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add option to set property namespace used to determine a nodes topology.
+- Add option to skip labelling nodes based on configured storage pools.
 
 ## [0.20.0] - 2022-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add option to set property namespace used to determine a nodes topology.
+
 ## [0.20.0] - 2022-07-20
 
 ### Added

--- a/cmd/linstor-csi/linstor-csi.go
+++ b/cmd/linstor-csi/linstor-csi.go
@@ -28,6 +28,7 @@ import (
 	"net/url"
 	"os"
 
+	linstor "github.com/LINBIT/golinstor"
 	lapi "github.com/LINBIT/golinstor/client"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/time/rate"
@@ -48,6 +49,7 @@ func main() {
 		rps                   = flag.Float64("linstor-api-requests-per-second", 0, "Maximum allowed number of LINSTOR API requests per second. Default: Unlimited")
 		burst                 = flag.Int("linstor-api-burst", 1, "Maximum number of API requests allowed before being limited by requests-per-second. Default: 1 (no bursting)")
 		bearerTokenFile       = flag.String("bearer-token", "", "Read the bearer token from the given file and use it for authentication.")
+		propNs                = flag.String("property-namespace", linstor.NamespcAuxiliary, "Limit the reported topology keys to properties from the given namespace.")
 	)
 
 	flag.Var(&volume.DefaultRemoteAccessPolicy, "default-remote-access-policy", "")
@@ -132,6 +134,7 @@ func main() {
 		client.LogFmt(logFmt),
 		client.LogLevel(*logLevel),
 		client.LogOut(logOut),
+		client.PropertyNamespace(*propNs),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/linstor-csi/linstor-csi.go
+++ b/cmd/linstor-csi/linstor-csi.go
@@ -50,6 +50,7 @@ func main() {
 		burst                 = flag.Int("linstor-api-burst", 1, "Maximum number of API requests allowed before being limited by requests-per-second. Default: 1 (no bursting)")
 		bearerTokenFile       = flag.String("bearer-token", "", "Read the bearer token from the given file and use it for authentication.")
 		propNs                = flag.String("property-namespace", linstor.NamespcAuxiliary, "Limit the reported topology keys to properties from the given namespace.")
+		labelBySP             = flag.Bool("label-by-storage-pool", true, "Set to false to disable labeling of nodes based on their configured storage pools.")
 	)
 
 	flag.Var(&volume.DefaultRemoteAccessPolicy, "default-remote-access-policy", "")
@@ -135,6 +136,7 @@ func main() {
 		client.LogLevel(*logLevel),
 		client.LogOut(logOut),
 		client.PropertyNamespace(*propNs),
+		client.LabelBySP(*labelBySP),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/pkg/client/linstor_test.go
+++ b/pkg/client/linstor_test.go
@@ -326,7 +326,7 @@ func TestLinstor_CapacityBytes(t *testing.T) {
 	m.On("GetAll", mock.Anything, &lapi.ListOpts{Prop: []string{"Aux/topology.kubernetes.io/zone=zone-1"}}).Return([]lapi.Node{{Name: "node-1"}}, nil)
 	m.On("GetAll", mock.Anything, mock.Anything).Return([]lapi.Node{{Name: "node-1"}, {Name: "node-2"}}, nil)
 
-	cl := Linstor{client: &lc.HighLevelClient{Client: &lapi.Client{Nodes: &m}}, log: logrus.WithField("test", t.Name())}
+	cl := Linstor{client: &lc.HighLevelClient{Client: &lapi.Client{Nodes: &m}, PropertyNamespace: lapiconsts.NamespcAuxiliary}, log: logrus.WithField("test", t.Name())}
 
 	testcases := []struct {
 		name             string
@@ -410,7 +410,7 @@ func TestLinstor_SortByPreferred(t *testing.T) {
 	m := &mocks.NodeProvider{}
 	m.On("GetAll", mock.Anything, &lapi.ListOpts{Prop: []string{"Aux/zone=1"}}).Return([]lapi.Node{{Name: "node-b"}, {Name: "node-c"}}, nil)
 
-	cl := Linstor{client: &lc.HighLevelClient{Client: &lapi.Client{Nodes: m}}, log: logrus.WithField("test", t.Name())}
+	cl := Linstor{client: &lc.HighLevelClient{Client: &lapi.Client{Nodes: m}, PropertyNamespace: lapiconsts.NamespcAuxiliary}, log: logrus.WithField("test", t.Name())}
 
 	testcases := []struct {
 		name              string

--- a/pkg/linstor/highlevelclient/high_level_client.go
+++ b/pkg/linstor/highlevelclient/high_level_client.go
@@ -50,7 +50,7 @@ func NewHighLevelClient(options ...lapi.Option) (*HighLevelClient, error) {
 
 // GenericAccessibleTopologies returns topologies based on linstor storage pools
 // and whether a resource is allowed to be accessed over the network.
-func (c *HighLevelClient) GenericAccessibleTopologies(ctx context.Context, volId string, remoteAcecssPolicy volume.RemoteAccessPolicy) ([]*csi.Topology, error) {
+func (c *HighLevelClient) GenericAccessibleTopologies(ctx context.Context, volId string, remoteAccessPolicy volume.RemoteAccessPolicy) ([]*csi.Topology, error) {
 	// Get all nodes where the resource is physically located.
 	r, err := c.Resources.GetAll(ctx, volId)
 	if err != nil {
@@ -76,7 +76,7 @@ func (c *HighLevelClient) GenericAccessibleTopologies(ctx context.Context, volId
 			}
 		}
 
-		for _, m := range remoteAcecssPolicy.AccessibleSegments(segs) {
+		for _, m := range remoteAccessPolicy.AccessibleSegments(segs) {
 			if len(m) == 0 {
 				// Empty segment -> access allowed from everywhere.
 				// This is special cased, otherwise CSI chokes on an empty segment map.


### PR DESCRIPTION
Adds options to:
* Change the default mapping of linstor node properties to k8s node labels
* Disable the node labels generated for storage pools.

This is done to create a more consistent user experience in a new operator release:
* The default mapping of all auxiliary properties caused some implementation details to leak (for example: all nodes suddenly had a `registered-by: piraeus-operator` label
* The storage pools were mostly unused, but required some extra code to keep in sync, such as restarting the CSI pod on any addition/removal.