### PR TITLE
Support live-migration with allow-two-primaries

### DIFF
--- a/pkg/client/linstor_test.go
+++ b/pkg/client/linstor_test.go
@@ -179,7 +179,7 @@ func TestLinstor_Attach(t *testing.T) {
 		}
 		cl := Linstor{client: &lc.HighLevelClient{Client: &lapi.Client{Resources: &m}}, log: logrus.WithField("test", t.Name())}
 
-		err := cl.Attach(context.Background(), ExampleResourceID, "node-2", false, true)
+		err := cl.Attach(context.Background(), ExampleResourceID, "node-2", false, false, true)
 		assert.NoError(t, err)
 		m.AssertExpectations(t)
 	})
@@ -196,7 +196,7 @@ func TestLinstor_Attach(t *testing.T) {
 		}
 		cl := Linstor{client: &lc.HighLevelClient{Client: &lapi.Client{Resources: &m}}, log: logrus.WithField("test", t.Name())}
 
-		err := cl.Attach(context.Background(), ExampleResourceID, "node-3", false, true)
+		err := cl.Attach(context.Background(), ExampleResourceID, "node-3", false, false, true)
 		assert.NoError(t, err)
 		m.AssertExpectations(t)
 	})
@@ -214,7 +214,7 @@ func TestLinstor_Attach(t *testing.T) {
 		}
 		cl := Linstor{client: &lc.HighLevelClient{Client: &lapi.Client{Resources: &m}}, log: logrus.WithField("test", t.Name())}
 
-		err := cl.Attach(context.Background(), ExampleResourceID, "node-3", false, true)
+		err := cl.Attach(context.Background(), ExampleResourceID, "node-3", false, false, true)
 		assert.NoError(t, err)
 		m.AssertExpectations(t)
 	})
@@ -231,7 +231,7 @@ func TestLinstor_Attach(t *testing.T) {
 		}
 		cl := Linstor{client: &lc.HighLevelClient{Client: &lapi.Client{Resources: &m}}, log: logrus.WithField("test", t.Name())}
 
-		err := cl.Attach(context.Background(), ExampleResourceID, "node-3", false, true)
+		err := cl.Attach(context.Background(), ExampleResourceID, "node-3", false, false, true)
 		assert.NoError(t, err)
 		m.AssertExpectations(t)
 	})
@@ -249,7 +249,7 @@ func TestLinstor_Attach(t *testing.T) {
 		}
 		cl := Linstor{client: &lc.HighLevelClient{Client: &lapi.Client{Resources: &m}}, log: logrus.WithField("test", t.Name())}
 
-		err := cl.Attach(context.Background(), ExampleResourceID, "node-3", false, true)
+		err := cl.Attach(context.Background(), ExampleResourceID, "node-3", false, false, true)
 		assert.NoError(t, err)
 		m.AssertExpectations(t)
 	})
@@ -266,7 +266,7 @@ func TestLinstor_Attach(t *testing.T) {
 		}
 		cl := Linstor{client: &lc.HighLevelClient{Client: &lapi.Client{Resources: &m}}, log: logrus.WithField("test", t.Name())}
 
-		err := cl.Attach(context.Background(), ExampleResourceID, "node-3", false, true)
+		err := cl.Attach(context.Background(), ExampleResourceID, "node-3", false, false, true)
 		assert.NoError(t, err)
 		m.AssertExpectations(t)
 	})
@@ -283,7 +283,7 @@ func TestLinstor_Attach(t *testing.T) {
 		}
 		cl := Linstor{client: &lc.HighLevelClient{Client: &lapi.Client{Resources: &m}}, log: logrus.WithField("test", t.Name())}
 
-		err := cl.Attach(context.Background(), ExampleResourceID, "node-2", true, true)
+		err := cl.Attach(context.Background(), ExampleResourceID, "node-2", true, false, true)
 		assert.NoError(t, err)
 		m.AssertExpectations(t)
 	})

--- a/pkg/client/mock.go
+++ b/pkg/client/mock.go
@@ -194,7 +194,7 @@ func (s *MockStorage) VolFromVol(ctx context.Context, sourceVol, vol *volume.Inf
 	return nil
 }
 
-func (s *MockStorage) Attach(ctx context.Context, volId, node string, readOnly, useQuorum bool) error {
+func (s *MockStorage) Attach(ctx context.Context, volId, node string, readOnly, rwxBlock, useQuorum bool) error {
 	s.assignedVolumes[volId] = append(s.assignedVolumes[volId], volume.Assignment{Node: node, Path: "/dev/" + volId, ReadOnly: &readOnly})
 	return nil
 }

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -650,7 +650,10 @@ func (d Driver) ControllerPublishVolume(ctx context.Context, req *csi.Controller
 			"ControllerPublishVolume failed for %s on node %s: %v", req.GetVolumeId(), req.GetNodeId(), err)
 	}
 
-	err = d.Assignments.Attach(ctx, req.GetVolumeId(), req.GetNodeId(), req.GetReadonly(), existingVolume.UseQuorum)
+	// ReadWriteMany block volume
+	rwxBlock := req.VolumeCapability.AccessMode.GetMode() == csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER && req.VolumeCapability.GetBlock() != nil
+
+	err = d.Assignments.Attach(ctx, req.GetVolumeId(), req.GetNodeId(), req.GetReadonly(), rwxBlock, existingVolume.UseQuorum)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal,
 			"ControllerPublishVolume failed for %s: %v", req.GetVolumeId(), err)

--- a/pkg/linstor/const.go
+++ b/pkg/linstor/const.go
@@ -38,6 +38,9 @@ const (
 	// resource) exists.
 	PropertyCreatedFor = lc.NamespcAuxiliary + "/csi-created-for"
 
+	// PropertyAllowTwoPrimaries is DRBD option to allow second primary. Mainly used for live-migration.
+	PropertyAllowTwoPrimaries = lc.NamespcDrbdNetOptions + "/allow-two-primaries"
+
 	// CreatedForTemporaryDisklessAttach marks a resource as temporary, i.e. it should be removed after it is no longer
 	// needed.
 	CreatedForTemporaryDisklessAttach = "temporary-diskless-attach"

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -83,7 +83,7 @@ type SnapshotCreateDeleter interface {
 // AttacherDettacher handles operations relating to volume accessiblity on nodes.
 type AttacherDettacher interface {
 	Querier
-	Attach(ctx context.Context, volId, node string, readOnly, useQuorum bool) error
+	Attach(ctx context.Context, volId, node string, readOnly, rwxBlock, useQuorum bool) error
 	Detach(ctx context.Context, volId, node string) error
 	NodeAvailable(ctx context.Context, node string) error
 	FindAssignmentOnNode(ctx context.Context, volId, node string) (*Assignment, error)


### PR DESCRIPTION
This PR allows to live-migrate KubeVirt virtual machines by setting `allow-two-primaries` flag dynamically.

fixes https://github.com/piraeusdatastore/linstor-csi/issues/159

## Changes in this PR:

* **controllerPublishVolume:**
    * if volume has `type: Block` and `accessMode: ReadWriteMany`;
    * if it is already `InUse` at one other node;
    
   enables `allow-two-primaries` flag

* **controllerUnpublishVolume:**
  * if volume `InUse` at one one less amount of nodes

  removes `allow-two-primaries` flag

