### PR TITLE
implement L2L backup shipping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for creating backups with LINSTOR-to-LINSTOR shipping.
+
 ## [1.5.0] - 2024-03-19
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.5
 
 require (
-	github.com/LINBIT/golinstor v0.50.0
+	github.com/LINBIT/golinstor v0.51.0
 	github.com/container-storage-interface/spec v1.9.0
 	github.com/haySwim/data v0.2.0
 	github.com/kubernetes-csi/csi-test/v5 v5.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/LINBIT/golinstor v0.50.0 h1:WLdk+Jca/6BSOgmGaFqYrGEZlh0D7kjps4ak20Ntj80=
-github.com/LINBIT/golinstor v0.50.0/go.mod h1:MCkHNdHxoGw4mnt8DGsSqWNF5ZGhYFy6Lr4tQLyVBs0=
+github.com/LINBIT/golinstor v0.51.0 h1:XvfcQN3jg7b/s79wrpTe/jzfFDGSNZy2pjGG8SDtFRM=
+github.com/LINBIT/golinstor v0.51.0/go.mod h1:MCkHNdHxoGw4mnt8DGsSqWNF5ZGhYFy6Lr4tQLyVBs0=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=

--- a/pkg/client/mock.go
+++ b/pkg/client/mock.go
@@ -148,6 +148,10 @@ func (s *MockStorage) SnapDelete(ctx context.Context, snap *volume.Snapshot) err
 	return nil
 }
 
+func (s *MockStorage) DeleteTemporarySnapshotID(ctx context.Context, id string) error {
+	return nil
+}
+
 func (s *MockStorage) ListSnaps(ctx context.Context, start, limit int) ([]*volume.Snapshot, error) {
 	if limit == 0 {
 		limit = len(s.snapshots) - start

--- a/pkg/linstor/const.go
+++ b/pkg/linstor/const.go
@@ -26,6 +26,9 @@ const (
 	// DriverName is the name used in CSI calls for this driver.
 	DriverName = "linstor.csi.linbit.com"
 
+	// LinstorBackupKVName is the name of the KV store used to map L2L backups to local snapshot names
+	LinstorBackupKVName = "csi-backup-mapping"
+
 	// LegacyParameterPassKey is the Aux props key in linstor where serialized CSI parameters
 	// are stored.
 	LegacyParameterPassKey = lc.NamespcAuxiliary + "/csi-volume-annotations"

--- a/pkg/volume/snapshot_params.go
+++ b/pkg/volume/snapshot_params.go
@@ -21,16 +21,19 @@ const (
 )
 
 type SnapshotParameters struct {
-	Type             SnapshotType `json:"type,omitempty"`
-	AllowIncremental bool         `json:"allow-incremental"`
-	RemoteName       string       `json:"remote-name,omitempty"`
-	DeleteLocal      bool         `json:"delete-local,omitempty"`
-	S3Endpoint       string       `json:"s3-endpoint,omitempty"`
-	S3Bucket         string       `json:"s3-bucket,omitempty"`
-	S3SigningRegion  string       `json:"s3-signing-region,omitempty"`
-	S3UsePathStyle   bool         `json:"s3-use-path-style"`
-	S3AccessKey      string       `json:"-"`
-	S3SecretKey      string       `json:"-"`
+	Type                     SnapshotType `json:"type,omitempty"`
+	AllowIncremental         bool         `json:"allow-incremental"`
+	RemoteName               string       `json:"remote-name,omitempty"`
+	DeleteLocal              bool         `json:"delete-local,omitempty"`
+	S3Endpoint               string       `json:"s3-endpoint,omitempty"`
+	S3Bucket                 string       `json:"s3-bucket,omitempty"`
+	S3SigningRegion          string       `json:"s3-signing-region,omitempty"`
+	S3UsePathStyle           bool         `json:"s3-use-path-style"`
+	S3AccessKey              string       `json:"-"`
+	S3SecretKey              string       `json:"-"`
+	LinstorTargetUrl         string       `json:"linstor-target-url,omitempty"`
+	LinstorTargetClusterID   string       `json:"linstor-target-cluster-id,omitempty"`
+	LinstorTargetStoragePool string       `json:"linstor-target-storage-pool,omitempty"`
 }
 
 func NewSnapshotParameters(params, secrets map[string]string) (*SnapshotParameters, error) {
@@ -81,6 +84,12 @@ func NewSnapshotParameters(params, secrets map[string]string) (*SnapshotParamete
 			}
 
 			p.S3UsePathStyle = b
+		case "/linstor-target-url":
+			p.LinstorTargetUrl = v
+		case "/linstor-target-cluster-id":
+			p.LinstorTargetClusterID = v
+		case "/linstor-target-storage-pool":
+			p.LinstorTargetStoragePool = v
 		default:
 			log.WithField("key", k).Warn("ignoring unknown snapshot parameter key")
 		}
@@ -103,14 +112,17 @@ func NewSnapshotParameters(params, secrets map[string]string) (*SnapshotParamete
 func (s *SnapshotParameters) String() string {
 	// NB: we use a value here instead of a pointer, so we don't recurse endlessly.
 	return fmt.Sprint(SnapshotParameters{
-		Type:             s.Type,
-		AllowIncremental: s.AllowIncremental,
-		RemoteName:       s.RemoteName,
-		S3Endpoint:       s.S3Endpoint,
-		S3Bucket:         s.S3Bucket,
-		S3SigningRegion:  s.S3SigningRegion,
-		S3UsePathStyle:   s.S3UsePathStyle,
-		S3AccessKey:      "***",
-		S3SecretKey:      "***",
+		Type:                     s.Type,
+		AllowIncremental:         s.AllowIncremental,
+		RemoteName:               s.RemoteName,
+		S3Endpoint:               s.S3Endpoint,
+		S3Bucket:                 s.S3Bucket,
+		S3SigningRegion:          s.S3SigningRegion,
+		S3UsePathStyle:           s.S3UsePathStyle,
+		S3AccessKey:              "***",
+		S3SecretKey:              "***",
+		LinstorTargetUrl:         s.LinstorTargetUrl,
+		LinstorTargetClusterID:   s.LinstorTargetClusterID,
+		LinstorTargetStoragePool: s.LinstorTargetStoragePool,
 	})
 }

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -81,6 +81,8 @@ type SnapshotCreateDeleter interface {
 	ListSnaps(ctx context.Context, start, limit int) ([]*Snapshot, error)
 	// VolFromSnap creates a new volume based on the provided snapshot.
 	VolFromSnap(ctx context.Context, snap *Snapshot, vol *Info, params *Parameters, snapParams *SnapshotParameters, topologies *csi.TopologyRequirement) error
+	// DeleteTemporarySnapshotID deletes the temporary snapshot ID.
+	DeleteTemporarySnapshotID(ctx context.Context, id string) error
 }
 
 // AttacherDettacher handles operations relating to volume accessiblity on nodes.


### PR DESCRIPTION
Fill in the missing implementation for backup shipping to another LINSTOR cluster. Because we can't "wish" for a specific snapshot name, we store a mapping of requested snapshot name to actually taken snapshot name in a special LINSTOR KV.

Other than that, it is simply a matter of wiring up the necessary plumbing.

This currently cannot restore a backup once it is shipped and the local snapshot deleted, and it is unlikely that such a thing could be implemented, as LINSTOR does not support downloading a snapshot once shipped.