### PR TITLE
run fsck before mounting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Run "fsck" before mounting a filesystem
+
 ## [1.10.0] - 2025-10-14
 
 ### Added

--- a/cmd/nfs-helper/mount.go
+++ b/cmd/nfs-helper/mount.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+
+	"github.com/piraeusdatastore/linstor-csi/pkg/utils"
 )
 
 func mount(ctx context.Context, args []string) error {
@@ -17,6 +19,10 @@ func mount(ctx context.Context, args []string) error {
 
 	if err := os.MkdirAll(mountpoint, 0o755); err != nil {
 		return fmt.Errorf("failed to create mount point directory '%s': %w", mountpoint, err)
+	}
+
+	if err := utils.Fsck(ctx, device); err != nil {
+		return fmt.Errorf("failed to run fsck on device '%s': %w", device, err)
 	}
 
 	if err := exec.CommandContext(ctx, "mount", device, mountpoint).Run(); err != nil {

--- a/pkg/client/linstor.go
+++ b/pkg/client/linstor.go
@@ -60,6 +60,7 @@ import (
 	"github.com/piraeusdatastore/linstor-csi/pkg/topology/scheduler/balancer"
 	"github.com/piraeusdatastore/linstor-csi/pkg/topology/scheduler/followtopology"
 	"github.com/piraeusdatastore/linstor-csi/pkg/topology/scheduler/manual"
+	"github.com/piraeusdatastore/linstor-csi/pkg/utils"
 	"github.com/piraeusdatastore/linstor-csi/pkg/volume"
 )
 
@@ -2283,6 +2284,10 @@ func (s *Linstor) Mount(ctx context.Context, source, target, fsType string, read
 
 			source = fmt.Sprintf("%s:%s", u.Hostname(), u.Path)
 			mntOpts = append(mntOpts, fmt.Sprintf("port=%s,vers=4", u.Port()))
+		} else if !block {
+			if err := utils.Fsck(ctx, source); err != nil {
+				return fmt.Errorf("failed to run fsck on device '%s': %w", source, err)
+			}
 		}
 
 		err = s.mounter.MountSensitiveWithoutSystemdWithMountFlags(source, target, fsType, mntOpts, nil, mntFlags)

--- a/pkg/utils/fsck.go
+++ b/pkg/utils/fsck.go
@@ -1,0 +1,30 @@
+package utils
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+)
+
+// Fsck runs fsck on an unmounted device in "automatic" mode.
+//
+// The device is expected to contain a valid xfs or ext4 filesystem.
+func Fsck(ctx context.Context, device string) error {
+	// -l: lock the devices in /run/fsck/<device>.lock
+	// -p: run into "auto" mode, not requesting confirmation on TTY.
+	//     This is an option that is specific to fsck.ext4 and fsck.xfs, passed along by fsck.
+	out, err := exec.CommandContext(ctx, "fsck", "-l", "-p", device).CombinedOutput()
+	if err != nil {
+		var execErr *exec.ExitError
+		if errors.As(err, &execErr) && execErr.ExitCode() <= 1 {
+			// Exit code 0: No error
+			// Exit code 1: Filesystem errors corrected
+			return nil
+		}
+
+		return fmt.Errorf("failed to run fsck: output: \"%s\", %w", out, err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
We had repeated issues with ext4 in particular, as that expects to run e2fsck from time to time. Why a journaling filesystem is so paranoid remains unknown, but we can try to be nice and run fsck.