### PR TITLE
supported LINSTOR volume clones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Enforce larger minimum volume size for filesystem volumes.
 - Skip LINSTOR-KV interaction for local and S3 snapshots.
+- Switch to using LINSTOR clones instead of temporary snapshots.
 
 ## [1.8.1] - 2025-06-24
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.2
 
 require (
-	github.com/LINBIT/golinstor v0.56.1
+	github.com/LINBIT/golinstor v0.56.2
 	github.com/container-storage-interface/spec v1.11.0
 	github.com/haySwim/data v0.2.0
 	github.com/kubernetes-csi/csi-test/v5 v5.3.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/LINBIT/golinstor v0.56.1 h1:26dzvmb3qs0KhnrUoXxPoW4mJG1wmlQhyn8j1yVrd9g=
-github.com/LINBIT/golinstor v0.56.1/go.mod h1:JF2dGKWa9wyT6M9GOHmlzqFB9/s84Z9bt3tRkZLvZSU=
+github.com/LINBIT/golinstor v0.56.2 h1:efT4d8C712bSEyxvhgMoExpPAVJhkViX8g+GOgC3fEI=
+github.com/LINBIT/golinstor v0.56.2/go.mod h1:JF2dGKWa9wyT6M9GOHmlzqFB9/s84Z9bt3tRkZLvZSU=
 github.com/container-storage-interface/spec v1.11.0 h1:H/YKTOeUZwHtyPOr9raR+HgFmGluGCklulxDYxSdVNM=
 github.com/container-storage-interface/spec v1.11.0/go.mod h1:DtUvaQszPml1YJfIK7c00mlv6/g4wNMLanLgiUbKFRI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/client/mock.go
+++ b/pkg/client/mock.go
@@ -82,6 +82,11 @@ func (s *MockStorage) Create(ctx context.Context, vol *volume.Info, params *volu
 	return nil
 }
 
+func (s *MockStorage) Clone(ctx context.Context, vol, src *volume.Info, params *volume.Parameters, topologies *csi.TopologyRequirement) error {
+	s.createdVolumes = append(s.createdVolumes, vol)
+	return nil
+}
+
 func (s *MockStorage) Delete(ctx context.Context, volId string) error {
 	for i, v := range s.createdVolumes {
 		if v != nil && (v.ID == volId) {

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -54,6 +54,7 @@ type CreateDeleter interface {
 	Querier
 	CompatibleVolumeId(name, pvcNamespace, pvcName string) string
 	Create(ctx context.Context, vol *Info, params *Parameters, topologies *csi.TopologyRequirement) error
+	Clone(ctx context.Context, vol, src *Info, params *Parameters, topologies *csi.TopologyRequirement) error
 	Delete(ctx context.Context, volId string) error
 
 	// AccessibleTopologies returns the list of key value pairs volume topologies


### PR DESCRIPTION
We already supported cloning volumes via snapshots. Since LINSTOR now can also clone volumes, and be smart about mixing and matching different storage pools, we can switch to using the LINSTOR clone path, enabling clones on more types of storage pools.