### PR TITLE
Fix: include node name in topology segments for RemoteAccessPolicyLoc…

### DIFF
--- a/pkg/linstor/highlevelclient/high_level_client.go
+++ b/pkg/linstor/highlevelclient/high_level_client.go
@@ -76,6 +76,11 @@ func (c *HighLevelClient) GenericAccessibleTopologies(ctx context.Context, volId
 			}
 		}
 
+		// Include the node name in segments so that RemoteAccessPolicyLocalOnly
+		// (which uses topology.LinstorNodeKey) can properly restrict access to
+		// only the nodes where the volume has diskful replicas.
+		segs[topology.LinstorNodeKey] = nodes[i].Name
+
 		for _, m := range remoteAccessPolicy.AccessibleSegments(segs) {
 			if len(m) == 0 {
 				// Empty segment -> access allowed from everywhere.


### PR DESCRIPTION
GenericAccessibleTopologies was not including the node hostname in the segments map passed to AccessibleSegments(). This caused RemoteAccessPolicyLocalOnly (allowRemoteVolumeAccess: false) to return an empty topology, effectively disabling nodeAffinity on PVs.

The fix adds topology.LinstorNodeKey to the segments map, allowing RemoteAccessPolicyLocalOnly to properly restrict volume access to only the nodes where diskful replicas exist.