### PR TITLE
better volume validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update validation of volume creation and registration requests, providing better validation of volumes.
+
 ## [1.7.1] - 2025-03-12
 
 ### Changed


### PR DESCRIPTION
Up to now, we did not properly validate volume capabilities during volume creation, allowing users to create FileSystem volumes with RWX capabilities.

Careful reading of the CSI standard shows that these capabilities need to be checked during CreateVolume and ValidateVolumeCapabilities calls.