### PR TITLE
sanity check that block volumes are usable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enforce larger minimum volume size for filesystem volumes.
 - Skip LINSTOR-KV interaction for local and S3 snapshots.
 - Switch to using LINSTOR clones instead of temporary snapshots.
+- Ensure block volumes are usable on mount.
 
 ## [1.8.1] - 2025-06-24
 


### PR DESCRIPTION
We want to ensure a mapped block volume are usable. Since we only bind-mount the device to a new location, we never verify that the device is usable. This may lead to a device that has no quorum being used. Depending on the workload using that device, this may go unnoticed.

So we do a simple sanity check by opening the device. A "rw" device opening fails immediately on open, a "ro" device might only fail on reading a specific sector. Since we can't really read the whole device, no additional checks are added for this case.