### PR TITLE
snapshots: search other remotes if not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Search for snapshots in differently named remotes if using new snapshot ID format.
+
 ## [1.10.1] - 2025-11-05
 
 ### Added


### PR DESCRIPTION
With the introduction of URL-based snapshot names, we removed the possibility to have snapshots work between clusters when the remote name did not match. A snapshot with the name:

S3://my-remote/res1/snap1

Could not be used from a cluster where "my-remote" was instead named "remote-from-another-cluster".

This came as a surprise to some users, so we make the effort to search additional remotes if the named remote does not contain the snapshot, or even does not exist at all.

Fixes: 8edb9d331010 ("snapshots: use URL-based snapshot name")