### PR TITLE
fix issues with left-over resource definition after volumes have been deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Ensure the BalanceResourceTask is disabled for resources in the process of being deleted.
+
 ## [1.8.0] - 2025-06-17
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.2
 
 require (
-	github.com/LINBIT/golinstor v0.55.0
+	github.com/LINBIT/golinstor v0.56.0
 	github.com/container-storage-interface/spec v1.11.0
 	github.com/haySwim/data v0.2.0
 	github.com/kubernetes-csi/csi-test/v5 v5.3.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/LINBIT/golinstor v0.55.0 h1:lO/fjCKR6rWqVS0YOiUeJeIDIG7vLQFZetiicSSjy5k=
-github.com/LINBIT/golinstor v0.55.0/go.mod h1:Al+or3qxnkEMBNHRBg37qygETyWfoDKfdmhoaehvuZo=
+github.com/LINBIT/golinstor v0.56.0 h1:kLz+weNkgHmBcn5gD0heffX4pX1V+tX6HhaSPQQVR+M=
+github.com/LINBIT/golinstor v0.56.0/go.mod h1:/KRf5tZrL1BGu0smvmeU/jJomFbxh2o55Uy6hEnQpCU=
 github.com/container-storage-interface/spec v1.11.0 h1:H/YKTOeUZwHtyPOr9raR+HgFmGluGCklulxDYxSdVNM=
 github.com/container-storage-interface/spec v1.11.0/go.mod h1:DtUvaQszPml1YJfIK7c00mlv6/g4wNMLanLgiUbKFRI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
* golinstor used to invalidate the cache before applying modifications. This might cause stale cache entries if the cache gets re-populated before the modification is made. The end result was that sometimes the CSI driver thought that certain resource should not be deleted. An update to golinstor fixes this issue.
* LINSTOR periodically runs a job that recreates replicas based on the RG settings. This sometimes interfered with our deletion logic, causing resource to not be properly cleaned up, leaving resources with no volumes and the resource definition behind. To fix this, disable the task for the resources we intent to delete.