### PR TITLE
Fixes around attaching volumes with unusual resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Default access policy for resources without replication layer is now "local only".
+
 ### Fixed
 
 - Do not try to create diskless resource if there is no compatible diskless layer (DRBD or NVMe) available.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Do not try to create diskless resource if there is no compatible diskless layer (DRBD or NVMe) available
+- Do not try to create diskless resource if there is no compatible diskless layer (DRBD or NVMe) available.
+- Do not allow attaching a volume that has no existing replica.
 
 ## [1.3.0] - 2023-11-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Do not try to create diskless resource if there is no compatible diskless layer (DRBD or NVMe) available
+
 ## [1.3.0] - 2023-11-15
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/pborman/uuid v1.2.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.8.4
+	golang.org/x/exp v0.0.0-20240119083558-1b970713d09a
 	golang.org/x/sys v0.16.0
 	golang.org/x/time v0.5.0
 	google.golang.org/grpc v1.60.1

--- a/go.sum
+++ b/go.sum
@@ -122,6 +122,8 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.18.0 h1:PGVlW0xEltQnzFZ55hkuX5+KLyrMYhHld1YHO4AKcdc=
 golang.org/x/crypto v0.18.0/go.mod h1:R0j02AL6hcrfOiy9T4ZYp/rcWeMxM3L6QYxlOuEG1mg=
+golang.org/x/exp v0.0.0-20240119083558-1b970713d09a h1:Q8/wZp0KX97QFTc2ywcOE0YRjZPVIx+MXInMzdvQqcA=
+golang.org/x/exp v0.0.0-20240119083558-1b970713d09a/go.mod h1:idGWGoKP1toJGkd5/ig9ZLuPcZBC3ewk7SzmH0uou08=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=

--- a/pkg/client/linstor.go
+++ b/pkg/client/linstor.go
@@ -517,6 +517,10 @@ func (s *Linstor) Attach(ctx context.Context, volId, node string, rwxBlock bool)
 			// are already covered in the allowed topology bits.
 			s.log.WithError(err).Info("fall back to manual diskless creation after make-available refused")
 
+			if disklessFlag == "" {
+				return fmt.Errorf("resource does not support diskless attachment")
+			}
+
 			rCreate := lapi.ResourceCreate{Resource: lapi.Resource{
 				Name:     volId,
 				NodeName: node,

--- a/pkg/client/linstor.go
+++ b/pkg/client/linstor.go
@@ -469,8 +469,12 @@ func (s *Linstor) Attach(ctx context.Context, volId, node string, rwxBlock bool)
 	}).Info("attaching volume")
 
 	ress, err := s.client.Resources.GetAll(ctx, volId)
-	if nil404(err) != nil {
+	if err != nil {
 		return err
+	}
+
+	if len(ress) == 0 {
+		return fmt.Errorf("failed to attach resource with no deployed replica")
 	}
 
 	var existingRes *lapi.Resource


### PR DESCRIPTION
Fixes some issues in the AttachVolume call and beyond:
* Do not try to attach a resources that does not have a replica
* Do not try to create a diskless resource if the resource does not support it
* Set default access policy to "local only" for resources without replication layer 