### PR TITLE
Add over provision factor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support to delete downloaded backups after restore operation (k8s only).
+- New parameter `overProvision`: when set available capacity on a node is calculated by taking into account
+  the reserved capacity in the pool based on existing volumes.
 
 ## [1.2.3] - 2023-08-31
 

--- a/pkg/client/linstor_test.go
+++ b/pkg/client/linstor_test.go
@@ -342,7 +342,7 @@ func TestLinstor_CapacityBytes(t *testing.T) {
 		testcase := &testcases[i]
 
 		t.Run(testcase.name, func(t *testing.T) {
-			cap, err := cl.CapacityBytes(context.Background(), testcase.storagePool, testcase.topology)
+			cap, err := cl.CapacityBytes(context.Background(), testcase.storagePool, nil, testcase.topology)
 			assert.NoError(t, err)
 			assert.Equal(t, testcase.expectedCapacity, cap)
 		})

--- a/pkg/client/mock.go
+++ b/pkg/client/mock.go
@@ -242,7 +242,7 @@ func (s *MockStorage) Status(ctx context.Context, volId string) ([]string, *csi.
 	return nodes, &csi.VolumeCondition{Abnormal: false, Message: "All replicas normal"}, nil
 }
 
-func (s *MockStorage) CapacityBytes(ctx context.Context, sp string, segments map[string]string) (int64, error) {
+func (s *MockStorage) CapacityBytes(ctx context.Context, pool string, overProvision *float64, segments map[string]string) (int64, error) {
 	return 50000000, nil
 }
 

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -829,7 +829,7 @@ func (d Driver) GetCapacity(ctx context.Context, req *csi.GetCapacityRequest) (*
 	for _, segment := range accessibleSegments {
 		d.log.WithField("segment", segment).Debug("Checking capacity of segment")
 
-		bytes, err := d.Storage.CapacityBytes(ctx, params.StoragePool, segment)
+		bytes, err := d.Storage.CapacityBytes(ctx, params.StoragePool, params.OverProvision, segment)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "%v", err)
 		}

--- a/pkg/volume/parameter.go
+++ b/pkg/volume/parameter.go
@@ -40,6 +40,7 @@ const (
 	postmountxfsopts
 	resourcegroup
 	usepvcname
+	overprovision
 )
 
 // Parameters configuration for linstor volumes.
@@ -91,6 +92,10 @@ type Parameters struct {
 	Properties map[string]string
 	// UsePvcName derives the volume name from the PVC name+namespace, if that information is available.
 	UsePvcName bool
+	// OverProvision determines how much free capacity is reported.
+	// If set, free capacity is calculated by (TotalCapacity * OverProvision) - ReservedCapacity.
+	// If not set, the free capacity is taken directly from LINSTOR.
+	OverProvision *float64
 }
 
 const DefaultDisklessStoragePoolName = "DfltDisklessStorPool"
@@ -229,6 +234,14 @@ func NewParameters(params map[string]string, topologyPrefix string) (Parameters,
 			// This parameter was unused. It is just parsed to not break any old storage classes that might be using
 			// it. Storage sizes are handled via CSI requests directly.
 			log.Warnf("using useless parameter '%s'", rawkey)
+
+		case overprovision:
+			f, err := strconv.ParseFloat(v, 64)
+			if err != nil {
+				return p, err
+			}
+
+			p.OverProvision = &f
 		}
 	}
 

--- a/pkg/volume/paramkey_enumer.go
+++ b/pkg/volume/paramkey_enumer.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 )
 
-const _paramKeyName = "allowremotevolumeaccessautoplaceclientlistdisklessonremainingdisklessstoragepooldonotplacewithregexencryptionfsoptslayerlistmountoptsnodelistplacementcountplacementpolicyreplicasondifferentreplicasonsamesizekibstoragepoolpostmountxfsoptsresourcegroupusepvcname"
+const _paramKeyName = "allowremotevolumeaccessautoplaceclientlistdisklessonremainingdisklessstoragepooldonotplacewithregexencryptionfsoptslayerlistmountoptsnodelistplacementcountplacementpolicyreplicasondifferentreplicasonsamesizekibstoragepoolpostmountxfsoptsresourcegroupusepvcnameoverprovision"
 
-var _paramKeyIndex = [...]uint16{0, 23, 32, 42, 61, 80, 99, 109, 115, 124, 133, 141, 155, 170, 189, 203, 210, 221, 237, 250, 260}
+var _paramKeyIndex = [...]uint16{0, 23, 32, 42, 61, 80, 99, 109, 115, 124, 133, 141, 155, 170, 189, 203, 210, 221, 237, 250, 260, 273}
 
 func (i paramKey) String() string {
 	if i < 0 || i >= paramKey(len(_paramKeyIndex)-1) {
@@ -17,7 +17,7 @@ func (i paramKey) String() string {
 	return _paramKeyName[_paramKeyIndex[i]:_paramKeyIndex[i+1]]
 }
 
-var _paramKeyValues = []paramKey{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19}
+var _paramKeyValues = []paramKey{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}
 
 var _paramKeyNameToValueMap = map[string]paramKey{
 	_paramKeyName[0:23]:    0,
@@ -40,6 +40,7 @@ var _paramKeyNameToValueMap = map[string]paramKey{
 	_paramKeyName[221:237]: 17,
 	_paramKeyName[237:250]: 18,
 	_paramKeyName[250:260]: 19,
+	_paramKeyName[260:273]: 20,
 }
 
 // paramKeyString retrieves an enum value from the enum constants string name.

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -103,7 +103,7 @@ type Querier interface {
 	// AllocationSizeKiB returns the number of KiB required to provision required bytes.
 	AllocationSizeKiB(requiredBytes, limitBytes int64) (int64, error)
 	// CapacityBytes returns the amount of free space, in bytes, in the storage pool specified by the params and topology.
-	CapacityBytes(ctx context.Context, pool string, segments map[string]string) (int64, error)
+	CapacityBytes(ctx context.Context, pool string, overProvision *float64, segments map[string]string) (int64, error)
 }
 
 // Mounter handles the filesystems located on volumes.


### PR DESCRIPTION
Adds a new overprovision parameter that calculates the capacity of a given
    storage pool based on the existing reserved space.
    
While we would like to use LINSTOR directly for that, it does not seem to
    be implemented: the "query-size-info" call seems to return inconsistent
    results.
    
The advantage of the new parameter is that people can opt-in to this new
    calculation by setting the parameter.
    
This also adds a cache for the call to `Resources.GetResourceView()`, as the CapacityBytes() is one of the "hottest" code paths, and we don't actually need to monitor the usage that closely.
