### PR TITLE
Fix behaviour of "delete-local" snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Do not run fsck on read-only mounts.
 
+### Fixed
+
+- Only delete local snapshot of backup when `delete-local` parameter is set.
+
 ## [1.10.3] - 2025-11-26
 
 ### Changed

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -1683,8 +1683,12 @@ func (d Driver) maybeDeleteLocalSnapshot(ctx context.Context, snap *volume.Snaps
 		return nil
 	}
 
-	// Create a new, local only snapshot object (no remote set!), so we don't accidentally delete the remote backup
-	return d.Snapshots.SnapDelete(ctx, &snap.SnapshotId)
+	// Create a new, local only snapshot ID (no remote set!), so we don't accidentally delete the remote backup
+	return d.Snapshots.SnapDelete(ctx, &volume.SnapshotId{
+		Type:         volume.SnapshotTypeInCluster,
+		SnapshotName: snap.SnapshotName,
+		SourceName:   snap.SourceName,
+	})
 }
 
 func missingAttr(methodCall, volumeID, attr string) error {


### PR DESCRIPTION
When creating remove snapshots with the "delete-local" parameter set, we should delete local snapshot, but not the remote backup.

However, with the change to use URL-based snapshot names, we accidentally changed the behaviour by passing in the full snapshot name, including the remote part. This caused the routine to delete also the backup on the remote location.

The fix is to implement what was still mentioned in the comment above: create a temporary copy of the SnapshotId without the remote part set.


Fixes: 8edb9d331010 ("snapshots: use URL-based snapshot name")