### PR TITLE
support deletion of snapshots after restore from backup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support to delete downloaded backups after restore operation (k8s only).
+
 ## [1.2.3] - 2023-08-31
 
 ### Changed

--- a/cmd/linstor-csi/linstor-csi.go
+++ b/cmd/linstor-csi/linstor-csi.go
@@ -139,6 +139,7 @@ func main() {
 		driver.Expander(linstorClient),
 		driver.NodeInformer(linstorClient),
 		driver.TopologyPrefix(*propNs),
+		driver.ConfigureKubernetesIfAvailable(),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/pkg/client/mock.go
+++ b/pkg/client/mock.go
@@ -190,7 +190,7 @@ func (s *MockStorage) FindSnapsBySource(ctx context.Context, sourceVol *volume.I
 	return results[start:end], nil
 }
 
-func (s *MockStorage) VolFromSnap(ctx context.Context, snap *volume.Snapshot, vol *volume.Info, parameters *volume.Parameters, topologies *csi.TopologyRequirement) error {
+func (s *MockStorage) VolFromSnap(ctx context.Context, snap *volume.Snapshot, vol *volume.Info, parameters *volume.Parameters, snapParams *volume.SnapshotParameters, topologies *csi.TopologyRequirement) error {
 	s.createdVolumes = append(s.createdVolumes, vol)
 	return nil
 }

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -80,7 +80,7 @@ type SnapshotCreateDeleter interface {
 	// List Snapshots should return a sorted list of snapshots.
 	ListSnaps(ctx context.Context, start, limit int) ([]*Snapshot, error)
 	// VolFromSnap creates a new volume based on the provided snapshot.
-	VolFromSnap(ctx context.Context, snap *Snapshot, vol *Info, params *Parameters, topologies *csi.TopologyRequirement) error
+	VolFromSnap(ctx context.Context, snap *Snapshot, vol *Info, params *Parameters, snapParams *SnapshotParameters, topologies *csi.TopologyRequirement) error
 }
 
 // AttacherDettacher handles operations relating to volume accessiblity on nodes.


### PR DESCRIPTION
When a user requests a restore from an off-site backup, they might want the local snapshot to be deleted after the restore.

We already have this option when creating the snapshot by using a special parameter on the snapshot class. However, we do not have that information available directly.

To support this, we need to lookup the snapshot content and snapshot class ourselfes, then parse the parameters. This is all optional, as LINSTOR CSI still needs to work outside kubernetes, or inside Kubernetes with incomplete information.