### PR TITLE
Add _netdev option to all mounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add `_netdev` mount option to all mounts. This ensures unmounting on system shutdown happens before the
+  network is unconfigured, which might cause DRBD to lose quorum.
+
 ## [0.22.1] - 2022-12-27
 
 ### Changed

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -316,6 +316,8 @@ func (d Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolum
 		}
 	}
 
+	volCtx.MountOptions = append(volCtx.MountOptions, "_netdev")
+
 	var fsType string
 
 	if block := req.GetVolumeCapability().GetBlock(); block != nil {


### PR DESCRIPTION
This ensures unmounting happens before the network stack is torn down during node shutdown, preventing situations where DRBD would lose quorum before systemd had the chance to unmount all CSI controlled mounts.