### PR TITLE
pass device path on publish from controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Pass device paths down from CSI Controller on publish, reducing LINSTOR API requests from the CSI Node.
+
 ## [1.6.0] - 2024-05-02
 
 ### Added

--- a/pkg/client/linstor_test.go
+++ b/pkg/client/linstor_test.go
@@ -152,7 +152,6 @@ const (
 
 func TestLinstor_Attach(t *testing.T) {
 	var (
-		ResourceModifyReadWrite                    = lapi.GenericPropsModify{OverrideProps: map[string]string{}}
 		ResourceModifyReadWriteWithTemporaryAttach = lapi.GenericPropsModify{OverrideProps: map[string]string{linstor.PropertyCreatedFor: linstor.CreatedForTemporaryDisklessAttach}}
 	)
 
@@ -173,12 +172,13 @@ func TestLinstor_Attach(t *testing.T) {
 
 		m.ExpectedCalls = []*mock.Call{
 			{Method: "GetAll", Arguments: mock.Arguments{mock.Anything, ExampleResourceID}, ReturnArguments: mock.Arguments{rv, rvErr}},
-			{Method: "ModifyVolume", Arguments: mock.Arguments{mock.Anything, ExampleResourceID, "node-2", 0, ResourceModifyReadWrite}, ReturnArguments: mock.Arguments{nil}},
+			{Method: "GetVolume", Arguments: mock.Arguments{mock.Anything, ExampleResourceID, "node-2", 0}, ReturnArguments: mock.Arguments{lapi.Volume{DevicePath: "/dev/vol1"}, nil}},
 		}
 		cl := Linstor{client: &lc.HighLevelClient{Client: &lapi.Client{Resources: &m}}, log: logrus.WithField("test", t.Name())}
 
-		err := cl.Attach(context.Background(), ExampleResourceID, "node-2", false)
+		path, err := cl.Attach(context.Background(), ExampleResourceID, "node-2", false)
 		assert.NoError(t, err)
+		assert.Equal(t, "/dev/vol1", path)
 		m.AssertExpectations(t)
 	})
 
@@ -191,11 +191,13 @@ func TestLinstor_Attach(t *testing.T) {
 			{Method: "Get", Arguments: mock.Arguments{mock.Anything, ExampleResourceID, "node-3"}, ReturnArguments: mock.Arguments{lapi.Resource{}, nil}},
 			{Method: "MakeAvailable", Arguments: mock.Arguments{mock.Anything, ExampleResourceID, "node-3", lapi.ResourceMakeAvailable{Diskful: false}}, ReturnArguments: mock.Arguments{nil}},
 			{Method: "ModifyVolume", Arguments: mock.Arguments{mock.Anything, ExampleResourceID, "node-3", 0, ResourceModifyReadWriteWithTemporaryAttach}, ReturnArguments: mock.Arguments{nil}},
+			{Method: "GetVolume", Arguments: mock.Arguments{mock.Anything, ExampleResourceID, "node-3", 0}, ReturnArguments: mock.Arguments{lapi.Volume{DevicePath: "/dev/vol1"}, nil}},
 		}
 		cl := Linstor{client: &lc.HighLevelClient{Client: &lapi.Client{Resources: &m}}, log: logrus.WithField("test", t.Name())}
 
-		err := cl.Attach(context.Background(), ExampleResourceID, "node-3", false)
+		path, err := cl.Attach(context.Background(), ExampleResourceID, "node-3", false)
 		assert.NoError(t, err)
+		assert.Equal(t, "/dev/vol1", path)
 		m.AssertExpectations(t)
 	})
 
@@ -209,11 +211,13 @@ func TestLinstor_Attach(t *testing.T) {
 			{Method: "MakeAvailable", Arguments: mock.Arguments{mock.Anything, ExampleResourceID, "node-3", lapi.ResourceMakeAvailable{Diskful: false}}, ReturnArguments: mock.Arguments{lapi.NotFoundError}},
 			{Method: "Create", Arguments: mock.Arguments{mock.Anything, lapi.ResourceCreate{Resource: lapi.Resource{Name: ExampleResourceID, NodeName: "node-3", Flags: []string{lapiconsts.FlagDrbdDiskless}}}}, ReturnArguments: mock.Arguments{nil}},
 			{Method: "ModifyVolume", Arguments: mock.Arguments{mock.Anything, ExampleResourceID, "node-3", 0, ResourceModifyReadWriteWithTemporaryAttach}, ReturnArguments: mock.Arguments{nil}},
+			{Method: "GetVolume", Arguments: mock.Arguments{mock.Anything, ExampleResourceID, "node-3", 0}, ReturnArguments: mock.Arguments{lapi.Volume{DevicePath: "/dev/vol1"}, nil}},
 		}
 		cl := Linstor{client: &lc.HighLevelClient{Client: &lapi.Client{Resources: &m}}, log: logrus.WithField("test", t.Name())}
 
-		err := cl.Attach(context.Background(), ExampleResourceID, "node-3", false)
+		path, err := cl.Attach(context.Background(), ExampleResourceID, "node-3", false)
 		assert.NoError(t, err)
+		assert.Equal(t, "/dev/vol1", path)
 		m.AssertExpectations(t)
 	})
 
@@ -225,12 +229,13 @@ func TestLinstor_Attach(t *testing.T) {
 			{Method: "GetAll", Arguments: mock.Arguments{mock.Anything, ExampleResourceID}, ReturnArguments: mock.Arguments{rv, rvErr}},
 			{Method: "Get", Arguments: mock.Arguments{mock.Anything, ExampleResourceID, "node-2"}, ReturnArguments: mock.Arguments{lapi.Resource{}, nil}},
 			{Method: "MakeAvailable", Arguments: mock.Arguments{mock.Anything, ExampleResourceID, "node-2", lapi.ResourceMakeAvailable{Diskful: false}}, ReturnArguments: mock.Arguments{nil}},
-			{Method: "ModifyVolume", Arguments: mock.Arguments{mock.Anything, ExampleResourceID, "node-2", 0, ResourceModifyReadWrite}, ReturnArguments: mock.Arguments{nil}},
+			{Method: "GetVolume", Arguments: mock.Arguments{mock.Anything, ExampleResourceID, "node-2", 0}, ReturnArguments: mock.Arguments{lapi.Volume{DevicePath: "/dev/vol1"}, nil}},
 		}
 		cl := Linstor{client: &lc.HighLevelClient{Client: &lapi.Client{Resources: &m}}, log: logrus.WithField("test", t.Name())}
 
-		err := cl.Attach(context.Background(), ExampleResourceID, "node-2", false)
+		path, err := cl.Attach(context.Background(), ExampleResourceID, "node-2", false)
 		assert.NoError(t, err)
+		assert.Equal(t, "/dev/vol1", path)
 		m.AssertExpectations(t)
 	})
 }

--- a/pkg/client/mock.go
+++ b/pkg/client/mock.go
@@ -204,9 +204,9 @@ func (s *MockStorage) VolFromVol(ctx context.Context, sourceVol, vol *volume.Inf
 	return nil
 }
 
-func (s *MockStorage) Attach(ctx context.Context, volId, node string, rwxBlock bool) error {
+func (s *MockStorage) Attach(ctx context.Context, volId, node string, rwxBlock bool) (string, error) {
 	s.assignedVolumes[volId] = append(s.assignedVolumes[volId], volume.Assignment{Node: node, Path: "/dev/" + volId})
-	return nil
+	return "/dev/" + volId, nil
 }
 
 func (s *MockStorage) Detach(ctx context.Context, volId, node string) error {
@@ -285,7 +285,7 @@ func (s *MockStorage) GetVolumeStats(path string) (volume.VolumeStats, error) {
 	return volume.VolumeStats{}, nil
 }
 
-func (s *MockStorage) NodeExpand(source, target string) error {
+func (s *MockStorage) NodeExpand(target string) error {
 	_, err := os.Stat(target)
 	if err != nil {
 		return err

--- a/pkg/driver/publish_context.go
+++ b/pkg/driver/publish_context.go
@@ -1,0 +1,32 @@
+package driver
+
+import (
+	"github.com/piraeusdatastore/linstor-csi/pkg/linstor"
+)
+
+const (
+	PublishContextMarker = linstor.ParameterNamespace + "/uses-publish-context"
+	DevicePath           = linstor.ParameterNamespace + "/device-path"
+)
+
+type PublishContext struct {
+	DevicePath string
+}
+
+func PublishContextFromMap(ctx map[string]string) *PublishContext {
+	_, ok := ctx[PublishContextMarker]
+	if !ok {
+		return nil
+	}
+
+	return &PublishContext{
+		DevicePath: ctx[DevicePath],
+	}
+}
+
+func (p *PublishContext) ToMap() map[string]string {
+	return map[string]string{
+		PublishContextMarker: "true",
+		DevicePath:           p.DevicePath,
+	}
+}

--- a/pkg/driver/volume_context.go
+++ b/pkg/driver/volume_context.go
@@ -20,6 +20,7 @@ type VolumeContext struct {
 	MountOptions        []string
 	PostMountXfsOptions string
 	RemoteAccessPolicy  volume.RemoteAccessPolicy
+	DevicePath          string
 }
 
 // NewVolumeContext creates a new default volume context, which does not specify any fancy mkfs/mount/post-mount options
@@ -56,6 +57,7 @@ func VolumeContextFromMap(ctx map[string]string) (*VolumeContext, error) {
 		MountOptions:        mountOpts,
 		PostMountXfsOptions: ctx[PostMountXfsOpts],
 		RemoteAccessPolicy:  policy,
+		DevicePath:          ctx[DevicePath],
 	}, nil
 }
 
@@ -70,6 +72,7 @@ func (v *VolumeContext) ToMap() (map[string]string, error) {
 		MountOptions:           encodeMountOpts(v.MountOptions),
 		PostMountXfsOpts:       v.PostMountXfsOptions,
 		RemoteAccessPolicyOpts: string(policy),
+		DevicePath:             v.DevicePath,
 	}, nil
 }
 

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -88,7 +88,7 @@ type SnapshotCreateDeleter interface {
 // AttacherDettacher handles operations relating to volume accessiblity on nodes.
 type AttacherDettacher interface {
 	Querier
-	Attach(ctx context.Context, volId, node string, rwxBlock bool) error
+	Attach(ctx context.Context, volId, node string, rwxBlock bool) (string, error)
 	Detach(ctx context.Context, volId, node string) error
 	NodeAvailable(ctx context.Context, node string) error
 	FindAssignmentOnNode(ctx context.Context, volId, node string) (*Assignment, error)
@@ -143,7 +143,9 @@ type NodeInformer interface {
 
 // Expander handles the resizing operations for volumes.
 type Expander interface {
-	NodeExpand(source, target string) error
+	// NodeExpand runs the appropriate resize operation on the target path.
+	// Must return os.ErrNotExist if the path does not exist or is not a valid mount point.
+	NodeExpand(target string) error
 	ControllerExpand(ctx context.Context, vol *Info) error
 }
 


### PR DESCRIPTION
When the node plugin receives a publish (== mount) call, it needs to know what device needs to be mounted. Up to now, this was done by an API request to LINSTOR. With the introduction of more aggressive caching, this often meant the request would end in a 404 since the cache did not know about the volume at all.

To fix this, we move the retrieval of the device path out of the node plugin entirely. We can simply pass the device path from the ControllerPublish() call down using the publish context. There, the cache is not an issue since for the volume to be created, some kind of modification is needed, which will always result in cache invalidation.

We also remove the request for the device path from the NodeExpand() call: we have to look at the local mount table so we get the device name from there.

With this change, the node plugin should no longer need to request LINSTOR API outside the node/storage pool information, which is not affected by this caching issue.