### PR TITLE
nfs: fix owner reference for endpoints

### DIFF
--- a/cmd/nfs-helper/advertise.go
+++ b/cmd/nfs-helper/advertise.go
@@ -62,12 +62,11 @@ func advertiseStart(ctx context.Context, args []string) error {
 				},
 				OwnerReferences: []metav1.OwnerReference{
 					{
-						APIVersion:         "v1",
-						Kind:               "Pod",
-						Name:               os.Getenv("POD_NAME"),
-						UID:                types.UID(os.Getenv("POD_UID")),
-						BlockOwnerDeletion: ptr.To(true),
-						Controller:         ptr.To(true),
+						APIVersion: "v1",
+						Kind:       "Pod",
+						Name:       os.Getenv("POD_NAME"),
+						UID:        types.UID(os.Getenv("POD_UID")),
+						Controller: ptr.To(true),
 					},
 				},
 			},


### PR DESCRIPTION
Setting BlockOwnerDeletion=true on the OwnerReference for the endpoint slice was intended to block removal of the Pod running the NFS instance until all service references have been removed.

This however would require additional privileges on the NFS server Pod, as Kubernetes verifies that the account creating the EndpointSlice is allowed to set finalizers on the Pod.

Since we don't really need block deletion of the Pod until the EndpointSlice is removed, we simply remove the BlockOwnerDeletion.