### PR TITLE
docker: switch base to debian 12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ARG TARGETARCH
 ARG LINSTOR_WAIT_UNTIL_VERSION=v0.2.1
 RUN curl -fsSL https://github.com/LINBIT/linstor-wait-until/releases/download/$LINSTOR_WAIT_UNTIL_VERSION/linstor-wait-until-$LINSTOR_WAIT_UNTIL_VERSION-$TARGETOS-$TARGETARCH.tar.gz | tar xvzC /
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 ARG LINSTOR_WAIT_UNTIL
 
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Some tools that interact with the kernel are not happy when using old tools on a new kernel. For example, turns out that resize2fs (the ext* resize tool) refuses to resize a mounted FS on a new kernel because the FS there reports some features it does not know about.

To fix, we use the latest debian stable release as our base image. Tools there should be new enough for the future.

See https://github.com/piraeusdatastore/piraeus-operator/issues/628