### PR TITLE
ignore unschedulable nodes in capacity requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Ignore storage capacity from "unschedulable" nodes. Those are nodes that are either evicted/evacuated or have the
+  `AutoplaceTarget` property set to `false`.
+
 ## [1.0.0] - 2023-02-28
 
 ### Changed


### PR DESCRIPTION
When scheduling Pods, the default kubernetes scheduler takes into account the reported storage capacity of nodes. Up to now, we also reported the capacity of evicted/evacuated or "AutoplaceTarget=false" nodes. This meant that Kubernetes tried to schedule Pods on nodes where storage could never be attached.

The (partial) fix is to ignore nodes during storage capacity accounting. This means users with stricter topology requirements get a reported capacity of 0 for those nodes.

It is not a complete fix, as from the CSI side we don't have a way mark the node as completely unscheduable.