### PR TITLE
disable fallback to RO mounts for RW volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Disable `mount` fallback to mount a volume RO even if a RW mount was requested.
+
 ## [1.6.4] - 2024-11-08
 
 ### Fixed

--- a/pkg/client/linstor.go
+++ b/pkg/client/linstor.go
@@ -1963,6 +1963,9 @@ func (s *Linstor) Mount(ctx context.Context, source, target, fsType string, read
 			return fmt.Errorf("failed to set source device readonly: %w", err)
 		}
 	} else {
+		// Explicitly set rw option: otherwise mount may fall back to RO mount on promotion errors
+		mntOpts = append(mntOpts, "rw")
+
 		// We might be re-using an existing device that was set RO previously
 		err = s.setDevReadWrite(ctx, source)
 		if err != nil {


### PR DESCRIPTION
If a user requests a RW volume, we disable the default behaviour of "mount" to fallback to RO mounts should there be an issue with the initial RW attempt.

This may happen if a DRBD device is in a weird state, where the default auto-promote does not succeed, but the resource is otherwise fine. A RO mount does not require an explicit state change, so it may succeed in such a situation.

By requesting "rw" in the mount options, we prevent this behaviour.