### PR TITLE
Use property namespace to prefix replica-on-* conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- When using another property namespace (other than `Aux/`), also use it to prefix `replicasOnSame`
+  and `replicasOnDifferent`. Values already prefixed with `Aux/` will be left unchanged.
+
 ## [1.0.1] - 2023-04-24
 
 ### Added

--- a/cmd/linstor-csi/linstor-csi.go
+++ b/cmd/linstor-csi/linstor-csi.go
@@ -138,6 +138,7 @@ func main() {
 		driver.VolumeStatter(linstorClient),
 		driver.Expander(linstorClient),
 		driver.NodeInformer(linstorClient),
+		driver.TopologyPrefix(*propNs),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/pkg/client/linstor.go
+++ b/pkg/client/linstor.go
@@ -438,7 +438,7 @@ func (s *Linstor) GetLegacyVolumeParameters(ctx context.Context, volId string) (
 		return nil, err
 	}
 
-	params, err := volume.NewParameters(decoded.Parameters)
+	params, err := volume.NewParameters(decoded.Parameters, s.client.PropertyNamespace)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/topology/scheduler/autoplacetopology/autoplacetopology.go
+++ b/pkg/topology/scheduler/autoplacetopology/autoplacetopology.go
@@ -25,7 +25,8 @@ import (
 // * If a `Requisite` topology is requested, all placement will be restricted onto those nodes.
 // * If a `Preferred` topology is requested, this scheduler will try to place at least one volume on those nodes.
 // This scheduler complies with the CSI spec for topology:
-//   https://github.com/container-storage-interface/spec/blob/v1.4.0/csi.proto#L523
+//
+//	https://github.com/container-storage-interface/spec/blob/v1.4.0/csi.proto#L523
 type Scheduler struct {
 	*lc.HighLevelClient
 	log *logrus.Entry
@@ -46,13 +47,13 @@ var _ scheduler.Interface = &Scheduler{}
 // constraint could mean we are not able to place the volume on the first preferred node.
 //
 // To fulfil all these requirements, this scheduler executes the following steps:
-// 1. It collects the list of requisite nodes. Note that only one replica on any requisite nodes is enough to fulfil
-//    the CSI spec.
-//   1a. Bail out early if we already have the required replica count _and_ any requisite node has a replica.
-// 2. Iterate over the preferred segments until we successfully placed a replica
-//   2a. Bail out early if we now have the required replica count _and_ any requisite node has a replica.
-// 3. Try to place remaining replicas on requisite nodes.
-// 4. Try to place remaining replicas on any nodes.
+//  1. It collects the list of requisite nodes. Note that only one replica on any requisite nodes is enough to fulfil
+//     the CSI spec.
+//     1a. Bail out early if we already have the required replica count _and_ any requisite node has a replica.
+//  2. Iterate over the preferred segments until we successfully placed a replica
+//     2a. Bail out early if we now have the required replica count _and_ any requisite node has a replica.
+//  3. Try to place remaining replicas on requisite nodes.
+//  4. Try to place remaining replicas on any nodes.
 func (s *Scheduler) Create(ctx context.Context, volId string, params *volume.Parameters, topologies *csi.TopologyRequirement) error {
 	log := s.log.WithField("volume", volId)
 

--- a/pkg/volume/parameter.go
+++ b/pkg/volume/parameter.go
@@ -100,7 +100,7 @@ var DefaultRemoteAccessPolicy = RemoteAccessPolicyAnywhere
 
 // NewParameters parses out the raw parameters we get and sets appropriate
 // zero values
-func NewParameters(params map[string]string) (Parameters, error) {
+func NewParameters(params map[string]string, topologyPrefix string) (Parameters, error) {
 	// set zero values
 	p := Parameters{
 		LayerList:               []devicelayerkind.DeviceLayerKind{devicelayerkind.Drbd, devicelayerkind.Storage},
@@ -159,9 +159,9 @@ func NewParameters(params map[string]string) (Parameters, error) {
 
 			p.LayerList = l
 		case replicasonsame:
-			p.ReplicasOnSame = maybeAddAux(strings.Split(v, " ")...)
+			p.ReplicasOnSame = maybeAddTopologyPrefix(topologyPrefix, strings.Split(v, " ")...)
 		case replicasondifferent:
-			p.ReplicasOnDifferent = maybeAddAux(strings.Split(v, " ")...)
+			p.ReplicasOnDifferent = maybeAddTopologyPrefix(topologyPrefix, strings.Split(v, " ")...)
 		case storagepool:
 			p.StoragePool = v
 		case disklessstoragepool:

--- a/pkg/volume/remoteaccess.go
+++ b/pkg/volume/remoteaccess.go
@@ -104,11 +104,12 @@ func subsetOf(a, b map[string]string) bool {
 // a more general pattern.
 //
 // Some examples
-//   [{a:1}, {a:1}] => [{a:1}]
-//   [{a:1}, {a:2}] => [{a:1}, {a:2}]
-//   [{a:1, b:1}, {a:1}] => [{a:1}]
-//   [{a:1, b:1}, {a:1, b:2}] => [{a:1, b:1}, {a:1, b:2}]
-//   [{a:1}, {a:1, b:1}, {a:1, b:2}] => [{a:1}]
+//
+//	[{a:1}, {a:1}] => [{a:1}]
+//	[{a:1}, {a:2}] => [{a:1}, {a:2}]
+//	[{a:1, b:1}, {a:1}] => [{a:1}]
+//	[{a:1, b:1}, {a:1, b:2}] => [{a:1, b:1}, {a:1, b:2}]
+//	[{a:1}, {a:1, b:1}, {a:1, b:2}] => [{a:1}]
 func PrunePattern(sources ...map[string]string) []map[string]string {
 	var result []map[string]string
 

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -136,7 +136,9 @@ type Expander interface {
 	ControllerExpand(ctx context.Context, vol *Info) error
 }
 
-func maybeAddAux(props ...string) []string {
+// Add the given prefix to the property name.
+// If the property is already prefixed (with "Aux/"), no modification is made.
+func maybeAddTopologyPrefix(prefix string, props ...string) []string {
 	const auxPrefix = lc.NamespcAuxiliary + "/"
 
 	result := make([]string, len(props))
@@ -144,7 +146,7 @@ func maybeAddAux(props ...string) []string {
 		if strings.HasPrefix(prop, auxPrefix) {
 			result[i] = prop
 		} else {
-			result[i] = auxPrefix + prop
+			result[i] = prefix + "/" + prop
 		}
 	}
 

--- a/pkg/volume/volume_test.go
+++ b/pkg/volume/volume_test.go
@@ -13,19 +13,19 @@ import (
 )
 
 func TestNewParameters(t *testing.T) {
-	empty, err := volume.NewParameters(nil)
+	empty, err := volume.NewParameters(nil, lc.NamespcAuxiliary)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, empty.ResourceGroup)
 
 	fixed, err := volume.NewParameters(map[string]string{
 		"resourcegroup": "rg1",
-	})
+	}, lc.NamespcAuxiliary)
 	assert.NoError(t, err)
 	assert.Equal(t, "rg1", fixed.ResourceGroup)
 
 	fixedWithNamespace, err := volume.NewParameters(map[string]string{
 		linstor.ParameterNamespace + "/resourcegroup": "rg1",
-	})
+	}, lc.NamespcAuxiliary)
 	assert.NoError(t, err)
 	assert.Equal(t, "rg1", fixedWithNamespace.ResourceGroup)
 
@@ -33,14 +33,14 @@ func TestNewParameters(t *testing.T) {
 		"DrbdOptions/auto-quorum":  "suspend-io",
 		"DrbdOptions/Net/protocol": "C",
 	}
-	legacy, err := volume.NewParameters(expected)
+	legacy, err := volume.NewParameters(expected, lc.NamespcAuxiliary)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, legacy.Properties)
 
 	generalProps, err := volume.NewParameters(map[string]string{
 		linstor.PropertyNamespace + "/DrbdOptions/auto-quorum":  "suspend-io",
 		linstor.PropertyNamespace + "/DrbdOptions/Net/protocol": "C",
-	})
+	}, lc.NamespcAuxiliary)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, generalProps.Properties)
 }


### PR DESCRIPTION
Since 0.21.0, users where able to change the default "namespace" where the CSI driver would expect topology information to be available on the node.

Until now, we did not change the prefix functionallity for settings replicas-on-same/different in the parameters: they were always prefixed with Aux/.

This became a problem with Operator v2, which configures Aux/topology as the default namespace for these kinds of labels. To fix, we change the prefix function to include the support the property namespace.

All "absolute" property names (i.e. those already prefixed with Aux/) are left untouched, so people can still refer to properties outside the namespace if they wish to do so.