### PR TITLE
implement deletion of local snapshots for S3 backups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Delete S3 backups in delete snapshot requests.
+- Delete local snapshots when creating S3 backups when new "delete-local" parameter is true.
 
 ## [1.1.1] - 2023-06-05
 

--- a/examples/k8s/volume-snapshot-class.yaml
+++ b/examples/k8s/volume-snapshot-class.yaml
@@ -15,6 +15,8 @@ parameters:
   # See https://linbit.com/drbd-user-guide/linstor-guide-1_0-en/#s-shipping_snapshots-linstor for details
   # on each parameter.
   snap.linstor.csi.linbit.com/remote-name: snapshot-bucket
+  # Delete local copy of the snapshot after uploading completes
+  snap.linstor.csi.linbit.com/delete-local: "true"
   snap.linstor.csi.linbit.com/allow-incremental: "false"
   snap.linstor.csi.linbit.com/s3-bucket: snapshot-bucket
   snap.linstor.csi.linbit.com/s3-endpoint: s3.us-west-1.amazonaws.com

--- a/pkg/volume/snapshot_params.go
+++ b/pkg/volume/snapshot_params.go
@@ -24,6 +24,7 @@ type SnapshotParameters struct {
 	Type             SnapshotType `json:"type,omitempty"`
 	AllowIncremental bool         `json:"allow-incremental"`
 	RemoteName       string       `json:"remote-name,omitempty"`
+	DeleteLocal      bool         `json:"delete-local,omitempty"`
 	S3Endpoint       string       `json:"s3-endpoint,omitempty"`
 	S3Bucket         string       `json:"s3-bucket,omitempty"`
 	S3SigningRegion  string       `json:"s3-signing-region,omitempty"`
@@ -51,6 +52,13 @@ func NewSnapshotParameters(params, secrets map[string]string) (*SnapshotParamete
 			}
 
 			p.Type = t
+		case "/delete-local":
+			b, err := strconv.ParseBool(v)
+			if err != nil {
+				return nil, err
+			}
+
+			p.DeleteLocal = b
 		case "/allow-incremental":
 			b, err := strconv.ParseBool(v)
 			if err != nil {
@@ -80,6 +88,10 @@ func NewSnapshotParameters(params, secrets map[string]string) (*SnapshotParamete
 
 	if p.Type != SnapshotTypeInCluster && p.RemoteName == "" {
 		return nil, fmt.Errorf("snapshots of type `%s` require specifying a %s/remote-name", p.Type, linstor.SnapshotParameterNamespace)
+	}
+
+	if p.Type == SnapshotTypeInCluster && p.DeleteLocal {
+		return nil, fmt.Errorf("cannot use %s/delete-local with in-cluster snapshots", linstor.SnapshotParameterNamespace)
 	}
 
 	p.S3AccessKey = secrets["access-key"]


### PR DESCRIPTION
When creating a remote backup in LINSTOR, we can remove the local snapshot after shipping completes.