### PR TITLE
Prevent shrinking of volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Prevent shrinking of volumes. While this is enforced by the CSI Provisioner already, when
+  restoring from backups (which do not have a reported size) these limits are not enforced.
+
 ## [1.2.1] - 2023-07-12
 
 ### Fixed

--- a/pkg/client/linstor.go
+++ b/pkg/client/linstor.go
@@ -1341,7 +1341,9 @@ func (s *Linstor) reconcileVolumeDefinition(ctx context.Context, info *volume.In
 		return nil, err
 	}
 
-	if vDef.SizeKib != expectedSizeKiB {
+	// We don't support shrinking. This is mostly covered by the provisioner, but with backups there may be
+	// edge cases where the "no shrinking" rule cannot be enforced. So we only allow volume growth here.
+	if vDef.SizeKib < expectedSizeKiB {
 		err := s.client.Client.ResourceDefinitions.ModifyVolumeDefinition(ctx, info.ID, 0, lapi.VolumeDefinitionModify{
 			SizeKib: expectedSizeKiB,
 		})


### PR DESCRIPTION
This is normally enforced by the provisioner, but when restoring from a backup without reported snapshot size, the provisioner cannot enforce this limit.

Instead we simply update the check to ensure the volume definition is never shrunk.