### PR TITLE
do not run fsck on read-only mounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Do not run fsck on read-only mounts.
+
 ## [1.10.3] - 2025-11-26
 
 ### Changed

--- a/pkg/client/linstor.go
+++ b/pkg/client/linstor.go
@@ -2347,7 +2347,7 @@ func (s *Linstor) Mount(ctx context.Context, source, target, fsType string, read
 
 			source = fmt.Sprintf("%s:%s", u.Hostname(), u.Path)
 			mntOpts = append(mntOpts, fmt.Sprintf("port=%s,vers=4", u.Port()))
-		} else if !block {
+		} else if !block && !readonly {
 			if err := utils.Fsck(ctx, source); err != nil {
 				return fmt.Errorf("failed to run fsck on device '%s': %w", source, err)
 			}


### PR DESCRIPTION
The device is explicitly set to be read-only, so fsck obviously fails.

This was only noticed on running the complete k8s test suite. I have never seen a ROX volume used in the wild :sweat_smile: 