### PR TITLE
Always use PVC name and namespace in volume creation and store as Aux properties

### DIFF
--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -547,12 +547,14 @@ func (d Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) 
 	pvcName := req.GetParameters()[ParameterCsiPvcName]
 	pvcNamespace := req.GetParameters()[ParameterCsiPvcNamespace]
 
-	var volId string
+	namespaceToUse := ""
+	nameToUse := ""
 	if params.UsePvcName {
-		volId = d.Storage.CompatibleVolumeId(req.GetName(), pvcNamespace, pvcName)
-	} else {
-		volId = d.Storage.CompatibleVolumeId(req.GetName(), "", "")
+		namespaceToUse = pvcNamespace
+		nameToUse = pvcName
 	}
+
+	volId := d.Storage.CompatibleVolumeId(req.GetName(), namespaceToUse, nameToUse)
 
 	log := d.log.WithField("volume", volId)
 	log.Infof("determined volume id for volume named '%s'", req.GetName())

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -547,14 +547,14 @@ func (d Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) 
 	pvcName := req.GetParameters()[ParameterCsiPvcName]
 	pvcNamespace := req.GetParameters()[ParameterCsiPvcNamespace]
 
-	namespaceToUse := ""
-	nameToUse := ""
+	pvcNamespaceToUse := ""
+	pvcNameToUse := ""
 	if params.UsePvcName {
-		namespaceToUse = pvcNamespace
-		nameToUse = pvcName
+		pvcNamespaceToUse = pvcNamespace
+		pvcNameToUse = pvcName
 	}
 
-	volId := d.Storage.CompatibleVolumeId(req.GetName(), namespaceToUse, nameToUse)
+	volId := d.Storage.CompatibleVolumeId(req.GetName(), pvcNamespaceToUse, pvcNameToUse)
 
 	log := d.log.WithField("volume", volId)
 	log.Infof("determined volume id for volume named '%s'", req.GetName())


### PR DESCRIPTION
This pull request updates the `CreateVolume` function in the LINSTOR CSI driver to always extract and utilize the PVC name and namespace from the CSI request parameters. These values are now used to generate a more consistent volume ID and are optionally added to the volume's properties in LINSTOR for improved metadata tracking and debugging.

Motivation

- By always attempting to use these parameters (with safe fallbacks), we ensure better alignment with Kubernetes PVC metadata.
- Storing PVC details in LINSTOR properties (e.g., as `Aux/csi.storage.k8s.io/pvc/name` and `Aux/csi.storage.k8s.io/pvc/namespace`) allows for easier querying and association of volumes with their originating PVCs via LINSTOR commands or API, without relying on external tools.

This change is backward-compatible in standard Kubernetes environments, where these parameters are always provided by the external provisioner.

```
linstor -m resource-definition list -r pvc-1e04f721-a49b-47ef-8551-98f29cea6087
[
  [
    {
      "name": "pvc-1e04f721-a49b-47ef-8551-98f29cea6087",
      "props": {
        "DrbdPrimarySetOn": "K8S-WN-1",
        "Aux/csi-provisioning-completed-by": "linstor-csi/v1.9.0-1-g8273505",
        "Aux/csi.storage.k8s.io/pvc/name": "linstor-test-pvc2",  <<<<< Pvc name in k8s
        "Aux/csi.storage.k8s.io/pvc/namespace": "test",  <<<<< Pvc namespace in k8s
        "DrbdOptions/auto-verify-alg": "sha1",
        "DrbdOptions/Resource/quorum": "majority",
        "FileSystem/MkfsParams": "",
        "FileSystem/Type": "xfs"
      },

```