### PR TITLE
backups: filter all backups based on ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- LINSTOR may return more backups than requested when searching for a specific snapshot ID. The results are now
+  filtered, ensuring we really restore from the expected backup.
+
 ## [0.21.0] - 2022-10-21
 
 ### Added

--- a/pkg/client/linstor.go
+++ b/pkg/client/linstor.go
@@ -1445,6 +1445,11 @@ func (s *Linstor) snapOrBackupById(ctx context.Context, id string) (*lapi.Snapsh
 		bMap := info.Linstor
 
 		for k := range bMap {
+			if bMap[k].OriginSnap != id {
+				log.WithField("backup", bMap[k].Id).Trace("skipping backup with wrong snapshot ID")
+				continue
+			}
+
 			if len(bMap[k].Vlms) != 1 {
 				log.WithField("backup", bMap[k].Id).Trace("skipping backup with wrong number of volumes")
 				continue


### PR DESCRIPTION
LINSTOR API should filter for the snapshot name already, but does not always seem to do so in all cases. Since we iterate and filter some results already, we can also check that the original snapshot name matches the expected ID.