### PR TITLE
do not try to resize block volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed an issue that caused the node publish call to attempt to resize a block volume: block volumes are now never
+  attempted to be resized.
+
 ## [1.6.3] - 2024-06-28
 
 ### Fixed

--- a/pkg/client/mock.go
+++ b/pkg/client/mock.go
@@ -258,27 +258,30 @@ func (s *MockStorage) Mount(ctx context.Context, source, target, fsType string, 
 	return nil
 }
 
-func (s *MockStorage) IsNotMountPoint(target string) (bool, error) {
+func (s *MockStorage) IsMountPoint(target string) (bool, error) {
 	_, err := os.Stat(target)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return true, nil
+			return false, nil
 		}
+
 		return false, err
 	}
-	return false, nil
+
+	return true, nil
 }
 
 func (s *MockStorage) Unmount(target string) error {
-	notMounted, err := s.IsNotMountPoint(target)
+	mounted, err := s.IsMountPoint(target)
 	if err != nil {
 		return err
 	}
-	if notMounted {
-		return nil
+
+	if mounted {
+		return os.RemoveAll(target)
 	}
 
-	return os.RemoveAll(target)
+	return nil
 }
 
 func (s *MockStorage) GetVolumeStats(path string) (volume.VolumeStats, error) {

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -430,12 +430,12 @@ func (d Driver) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeSt
 		return nil, missingAttr("NodeGetVolumeStats", req.GetVolumeId(), "VolumeId")
 	}
 
-	notMounted, err := d.Mounter.IsNotMountPoint(req.GetVolumePath())
+	mounted, err := d.Mounter.IsMountPoint(req.GetVolumePath())
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "NodeGetVolumeStats failed for %s: failed to check if path %v is mounted: %v", req.GetVolumeId(), req.GetVolumePath(), err)
 	}
 
-	if notMounted {
+	if !mounted {
 		return nil, status.Errorf(codes.NotFound, "NodeGetVolumeStats failed for %s: path %v is not mounted", req.GetVolumeId(), req.GetVolumePath())
 	}
 

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -112,7 +112,7 @@ type Querier interface {
 type Mounter interface {
 	Mount(ctx context.Context, source, target, fsType string, readonly bool, mntOpts []string) error
 	Unmount(target string) error
-	IsNotMountPoint(target string) (bool, error)
+	IsMountPoint(target string) (bool, error)
 }
 
 // VolumeStats provides details about filesystem usage.


### PR DESCRIPTION
Block volumes cannot be resized, so there is no point in even attempting it. An attempt would fail because it could not determine the FS one the volume, as there likely isn't any. A retry would then succeed as there is an earlier check if we need to mount at all.

The fix is to rearrange the logic to only attempt to resize filesystem volumes.

While at it, also remove the deprecated "IsNotMountPoint". The double negative was getting confusing in any case.