### PR TITLE
remove quorum workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - When using another property namespace (other than `Aux/`), also use it to prefix `replicasOnSame`
   and `replicasOnDifferent`. Values already prefixed with `Aux/` will be left unchanged.
+- Starting with 0.13.1, the CSI driver tried to work around an issue in quorum calculation
+  by forcing the creation of a diskful instead of the normal diskless resource. Since DRBD 9.1.12/9.2.0,
+  this is no longer necessary, as quorum is now inherited from the diskful counterparts.
 
 ## [1.0.1] - 2023-04-24
 

--- a/pkg/client/linstor_test.go
+++ b/pkg/client/linstor_test.go
@@ -179,7 +179,7 @@ func TestLinstor_Attach(t *testing.T) {
 		}
 		cl := Linstor{client: &lc.HighLevelClient{Client: &lapi.Client{Resources: &m}}, log: logrus.WithField("test", t.Name())}
 
-		err := cl.Attach(context.Background(), ExampleResourceID, "node-2", false, false, true)
+		err := cl.Attach(context.Background(), ExampleResourceID, "node-2", false, false)
 		assert.NoError(t, err)
 		m.AssertExpectations(t)
 	})
@@ -196,7 +196,7 @@ func TestLinstor_Attach(t *testing.T) {
 		}
 		cl := Linstor{client: &lc.HighLevelClient{Client: &lapi.Client{Resources: &m}}, log: logrus.WithField("test", t.Name())}
 
-		err := cl.Attach(context.Background(), ExampleResourceID, "node-3", false, false, true)
+		err := cl.Attach(context.Background(), ExampleResourceID, "node-3", false, false)
 		assert.NoError(t, err)
 		m.AssertExpectations(t)
 	})
@@ -214,59 +214,7 @@ func TestLinstor_Attach(t *testing.T) {
 		}
 		cl := Linstor{client: &lc.HighLevelClient{Client: &lapi.Client{Resources: &m}}, log: logrus.WithField("test", t.Name())}
 
-		err := cl.Attach(context.Background(), ExampleResourceID, "node-3", false, false, true)
-		assert.NoError(t, err)
-		m.AssertExpectations(t)
-	})
-
-	t.Run("no resource with reduced diskfull resources", func(t *testing.T) {
-		m := mocks.ResourceProvider{}
-		rv, rvErr := fromJson(ResourceViewOneOfflineNoQuorum)
-
-		m.ExpectedCalls = []*mock.Call{
-			{Method: "GetResourceView", Arguments: mock.Arguments{mock.Anything, mock.Anything}, ReturnArguments: mock.Arguments{rv, rvErr}},
-			{Method: "Get", Arguments: mock.Arguments{mock.Anything, ExampleResourceID, "node-3"}, ReturnArguments: mock.Arguments{lapi.Resource{}, nil}},
-			{Method: "MakeAvailable", Arguments: mock.Arguments{mock.Anything, ExampleResourceID, "node-3", lapi.ResourceMakeAvailable{Diskful: true}}, ReturnArguments: mock.Arguments{nil}},
-			{Method: "ModifyVolume", Arguments: mock.Arguments{mock.Anything, ExampleResourceID, "node-3", 0, ResourceModifyReadWriteWithTemporaryAttach}, ReturnArguments: mock.Arguments{nil}},
-		}
-		cl := Linstor{client: &lc.HighLevelClient{Client: &lapi.Client{Resources: &m}}, log: logrus.WithField("test", t.Name())}
-
-		err := cl.Attach(context.Background(), ExampleResourceID, "node-3", false, false, true)
-		assert.NoError(t, err)
-		m.AssertExpectations(t)
-	})
-
-	t.Run("no resource with reduced diskfull resources - make-available conflict", func(t *testing.T) {
-		m := mocks.ResourceProvider{}
-		rv, rvErr := fromJson(ResourceViewOneOfflineNoQuorum)
-
-		m.ExpectedCalls = []*mock.Call{
-			{Method: "GetResourceView", Arguments: mock.Arguments{mock.Anything, mock.Anything}, ReturnArguments: mock.Arguments{rv, rvErr}},
-			{Method: "Get", Arguments: mock.Arguments{mock.Anything, ExampleResourceID, "node-3"}, ReturnArguments: mock.Arguments{lapi.Resource{}, nil}},
-			{Method: "MakeAvailable", Arguments: mock.Arguments{mock.Anything, ExampleResourceID, "node-3", lapi.ResourceMakeAvailable{Diskful: true}}, ReturnArguments: mock.Arguments{lapi.NotFoundError}},
-			{Method: "Create", Arguments: mock.Arguments{mock.Anything, lapi.ResourceCreate{Resource: lapi.Resource{Name: ExampleResourceID, NodeName: "node-3"}}}, ReturnArguments: mock.Arguments{nil}},
-			{Method: "ModifyVolume", Arguments: mock.Arguments{mock.Anything, ExampleResourceID, "node-3", 0, ResourceModifyReadWriteWithTemporaryAttach}, ReturnArguments: mock.Arguments{nil}},
-		}
-		cl := Linstor{client: &lc.HighLevelClient{Client: &lapi.Client{Resources: &m}}, log: logrus.WithField("test", t.Name())}
-
-		err := cl.Attach(context.Background(), ExampleResourceID, "node-3", false, false, true)
-		assert.NoError(t, err)
-		m.AssertExpectations(t)
-	})
-
-	t.Run("no resource with reduced standalone resources", func(t *testing.T) {
-		m := mocks.ResourceProvider{}
-		rv, rvErr := fromJson(ResourceViewOneDrbdForceDisconnectNoQuorum)
-
-		m.ExpectedCalls = []*mock.Call{
-			{Method: "GetResourceView", Arguments: mock.Arguments{mock.Anything, mock.Anything}, ReturnArguments: mock.Arguments{rv, rvErr}},
-			{Method: "Get", Arguments: mock.Arguments{mock.Anything, ExampleResourceID, "node-3"}, ReturnArguments: mock.Arguments{lapi.Resource{}, nil}},
-			{Method: "MakeAvailable", Arguments: mock.Arguments{mock.Anything, ExampleResourceID, "node-3", lapi.ResourceMakeAvailable{Diskful: true}}, ReturnArguments: mock.Arguments{nil}},
-			{Method: "ModifyVolume", Arguments: mock.Arguments{mock.Anything, ExampleResourceID, "node-3", 0, ResourceModifyReadWriteWithTemporaryAttach}, ReturnArguments: mock.Arguments{nil}},
-		}
-		cl := Linstor{client: &lc.HighLevelClient{Client: &lapi.Client{Resources: &m}}, log: logrus.WithField("test", t.Name())}
-
-		err := cl.Attach(context.Background(), ExampleResourceID, "node-3", false, false, true)
+		err := cl.Attach(context.Background(), ExampleResourceID, "node-3", false, false)
 		assert.NoError(t, err)
 		m.AssertExpectations(t)
 	})
@@ -283,7 +231,7 @@ func TestLinstor_Attach(t *testing.T) {
 		}
 		cl := Linstor{client: &lc.HighLevelClient{Client: &lapi.Client{Resources: &m}}, log: logrus.WithField("test", t.Name())}
 
-		err := cl.Attach(context.Background(), ExampleResourceID, "node-2", true, false, true)
+		err := cl.Attach(context.Background(), ExampleResourceID, "node-2", true, false)
 		assert.NoError(t, err)
 		m.AssertExpectations(t)
 	})

--- a/pkg/client/mock.go
+++ b/pkg/client/mock.go
@@ -194,7 +194,7 @@ func (s *MockStorage) VolFromVol(ctx context.Context, sourceVol, vol *volume.Inf
 	return nil
 }
 
-func (s *MockStorage) Attach(ctx context.Context, volId, node string, readOnly, rwxBlock, useQuorum bool) error {
+func (s *MockStorage) Attach(ctx context.Context, volId, node string, readOnly, rwxBlock bool) error {
 	s.assignedVolumes[volId] = append(s.assignedVolumes[volId], volume.Assignment{Node: node, Path: "/dev/" + volId, ReadOnly: &readOnly})
 	return nil
 }

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -666,7 +666,7 @@ func (d Driver) ControllerPublishVolume(ctx context.Context, req *csi.Controller
 	// ReadWriteMany block volume
 	rwxBlock := req.VolumeCapability.AccessMode.GetMode() == csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER && req.VolumeCapability.GetBlock() != nil
 
-	err = d.Assignments.Attach(ctx, req.GetVolumeId(), req.GetNodeId(), req.GetReadonly(), rwxBlock, existingVolume.UseQuorum)
+	err = d.Assignments.Attach(ctx, req.GetVolumeId(), req.GetNodeId(), req.GetReadonly(), rwxBlock)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal,
 			"ControllerPublishVolume failed for %s: %v", req.GetVolumeId(), err)

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -83,7 +83,7 @@ type SnapshotCreateDeleter interface {
 // AttacherDettacher handles operations relating to volume accessiblity on nodes.
 type AttacherDettacher interface {
 	Querier
-	Attach(ctx context.Context, volId, node string, readOnly, rwxBlock, useQuorum bool) error
+	Attach(ctx context.Context, volId, node string, readOnly, rwxBlock bool) error
 	Detach(ctx context.Context, volId, node string) error
 	NodeAvailable(ctx context.Context, node string) error
 	FindAssignmentOnNode(ctx context.Context, volId, node string) (*Assignment, error)


### PR DESCRIPTION
The CSI driver had a special case for attaching volumes to a degraded cluster. This is no longer necessary, as DRBD now (9.1.12/9.2.0) calculates quorum differently, meaning adding diskless to a degraded cluster still works.