### PR TITLE
fix snapshot name when creating an S3 backup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Only delete local snapshot of backup when `delete-local` parameter is set.
+- Fixed volume snapshot handle using the wrong format for S3 remotes when `delete-local` is set.
 
 ## [1.10.3] - 2025-11-26
 

--- a/examples/k8s/volume-snapshot.yaml
+++ b/examples/k8s/volume-snapshot.yaml
@@ -3,7 +3,6 @@ kind: VolumeSnapshot
 metadata:
   name: linstor-snapshot-test
 spec:
-  snapshotClassName: linstor-csi-snapshot-class
+  volumeSnapshotClassName: linstor-csi-snapshot-class
   source:
-    name: linstor-pvc-test
-    kind: PersistentVolumeClaim
+    persistentVolumeClaimName: linstor-pvc-test

--- a/pkg/client/linstor.go
+++ b/pkg/client/linstor.go
@@ -942,6 +942,11 @@ func (s *Linstor) SnapCreate(ctx context.Context, id string, params *volume.Snap
 
 	for i := range lsnaps {
 		s, err := linstorSnapshotToCSI(&lsnaps[i])
+
+		if s != nil {
+			s.Type = params.Type
+		}
+
 		result = append(result, s)
 		errs = append(errs, err)
 	}


### PR DESCRIPTION
When an S3 backup gets created, we forgot to set the "Type" to S3 in one case. This then lead to issues when using "delete-local" snapshot parameter, as then the default "InCluster://" based url obviously did not work.