### PR TITLE
implement deletion for backups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Delete S3 backups in delete snapshot requests.
+
 ## [1.1.1] - 2023-06-05
 
 ### Changed

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -44,6 +44,11 @@ type Assignment struct {
 	Path string
 }
 
+type Snapshot struct {
+	csi.Snapshot
+	Remote string
+}
+
 // CreateDeleter handles the creation and deletion of volumes.
 type CreateDeleter interface {
 	Querier
@@ -63,19 +68,19 @@ type CreateDeleter interface {
 type SnapshotCreateDeleter interface {
 	// CompatibleSnapshotId returns an ID unique to the suggested name
 	CompatibleSnapshotId(name string) string
-	SnapCreate(ctx context.Context, id string, sourceVolId string, params *SnapshotParameters) (*csi.Snapshot, error)
-	SnapDelete(ctx context.Context, snap *csi.Snapshot) error
+	SnapCreate(ctx context.Context, id string, sourceVolId string, params *SnapshotParameters) (*Snapshot, error)
+	SnapDelete(ctx context.Context, snap *Snapshot) error
 	// FindSnapByID searches the snapshot in the backend
 	// It returns:
 	// * the snapshot, nil if not found
 	// * true, if the snapshot is either in progress or successful
 	// * any error encountered
-	FindSnapByID(ctx context.Context, id string) (*csi.Snapshot, bool, error)
-	FindSnapsBySource(ctx context.Context, sourceVol *Info, start, limit int) ([]*csi.Snapshot, error)
+	FindSnapByID(ctx context.Context, id string) (*Snapshot, bool, error)
+	FindSnapsBySource(ctx context.Context, sourceVol *Info, start, limit int) ([]*Snapshot, error)
 	// List Snapshots should return a sorted list of snapshots.
-	ListSnaps(ctx context.Context, start, limit int) ([]*csi.Snapshot, error)
+	ListSnaps(ctx context.Context, start, limit int) ([]*Snapshot, error)
 	// VolFromSnap creates a new volume based on the provided snapshot.
-	VolFromSnap(ctx context.Context, snap *csi.Snapshot, vol *Info, params *Parameters, topologies *csi.TopologyRequirement) error
+	VolFromSnap(ctx context.Context, snap *Snapshot, vol *Info, params *Parameters, topologies *csi.TopologyRequirement) error
 }
 
 // AttacherDettacher handles operations relating to volume accessiblity on nodes.

--- a/test/compat_test.go
+++ b/test/compat_test.go
@@ -18,26 +18,30 @@ import (
 )
 
 var (
-	snapshotA = &csi.Snapshot{
-		SnapshotId:     "snapshot-a1b89a9c-f59d-40f1-843a-e4240e98d956",
-		SourceVolumeId: "pvc-5113e62a-2874-421c-979a-ef08e1543581",
-		CreationTime: &timestamppb.Timestamp{
-			Seconds: 1607588002,
-			Nanos:   126000000,
+	snapshotA = &volume.Snapshot{
+		Snapshot: csi.Snapshot{
+			SnapshotId:     "snapshot-a1b89a9c-f59d-40f1-843a-e4240e98d956",
+			SourceVolumeId: "pvc-5113e62a-2874-421c-979a-ef08e1543581",
+			CreationTime: &timestamppb.Timestamp{
+				Seconds: 1607588002,
+				Nanos:   126000000,
+			},
+			SizeBytes:  838860800,
+			ReadyToUse: true,
 		},
-		SizeBytes:  838860800,
-		ReadyToUse: true,
 	}
 
-	snapshotB = &csi.Snapshot{
-		SnapshotId:     "snapshot-2255bcf5-6e8a-43ba-8856-a3e330424831",
-		SourceVolumeId: "pvc-9f0cceb1-6ef7-425e-9f29-15c482b3ac65",
-		CreationTime: &timestamppb.Timestamp{
-			Seconds: 1607588001,
-			Nanos:   392000000,
+	snapshotB = &volume.Snapshot{
+		Snapshot: csi.Snapshot{
+			SnapshotId:     "snapshot-2255bcf5-6e8a-43ba-8856-a3e330424831",
+			SourceVolumeId: "pvc-9f0cceb1-6ef7-425e-9f29-15c482b3ac65",
+			CreationTime: &timestamppb.Timestamp{
+				Seconds: 1607588001,
+				Nanos:   392000000,
+			},
+			SizeBytes:  524288000,
+			ReadyToUse: true,
 		},
-		SizeBytes:  524288000,
-		ReadyToUse: true,
 	}
 
 	fakeControllerResponses = []fakeControllerCfg{
@@ -108,7 +112,7 @@ func TestCompatListSnaps(t *testing.T) {
 	snaps, err := compatClient.ListSnaps(ctx, 0, 0)
 	assert.NoError(t, err)
 
-	expectedSnaps := []*csi.Snapshot{snapshotA, snapshotB}
+	expectedSnaps := []*volume.Snapshot{snapshotA, snapshotB}
 	assert.ElementsMatch(t, expectedSnaps, snaps)
 }
 
@@ -141,5 +145,5 @@ func TestCompatFindSnapBySource(t *testing.T) {
 	volB := &volume.Info{ID: snapshotB.SourceVolumeId}
 	actual, err := compatClient.FindSnapsBySource(ctx, volB, 0, 0)
 	assert.NoError(t, err)
-	assert.ElementsMatch(t, []*csi.Snapshot{snapshotB}, actual)
+	assert.ElementsMatch(t, []*volume.Snapshot{snapshotB}, actual)
 }


### PR DESCRIPTION
Implement deletion for S3 snapshots/backups by calling the appropriate API in the DeleteSnapshot() call.

In order to speed up this process, we also enhance the existing Find/ListSnapshot functions to return the originating LINSTOR remote name. This both identifies the item as a backup, and helps with the delete calls.