### PR TITLE
params: allow setting multiple storage pools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support specifying multiple storage pools in the parameters, separated by spaces.
+
 ## [1.4.0] - 2024-02-01
 
 ### Breaking

--- a/pkg/client/linstor_test.go
+++ b/pkg/client/linstor_test.go
@@ -276,7 +276,7 @@ func TestLinstor_CapacityBytes(t *testing.T) {
 
 	testcases := []struct {
 		name             string
-		storagePool      string
+		storagePools     []string
 		topology         map[string]string
 		expectedCapacity int64
 	}{
@@ -300,13 +300,18 @@ func TestLinstor_CapacityBytes(t *testing.T) {
 		},
 		{
 			name:             "just pool-a from params",
-			storagePool:      "pool-a",
+			storagePools:     []string{"pool-a"},
 			expectedCapacity: (1 + 2) * 1024,
 		},
 		{
 			name:             "just pool-b from params",
-			storagePool:      "pool-b",
+			storagePools:     []string{"pool-b"},
 			expectedCapacity: (3 + 4) * 1024,
+		},
+		{
+			name:             "both pools like all",
+			storagePools:     []string{"pool-a", "pool-b"},
+			expectedCapacity: (1 + 2 + 3 + 4) * 1024,
 		},
 		{
 			name: "just pool-a from topology",
@@ -343,7 +348,7 @@ func TestLinstor_CapacityBytes(t *testing.T) {
 		testcase := &testcases[i]
 
 		t.Run(testcase.name, func(t *testing.T) {
-			cap, err := cl.CapacityBytes(context.Background(), testcase.storagePool, nil, testcase.topology)
+			cap, err := cl.CapacityBytes(context.Background(), testcase.storagePools, nil, testcase.topology)
 			assert.NoError(t, err)
 			assert.Equal(t, testcase.expectedCapacity, cap)
 		})

--- a/pkg/client/mock.go
+++ b/pkg/client/mock.go
@@ -242,7 +242,7 @@ func (s *MockStorage) Status(ctx context.Context, volId string) ([]string, *csi.
 	return nodes, &csi.VolumeCondition{Abnormal: false, Message: "All replicas normal"}, nil
 }
 
-func (s *MockStorage) CapacityBytes(ctx context.Context, pool string, overProvision *float64, segments map[string]string) (int64, error) {
+func (s *MockStorage) CapacityBytes(ctx context.Context, pools []string, overProvision *float64, segments map[string]string) (int64, error) {
 	return 50000000, nil
 }
 

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -829,7 +829,7 @@ func (d Driver) GetCapacity(ctx context.Context, req *csi.GetCapacityRequest) (*
 	for _, segment := range accessibleSegments {
 		d.log.WithField("segment", segment).Debug("Checking capacity of segment")
 
-		bytes, err := d.Storage.CapacityBytes(ctx, params.StoragePool, params.OverProvision, segment)
+		bytes, err := d.Storage.CapacityBytes(ctx, params.StoragePools, params.OverProvision, segment)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "%v", err)
 		}

--- a/pkg/topology/scheduler/balancer/balancer.go
+++ b/pkg/topology/scheduler/balancer/balancer.go
@@ -321,7 +321,7 @@ func (b BalanceScheduler) deploy(ctx context.Context, volId string, params *volu
 }
 
 func (b BalanceScheduler) Create(ctx context.Context, volId string, params *volume.Parameters, topologies *csi.TopologyRequirement) error {
-	if params.StoragePool != "" {
+	if len(params.StoragePools) > 0 {
 		return fmt.Errorf("placementPolicyBalance does not support choosing StoragePool, it should be picked automatically")
 	}
 

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -103,7 +103,7 @@ type Querier interface {
 	// AllocationSizeKiB returns the number of KiB required to provision required bytes.
 	AllocationSizeKiB(requiredBytes, limitBytes int64) (int64, error)
 	// CapacityBytes returns the amount of free space, in bytes, in the storage pool specified by the params and topology.
-	CapacityBytes(ctx context.Context, pool string, overProvision *float64, segments map[string]string) (int64, error)
+	CapacityBytes(ctx context.Context, pools []string, overProvision *float64, segments map[string]string) (int64, error)
 }
 
 // Mounter handles the filesystems located on volumes.

--- a/pkg/volume/volume_test.go
+++ b/pkg/volume/volume_test.go
@@ -116,16 +116,14 @@ func TestParameters_ToResourceGroupModify(t *testing.T) {
 		},
 		{
 			name:     "wrong-select-filters",
-			params:   volume.Parameters{LayerList: []devicelayerkind.DeviceLayerKind{devicelayerkind.Writecache, devicelayerkind.Drbd, devicelayerkind.Storage}, PlacementCount: 3, ResourceGroup: "wrong-select-filters", StoragePool: "pool"},
+			params:   volume.Parameters{LayerList: []devicelayerkind.DeviceLayerKind{devicelayerkind.Writecache, devicelayerkind.Drbd, devicelayerkind.Storage}, PlacementCount: 3, ResourceGroup: "wrong-select-filters", StoragePools: []string{"pool1", "pool2"}},
 			existing: lapi.ResourceGroup{Name: "wrong-select-filters", SelectFilter: lapi.AutoSelectFilter{LayerStack: []string{string(devicelayerkind.Drbd)}, PlaceCount: 2}},
 			expectedModify: lapi.ResourceGroupModify{
-				OverrideProps: map[string]string{
-					lc.KeyStorPoolName: "pool",
-				},
+				OverrideProps: make(map[string]string),
 				SelectFilter: lapi.AutoSelectFilter{
-					LayerStack:  []string{string(devicelayerkind.Writecache), string(devicelayerkind.Drbd), string(devicelayerkind.Storage)},
-					PlaceCount:  3,
-					StoragePool: "pool",
+					LayerStack:      []string{string(devicelayerkind.Writecache), string(devicelayerkind.Drbd), string(devicelayerkind.Storage)},
+					PlaceCount:      3,
+					StoragePoolList: []string{"pool1", "pool2"},
 				},
 			},
 			expectedChanged: true,


### PR DESCRIPTION
LINSTOR Resource Groups can have multiple storage pools set in a single resource group. LINSTOR then selects one matching pool for every resource placement.

Since storage pool names cannot contain any spaces, there should be no existing storage class with spaces in the storage pool parameter. This means we can simply reuse the existing parameter.