### PR TITLE
update golinstor to fix caching issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed node filtering when initial placement was not possible. This now takes the remoteAccessPolicy into account like
+  intended.
+
 ## [1.6.2] - 2024-06-19
 
 ### Fixed

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.22.2
 
 require (
-	github.com/LINBIT/golinstor v0.52.1
+	github.com/LINBIT/golinstor v0.52.2
 	github.com/container-storage-interface/spec v1.9.0
 	github.com/haySwim/data v0.2.0
 	github.com/kubernetes-csi/csi-test/v5 v5.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/LINBIT/golinstor v0.52.1 h1:TBLv3E9Lr7cEDQvorRivZhtZS5xP1oUUOxoAGBwJoAg=
-github.com/LINBIT/golinstor v0.52.1/go.mod h1:D811Eyjhoy6t1Tl36HTW4by0s6O5g0cVgV/t58oN+0g=
+github.com/LINBIT/golinstor v0.52.2 h1:O2+NRWUfn0WdgslVRywF1it2+qS1Zkak/RuuZZMY0vs=
+github.com/LINBIT/golinstor v0.52.2/go.mod h1:aPtOD/STz0JO0u7xrOVH3ZdzpDHwXcHzjKzczOReXu8=
 github.com/container-storage-interface/spec v1.9.0 h1:zKtX4STsq31Knz3gciCYCi1SXtO2HJDecIjDVboYavY=
 github.com/container-storage-interface/spec v1.9.0/go.mod h1:ZfDu+3ZRyeVqxZM0Ds19MVLkN2d1XJ5MAfi1L3VjlT0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
The golinstor caching implementation did not filter by properties, which is used by the NodesForTopology() call to filter the nodes based on properties.

This meant that in some scenarios, LINSTOR CSI would place volumes on unexpected nodes, as it got the full list of nodes instead of one filtered to just some property.