### PR TITLE
skip LINSTOR KV for local and S3 snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Enforce larger minimum volume size for filesystem volumes.
+- Skip LINSTOR-KV interaction for local and S3 snapshots.
 
 ## [1.8.1] - 2025-06-24
 

--- a/pkg/client/linstor.go
+++ b/pkg/client/linstor.go
@@ -1052,7 +1052,11 @@ func (s *Linstor) SnapDelete(ctx context.Context, snap *volume.Snapshot) error {
 	return nil
 }
 
-func (s *Linstor) DeleteTemporarySnapshotID(ctx context.Context, id string) error {
+func (s *Linstor) DeleteTemporarySnapshotID(ctx context.Context, id string, snapParams *volume.SnapshotParameters) error {
+	if snapParams.Type != volume.SnapshotTypeLinstor {
+		return nil
+	}
+
 	err := s.client.KeyValueStore.CreateOrModify(ctx, linstor.LinstorBackupKVName, lapi.GenericPropsModify{
 		DeleteProps: []string{id},
 	})

--- a/pkg/client/mock.go
+++ b/pkg/client/mock.go
@@ -148,7 +148,7 @@ func (s *MockStorage) SnapDelete(ctx context.Context, snap *volume.Snapshot) err
 	return nil
 }
 
-func (s *MockStorage) DeleteTemporarySnapshotID(ctx context.Context, id string) error {
+func (s *MockStorage) DeleteTemporarySnapshotID(ctx context.Context, id string, snapParams *volume.SnapshotParameters) error {
 	return nil
 }
 

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -993,7 +993,7 @@ func (d Driver) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotReque
 			if existingSnap.ReadyToUse {
 				d.log.WithField("snapshot id", id).Debug("snapshot ready, delete temporary ID mapping if it exists")
 
-				err := d.Snapshots.DeleteTemporarySnapshotID(ctx, id)
+				err := d.Snapshots.DeleteTemporarySnapshotID(ctx, id, params)
 				if err != nil {
 					return nil, status.Errorf(codes.Internal, "failed to delete temporary snapshot ID: %v", err)
 				}
@@ -1019,7 +1019,7 @@ func (d Driver) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotReque
 	if snap.ReadyToUse {
 		d.log.WithField("snapshot id", id).Debug("snapshot ready, delete temporary ID mapping if it exists")
 
-		err := d.Snapshots.DeleteTemporarySnapshotID(ctx, id)
+		err := d.Snapshots.DeleteTemporarySnapshotID(ctx, id, params)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "failed to delete temporary snapshot ID: %v", err)
 		}

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -82,7 +82,7 @@ type SnapshotCreateDeleter interface {
 	// VolFromSnap creates a new volume based on the provided snapshot.
 	VolFromSnap(ctx context.Context, snap *Snapshot, vol *Info, params *Parameters, snapParams *SnapshotParameters, topologies *csi.TopologyRequirement) error
 	// DeleteTemporarySnapshotID deletes the temporary snapshot ID.
-	DeleteTemporarySnapshotID(ctx context.Context, id string) error
+	DeleteTemporarySnapshotID(ctx context.Context, id string, snapParams *SnapshotParameters) error
 	// ReconcileRemote creates or updates a remote based on the given snapshot parameters.
 	ReconcileRemote(ctx context.Context, params *SnapshotParameters) error
 }


### PR DESCRIPTION
For L2L snapshots, we need to store the name of the created snapshot, as we can't influence the LINSTOR generated snapshot name for those. Storing the name means we can find the created snapshot again should the request need to be retried because of a timeout.

For local and S3 snapshots, we can just pass the snapshot ID from CSI to LINSTOR, meaning we don't need to external name mapping. So we can also skip the cleanup step.