### PR TITLE
fix: prevent resource definition deletion when PVC still exists

### DIFF
--- a/cmd/linstor-csi/linstor-csi.go
+++ b/cmd/linstor-csi/linstor-csi.go
@@ -36,6 +36,7 @@ import (
 	"github.com/piraeusdatastore/linstor-csi/pkg/client"
 	"github.com/piraeusdatastore/linstor-csi/pkg/driver"
 	lc "github.com/piraeusdatastore/linstor-csi/pkg/linstor/highlevelclient"
+	"github.com/piraeusdatastore/linstor-csi/pkg/utils"
 	"github.com/piraeusdatastore/linstor-csi/pkg/volume"
 )
 
@@ -128,14 +129,21 @@ func main() {
 		log.Fatal(err)
 	}
 
-	linstorClient, err := client.NewLinstor(
+	linstorOps := []func(*client.Linstor) error{
 		client.APIClient(c),
 		client.LogFmt(logFmt),
 		client.LogLevel(*logLevel),
 		client.LogOut(logOut),
 		client.PropertyNamespace(*propNs),
 		client.LabelBySP(*labelBySP),
-	)
+	}
+
+	_, kubeDyn, kubeErr := utils.KubernetesClient()
+	if kubeErr == nil {
+		linstorOps = append(linstorOps, client.KubeClient(kubeDyn))
+	}
+
+	linstorClient, err := client.NewLinstor(linstorOps...)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/client/linstor.go
+++ b/pkg/client/linstor.go
@@ -1470,9 +1470,8 @@ func (s *Linstor) reconcileSnapshotResources(ctx context.Context, snapshot *volu
 		return fmt.Errorf("snapshot '%s' not deployed on any node", snap.Name)
 	}
 
-	// Optimize the node we use to restore. It should be one of the preferred nodes, or just the first with a snapshot
-	// if no preferred nodes match.
-	var selectedNode string
+	// Collect available snapshot nodes, preferring those matching the topology hints.
+	var preferred, available []string
 	for _, snapNode := range snap.Nodes {
 		if err := s.NodeAvailable(ctx, snapNode); err != nil {
 			logger.WithField("selected node candidate", snapNode).WithError(err).Debug("node is not available")
@@ -1480,13 +1479,23 @@ func (s *Linstor) reconcileSnapshotResources(ctx context.Context, snapshot *volu
 		}
 
 		if slices.Contains(preferredNodes, snapNode) {
-			// We found a perfect candidate.
-			selectedNode = snapNode
-			break
-		} else if selectedNode == "" {
-			// Set a fallback if we have no candidate yet.
-			selectedNode = snapNode
+			preferred = append(preferred, snapNode)
 		}
+
+		available = append(available, snapNode)
+	}
+
+	// Pick a random node from preferred candidates, falling back to any available node.
+	// Randomization distributes restore load across snapshot nodes, preventing all
+	// clones of the same source from concentrating on a single node.
+	candidates := preferred
+	if len(candidates) == 0 {
+		candidates = available
+	}
+
+	var selectedNode string
+	if len(candidates) > 0 {
+		selectedNode = candidates[rand.Intn(len(candidates))]
 	}
 
 	if selectedNode == "" {

--- a/pkg/client/linstor.go
+++ b/pkg/client/linstor.go
@@ -46,6 +46,10 @@ import (
 	"github.com/pborman/uuid"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/mount-utils"
 	utilexec "k8s.io/utils/exec"
 	"k8s.io/utils/ptr"
@@ -72,6 +76,16 @@ type Linstor struct {
 	mounter        mount.Interface
 	resizer        *mount.ResizeFs
 	labelBySP      bool
+	kubeClient     dynamic.Interface
+}
+
+// KubeClient sets the dynamic Kubernetes client used to check PV/PVC state
+// before deleting resource definitions.
+func KubeClient(c dynamic.Interface) func(*Linstor) error {
+	return func(l *Linstor) error {
+		l.kubeClient = c
+		return nil
+	}
 }
 
 // NewLinstor returns a high-level linstor client for CSI applications to interact with
@@ -2788,6 +2802,29 @@ func (s *Linstor) GetNodeTopologies(ctx context.Context, nodename string) (*csi.
 // * No snapshots of the resource exist
 func (s *Linstor) deleteResourceDefinitionAndGroupIfUnused(ctx context.Context, rdName string) error {
 	log := s.log.WithField("rd", rdName)
+
+	// Safety check: if a Kubernetes PV still exists and is Bound to a PVC that
+	// is not being deleted, do not delete the resource definition.
+	if s.kubeClient != nil {
+		pvGVR := schema.GroupVersionResource{Version: "v1", Resource: "persistentvolumes"}
+		pv, err := s.kubeClient.Resource(pvGVR).Get(ctx, rdName, metav1.GetOptions{})
+		if err == nil && pv.GetDeletionTimestamp() == nil {
+			phase, _, _ := unstructured.NestedString(pv.Object, "status", "phase")
+			claimNs, _, _ := unstructured.NestedString(pv.Object, "spec", "claimRef", "namespace")
+			claimName, _, _ := unstructured.NestedString(pv.Object, "spec", "claimRef", "name")
+			if phase == "Bound" && claimName != "" {
+				pvcGVR := schema.GroupVersionResource{Version: "v1", Resource: "persistentvolumeclaims"}
+				pvc, err := s.kubeClient.Resource(pvcGVR).Namespace(claimNs).Get(ctx, claimName, metav1.GetOptions{})
+				if err == nil && pvc.GetDeletionTimestamp() == nil {
+					log.WithField("pvc", claimName).Info(
+						"not deleting resource definition, PVC still exists and is not being deleted",
+					)
+					return nil
+				}
+			}
+		}
+	}
+
 	log.Debug("checking for undeleted resources")
 
 	resources, err := s.client.Resources.GetAll(ctx, rdName)

--- a/pkg/client/linstor.go
+++ b/pkg/client/linstor.go
@@ -1288,7 +1288,7 @@ func (s *Linstor) VolFromSnap(ctx context.Context, snap *volume.Snapshot, vol *v
 		return err
 	}
 
-	if params.RelocateAfterSnapshotRestore {
+	if snapParams != nil && snapParams.RelocateAfterRestore {
 		logger.Debug("relocate resources to optimal nodes")
 
 		if err := s.relocateResources(ctx, vol.ID, rGroup.Name); err != nil {

--- a/pkg/client/linstor.go
+++ b/pkg/client/linstor.go
@@ -462,6 +462,14 @@ func (s *Linstor) Clone(ctx context.Context, vol, src *volume.Info, params *volu
 		return err
 	}
 
+	if params.RelocateAfterClone {
+		logger.Debug("relocate resources to optimal nodes")
+
+		if err := s.relocateResources(ctx, vol.ID, rGroup.Name); err != nil {
+			logger.WithError(err).Warn("resource relocation failed, volume is still usable")
+		}
+	}
+
 	logger.Debug("reconcile extra properties")
 
 	err = s.client.ResourceDefinitions.Modify(ctx, vol.ID, lapi.GenericPropsModify{OverrideProps: vol.Properties})
@@ -1280,6 +1288,14 @@ func (s *Linstor) VolFromSnap(ctx context.Context, snap *volume.Snapshot, vol *v
 		return err
 	}
 
+	if params.RelocateAfterSnapshotRestore {
+		logger.Debug("relocate resources to optimal nodes")
+
+		if err := s.relocateResources(ctx, vol.ID, rGroup.Name); err != nil {
+			logger.WithError(err).Warn("resource relocation failed, volume is still usable")
+		}
+	}
+
 	logger.Debug("reconcile extra properties")
 
 	err = s.client.ResourceDefinitions.Modify(ctx, vol.ID, lapi.GenericPropsModify{OverrideProps: vol.Properties})
@@ -1683,6 +1699,114 @@ func (s *Linstor) reconcileResourcePlacement(ctx context.Context, vol *volume.In
 	err = volumeScheduler.Create(ctx, vol.ID, params, topologies)
 	if err != nil {
 		return err
+	}
+
+	return nil
+}
+
+const propertyRelocationTriggered = "Aux/csi-relocation-triggered"
+
+// relocateResources migrates replicas from their current nodes to the nodes that
+// LINSTOR's autoplacer considers optimal. This is a best-effort, fire-and-forget
+// operation: migrate-disk API is asynchronous and the volume remains usable on its
+// current nodes even if relocation fails.
+func (s *Linstor) relocateResources(ctx context.Context, volID, rgName string) error {
+	logger := s.log.WithFields(logrus.Fields{
+		"volume":        volID,
+		"resourceGroup": rgName,
+	})
+
+	// Check if relocation was already triggered (idempotency guard).
+	rd, err := s.client.ResourceDefinitions.Get(ctx, volID)
+	if err != nil {
+		return fmt.Errorf("failed to get resource definition: %w", err)
+	}
+
+	if rd.Props[propertyRelocationTriggered] != "" {
+		logger.Debug("relocation already triggered, skipping")
+		return nil
+	}
+
+	// Get current diskful nodes.
+	resources, err := s.client.Resources.GetAll(ctx, volID)
+	if err != nil {
+		return fmt.Errorf("failed to list resources: %w", err)
+	}
+
+	currentNodes := util.DeployedDiskfullyNodes(resources)
+
+	// Query optimal placement from LINSTOR autoplacer.
+	sizeInfo, err := s.client.ResourceGroups.QuerySizeInfo(ctx, rgName, lapi.QuerySizeInfoRequest{})
+	if err != nil {
+		return fmt.Errorf("failed to query size info: %w", err)
+	}
+
+	if sizeInfo.SpaceInfo == nil || len(sizeInfo.SpaceInfo.NextSpawnResult) == 0 {
+		logger.Debug("no spawn result from query-size-info, skipping relocation")
+		return nil
+	}
+
+	// Build a map of optimal node -> storage pool.
+	optimalPools := make(map[string]string, len(sizeInfo.SpaceInfo.NextSpawnResult))
+	for _, r := range sizeInfo.SpaceInfo.NextSpawnResult {
+		optimalPools[r.NodeName] = r.StorPoolName
+	}
+
+	// Compute nodes to remove (current but not optimal) and nodes to add (optimal but not current).
+	var nodesToRemove, nodesToAdd []string
+
+	for _, node := range currentNodes {
+		if _, ok := optimalPools[node]; !ok {
+			nodesToRemove = append(nodesToRemove, node)
+		}
+	}
+
+	for _, r := range sizeInfo.SpaceInfo.NextSpawnResult {
+		if !slices.Contains(currentNodes, r.NodeName) {
+			nodesToAdd = append(nodesToAdd, r.NodeName)
+		}
+	}
+
+	// Only migrate min(remove, add) pairs.
+	pairs := min(len(nodesToRemove), len(nodesToAdd))
+	if pairs == 0 {
+		logger.Debug("no relocation needed, placement is already optimal")
+		return nil
+	}
+
+	logger.Infof("relocating %d replica(s): %v -> %v", pairs, nodesToRemove[:pairs], nodesToAdd[:pairs])
+
+	// Mark relocation as triggered before starting migrations.
+	err = s.client.ResourceDefinitions.Modify(ctx, volID, lapi.GenericPropsModify{
+		OverrideProps: map[string]string{propertyRelocationTriggered: "true"},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to set relocation property: %w", err)
+	}
+
+	// Migrate each pair sequentially (LINSTOR serializes at the RD level anyway).
+	for i := range pairs {
+		fromNode := nodesToRemove[i]
+		toNode := nodesToAdd[i]
+		storPool := optimalPools[toNode]
+
+		logger := logger.WithFields(logrus.Fields{"from": fromNode, "to": toNode, "storagePool": storPool})
+
+		logger.Info("creating diskless resource on target node")
+
+		err := s.client.Resources.MakeAvailable(ctx, volID, toNode, lapi.ResourceMakeAvailable{})
+		if err != nil {
+			logger.WithError(err).Warn("failed to create diskless on target, skipping this pair")
+			continue
+		}
+
+		logger.Info("initiating migrate-disk")
+
+		err = s.client.Resources.Migrate(ctx, volID, fromNode, toNode, storPool)
+		if err != nil {
+			logger.WithError(err).Warn("migrate-disk failed, skipping this pair")
+			continue
+		}
 	}
 
 	return nil

--- a/pkg/volume/parameter.go
+++ b/pkg/volume/parameter.go
@@ -139,11 +139,11 @@ func NewParameters(params map[string]string, topologyPrefix string) (Parameters,
 		Encryption:             false,
 		PlacementPolicy:        topology.AutoPlaceTopology,
 		Properties:             make(map[string]string),
-		NfsConfigTemplatePath:        "/etc/nfs-helper/default-config.tmpl",
-		NfsServiceName:               "linstor-csi-nfs",
-		NfsSquash:                    "no_root_squash",
-		NfsRecoveryVolumeBytes:       300 * 1024 * 1024,
-		RelocateAfterClone: false,
+		NfsConfigTemplatePath:  "/etc/nfs-helper/default-config.tmpl",
+		NfsServiceName:         "linstor-csi-nfs",
+		NfsSquash:              "no_root_squash",
+		NfsRecoveryVolumeBytes: 300 * 1024 * 1024,
+		RelocateAfterClone:     false,
 	}
 
 	for k, v := range params {

--- a/pkg/volume/parameter.go
+++ b/pkg/volume/parameter.go
@@ -51,7 +51,6 @@ const (
 	nfssquash
 	nfsrecoveryvolumesize
 	relocateafterclone
-	relocateaftersnapshotrestore
 )
 
 // Parameters configuration for linstor volumes.
@@ -122,8 +121,6 @@ type Parameters struct {
 	NfsRecoveryVolumeBytes int64
 	// RelocateAfterClone triggers asynchronous relocation of replicas to optimal nodes after cloning.
 	RelocateAfterClone bool
-	// RelocateAfterSnapshotRestore triggers asynchronous relocation of replicas to optimal nodes after snapshot restore.
-	RelocateAfterSnapshotRestore bool
 }
 
 const DefaultDisklessStoragePoolName = "DfltDisklessStorPool"
@@ -146,8 +143,7 @@ func NewParameters(params map[string]string, topologyPrefix string) (Parameters,
 		NfsServiceName:               "linstor-csi-nfs",
 		NfsSquash:                    "no_root_squash",
 		NfsRecoveryVolumeBytes:       300 * 1024 * 1024,
-		RelocateAfterClone:           true,
-		RelocateAfterSnapshotRestore: true,
+		RelocateAfterClone: false,
 	}
 
 	for k, v := range params {
@@ -302,13 +298,6 @@ func NewParameters(params map[string]string, topologyPrefix string) (Parameters,
 			}
 
 			p.RelocateAfterClone = val
-		case relocateaftersnapshotrestore:
-			val, err := strconv.ParseBool(v)
-			if err != nil {
-				return p, err
-			}
-
-			p.RelocateAfterSnapshotRestore = val
 		}
 	}
 

--- a/pkg/volume/parameter.go
+++ b/pkg/volume/parameter.go
@@ -50,6 +50,8 @@ const (
 	nfsservicename
 	nfssquash
 	nfsrecoveryvolumesize
+	relocateafterclone
+	relocateaftersnapshotrestore
 )
 
 // Parameters configuration for linstor volumes.
@@ -118,6 +120,10 @@ type Parameters struct {
 	// NfsRecoveryVolumeSize sets the volume size (in bytes) of the recovery volume used by the NFS server.
 	// Defaults to 300MiB.
 	NfsRecoveryVolumeBytes int64
+	// RelocateAfterClone triggers asynchronous relocation of replicas to optimal nodes after cloning.
+	RelocateAfterClone bool
+	// RelocateAfterSnapshotRestore triggers asynchronous relocation of replicas to optimal nodes after snapshot restore.
+	RelocateAfterSnapshotRestore bool
 }
 
 const DefaultDisklessStoragePoolName = "DfltDisklessStorPool"
@@ -136,10 +142,12 @@ func NewParameters(params map[string]string, topologyPrefix string) (Parameters,
 		Encryption:             false,
 		PlacementPolicy:        topology.AutoPlaceTopology,
 		Properties:             make(map[string]string),
-		NfsConfigTemplatePath:  "/etc/nfs-helper/default-config.tmpl",
-		NfsServiceName:         "linstor-csi-nfs",
-		NfsSquash:              "no_root_squash",
-		NfsRecoveryVolumeBytes: 300 * 1024 * 1024,
+		NfsConfigTemplatePath:        "/etc/nfs-helper/default-config.tmpl",
+		NfsServiceName:               "linstor-csi-nfs",
+		NfsSquash:                    "no_root_squash",
+		NfsRecoveryVolumeBytes:       300 * 1024 * 1024,
+		RelocateAfterClone:           true,
+		RelocateAfterSnapshotRestore: true,
 	}
 
 	for k, v := range params {
@@ -287,6 +295,20 @@ func NewParameters(params map[string]string, topologyPrefix string) (Parameters,
 			}
 
 			p.NfsRecoveryVolumeBytes = s.Value()
+		case relocateafterclone:
+			val, err := strconv.ParseBool(v)
+			if err != nil {
+				return p, err
+			}
+
+			p.RelocateAfterClone = val
+		case relocateaftersnapshotrestore:
+			val, err := strconv.ParseBool(v)
+			if err != nil {
+				return p, err
+			}
+
+			p.RelocateAfterSnapshotRestore = val
 		}
 	}
 

--- a/pkg/volume/paramkey_enumer.go
+++ b/pkg/volume/paramkey_enumer.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 )
 
-const _paramKeyName = "allowremotevolumeaccessautoplaceclientlistdisklessonremainingdisklessstoragepooldonotplacewithregexencryptionfsoptslayerlistmountoptsnodelistplacementcountplacementpolicyreplicasondifferentreplicasonsamesizekibstoragepoolpostmountxfsoptsresourcegroupusepvcnameoverprovisionxreplicasondifferentnfsconfigtemplatenfsservicenamenfssquashnfsrecoveryvolumesizerelocateafterclonerelocateaftersnapshotrestore"
+const _paramKeyName = "allowremotevolumeaccessautoplaceclientlistdisklessonremainingdisklessstoragepooldonotplacewithregexencryptionfsoptslayerlistmountoptsnodelistplacementcountplacementpolicyreplicasondifferentreplicasonsamesizekibstoragepoolpostmountxfsoptsresourcegroupusepvcnameoverprovisionxreplicasondifferentnfsconfigtemplatenfsservicenamenfssquashnfsrecoveryvolumesizerelocateafterclone"
 
-var _paramKeyIndex = [...]uint16{0, 23, 32, 42, 61, 80, 99, 109, 115, 124, 133, 141, 155, 170, 189, 203, 210, 221, 237, 250, 260, 273, 293, 310, 324, 333, 354, 372, 400}
+var _paramKeyIndex = [...]uint16{0, 23, 32, 42, 61, 80, 99, 109, 115, 124, 133, 141, 155, 170, 189, 203, 210, 221, 237, 250, 260, 273, 293, 310, 324, 333, 354, 372}
 
-const _paramKeyLowerName = "allowremotevolumeaccessautoplaceclientlistdisklessonremainingdisklessstoragepooldonotplacewithregexencryptionfsoptslayerlistmountoptsnodelistplacementcountplacementpolicyreplicasondifferentreplicasonsamesizekibstoragepoolpostmountxfsoptsresourcegroupusepvcnameoverprovisionxreplicasondifferentnfsconfigtemplatenfsservicenamenfssquashnfsrecoveryvolumesizerelocateafterclonerelocateaftersnapshotrestore"
+const _paramKeyLowerName = "allowremotevolumeaccessautoplaceclientlistdisklessonremainingdisklessstoragepooldonotplacewithregexencryptionfsoptslayerlistmountoptsnodelistplacementcountplacementpolicyreplicasondifferentreplicasonsamesizekibstoragepoolpostmountxfsoptsresourcegroupusepvcnameoverprovisionxreplicasondifferentnfsconfigtemplatenfsservicenamenfssquashnfsrecoveryvolumesizerelocateafterclone"
 
 func (i paramKey) String() string {
 	if i < 0 || i >= paramKey(len(_paramKeyIndex)-1) {
@@ -51,10 +51,9 @@ func _paramKeyNoOp() {
 	_ = x[nfssquash-(24)]
 	_ = x[nfsrecoveryvolumesize-(25)]
 	_ = x[relocateafterclone-(26)]
-	_ = x[relocateaftersnapshotrestore-(27)]
 }
 
-var _paramKeyValues = []paramKey{allowremotevolumeaccess, autoplace, clientlist, disklessonremaining, disklessstoragepool, donotplacewithregex, encryption, fsopts, layerlist, mountopts, nodelist, placementcount, placementpolicy, replicasondifferent, replicasonsame, sizekib, storagepool, postmountxfsopts, resourcegroup, usepvcname, overprovision, xreplicasondifferent, nfsconfigtemplate, nfsservicename, nfssquash, nfsrecoveryvolumesize, relocateafterclone, relocateaftersnapshotrestore}
+var _paramKeyValues = []paramKey{allowremotevolumeaccess, autoplace, clientlist, disklessonremaining, disklessstoragepool, donotplacewithregex, encryption, fsopts, layerlist, mountopts, nodelist, placementcount, placementpolicy, replicasondifferent, replicasonsame, sizekib, storagepool, postmountxfsopts, resourcegroup, usepvcname, overprovision, xreplicasondifferent, nfsconfigtemplate, nfsservicename, nfssquash, nfsrecoveryvolumesize, relocateafterclone}
 
 var _paramKeyNameToValueMap = map[string]paramKey{
 	_paramKeyName[0:23]:         allowremotevolumeaccess,
@@ -111,8 +110,6 @@ var _paramKeyNameToValueMap = map[string]paramKey{
 	_paramKeyLowerName[333:354]: nfsrecoveryvolumesize,
 	_paramKeyName[354:372]:      relocateafterclone,
 	_paramKeyLowerName[354:372]: relocateafterclone,
-	_paramKeyName[372:400]:      relocateaftersnapshotrestore,
-	_paramKeyLowerName[372:400]: relocateaftersnapshotrestore,
 }
 
 var _paramKeyNames = []string{
@@ -143,7 +140,6 @@ var _paramKeyNames = []string{
 	_paramKeyName[324:333],
 	_paramKeyName[333:354],
 	_paramKeyName[354:372],
-	_paramKeyName[372:400],
 }
 
 // paramKeyString retrieves an enum value from the enum constants string name.

--- a/pkg/volume/paramkey_enumer.go
+++ b/pkg/volume/paramkey_enumer.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 )
 
-const _paramKeyName = "allowremotevolumeaccessautoplaceclientlistdisklessonremainingdisklessstoragepooldonotplacewithregexencryptionfsoptslayerlistmountoptsnodelistplacementcountplacementpolicyreplicasondifferentreplicasonsamesizekibstoragepoolpostmountxfsoptsresourcegroupusepvcnameoverprovisionxreplicasondifferentnfsconfigtemplatenfsservicenamenfssquashnfsrecoveryvolumesize"
+const _paramKeyName = "allowremotevolumeaccessautoplaceclientlistdisklessonremainingdisklessstoragepooldonotplacewithregexencryptionfsoptslayerlistmountoptsnodelistplacementcountplacementpolicyreplicasondifferentreplicasonsamesizekibstoragepoolpostmountxfsoptsresourcegroupusepvcnameoverprovisionxreplicasondifferentnfsconfigtemplatenfsservicenamenfssquashnfsrecoveryvolumesizerelocateafterclonerelocateaftersnapshotrestore"
 
-var _paramKeyIndex = [...]uint16{0, 23, 32, 42, 61, 80, 99, 109, 115, 124, 133, 141, 155, 170, 189, 203, 210, 221, 237, 250, 260, 273, 293, 310, 324, 333, 354}
+var _paramKeyIndex = [...]uint16{0, 23, 32, 42, 61, 80, 99, 109, 115, 124, 133, 141, 155, 170, 189, 203, 210, 221, 237, 250, 260, 273, 293, 310, 324, 333, 354, 372, 400}
 
-const _paramKeyLowerName = "allowremotevolumeaccessautoplaceclientlistdisklessonremainingdisklessstoragepooldonotplacewithregexencryptionfsoptslayerlistmountoptsnodelistplacementcountplacementpolicyreplicasondifferentreplicasonsamesizekibstoragepoolpostmountxfsoptsresourcegroupusepvcnameoverprovisionxreplicasondifferentnfsconfigtemplatenfsservicenamenfssquashnfsrecoveryvolumesize"
+const _paramKeyLowerName = "allowremotevolumeaccessautoplaceclientlistdisklessonremainingdisklessstoragepooldonotplacewithregexencryptionfsoptslayerlistmountoptsnodelistplacementcountplacementpolicyreplicasondifferentreplicasonsamesizekibstoragepoolpostmountxfsoptsresourcegroupusepvcnameoverprovisionxreplicasondifferentnfsconfigtemplatenfsservicenamenfssquashnfsrecoveryvolumesizerelocateafterclonerelocateaftersnapshotrestore"
 
 func (i paramKey) String() string {
 	if i < 0 || i >= paramKey(len(_paramKeyIndex)-1) {
@@ -50,9 +50,11 @@ func _paramKeyNoOp() {
 	_ = x[nfsservicename-(23)]
 	_ = x[nfssquash-(24)]
 	_ = x[nfsrecoveryvolumesize-(25)]
+	_ = x[relocateafterclone-(26)]
+	_ = x[relocateaftersnapshotrestore-(27)]
 }
 
-var _paramKeyValues = []paramKey{allowremotevolumeaccess, autoplace, clientlist, disklessonremaining, disklessstoragepool, donotplacewithregex, encryption, fsopts, layerlist, mountopts, nodelist, placementcount, placementpolicy, replicasondifferent, replicasonsame, sizekib, storagepool, postmountxfsopts, resourcegroup, usepvcname, overprovision, xreplicasondifferent, nfsconfigtemplate, nfsservicename, nfssquash, nfsrecoveryvolumesize}
+var _paramKeyValues = []paramKey{allowremotevolumeaccess, autoplace, clientlist, disklessonremaining, disklessstoragepool, donotplacewithregex, encryption, fsopts, layerlist, mountopts, nodelist, placementcount, placementpolicy, replicasondifferent, replicasonsame, sizekib, storagepool, postmountxfsopts, resourcegroup, usepvcname, overprovision, xreplicasondifferent, nfsconfigtemplate, nfsservicename, nfssquash, nfsrecoveryvolumesize, relocateafterclone, relocateaftersnapshotrestore}
 
 var _paramKeyNameToValueMap = map[string]paramKey{
 	_paramKeyName[0:23]:         allowremotevolumeaccess,
@@ -107,6 +109,10 @@ var _paramKeyNameToValueMap = map[string]paramKey{
 	_paramKeyLowerName[324:333]: nfssquash,
 	_paramKeyName[333:354]:      nfsrecoveryvolumesize,
 	_paramKeyLowerName[333:354]: nfsrecoveryvolumesize,
+	_paramKeyName[354:372]:      relocateafterclone,
+	_paramKeyLowerName[354:372]: relocateafterclone,
+	_paramKeyName[372:400]:      relocateaftersnapshotrestore,
+	_paramKeyLowerName[372:400]: relocateaftersnapshotrestore,
 }
 
 var _paramKeyNames = []string{
@@ -136,6 +142,8 @@ var _paramKeyNames = []string{
 	_paramKeyName[310:324],
 	_paramKeyName[324:333],
 	_paramKeyName[333:354],
+	_paramKeyName[354:372],
+	_paramKeyName[372:400],
 }
 
 // paramKeyString retrieves an enum value from the enum constants string name.

--- a/pkg/volume/snapshot_params.go
+++ b/pkg/volume/snapshot_params.go
@@ -92,7 +92,7 @@ func NewSnapshotParameters(params, secrets map[string]string) (*SnapshotParamete
 			p.LinstorTargetClusterID = v
 		case "/linstor-target-storage-pool":
 			p.LinstorTargetStoragePool = v
-		case "/relocate-after-restore":
+		case "/relocateAfterRestore":
 			b, err := strconv.ParseBool(v)
 			if err != nil {
 				return nil, err

--- a/pkg/volume/snapshot_params.go
+++ b/pkg/volume/snapshot_params.go
@@ -35,6 +35,7 @@ type SnapshotParameters struct {
 	LinstorTargetUrl         string       `json:"linstor-target-url,omitempty"`
 	LinstorTargetClusterID   string       `json:"linstor-target-cluster-id,omitempty"`
 	LinstorTargetStoragePool string       `json:"linstor-target-storage-pool,omitempty"`
+	RelocateAfterRestore     bool         `json:"relocate-after-restore,omitempty"`
 }
 
 func NewSnapshotParameters(params, secrets map[string]string) (*SnapshotParameters, error) {
@@ -91,6 +92,13 @@ func NewSnapshotParameters(params, secrets map[string]string) (*SnapshotParamete
 			p.LinstorTargetClusterID = v
 		case "/linstor-target-storage-pool":
 			p.LinstorTargetStoragePool = v
+		case "/relocate-after-restore":
+			b, err := strconv.ParseBool(v)
+			if err != nil {
+				return nil, err
+			}
+
+			p.RelocateAfterRestore = b
 		default:
 			log.WithField("key", k).Warn("ignoring unknown snapshot parameter key")
 		}


### PR DESCRIPTION
## Summary

Before deleting a resource definition, check if the corresponding Kubernetes PV
is still Bound to a PVC that is not being deleted. This prevents accidental RD
deletion when resources are stuck in DELETING state.

## Problem

When DRBD resources get stuck in DELETING state (e.g. due to bitmap mismatch
after toggle-disk), `deleteResourceDefinitionAndGroupIfUnused()` checks only
whether all resources have the `FlagDelete` flag. If they do, it proceeds to
delete the entire resource definition -- even if the PVC is still active and
Bound.

This can lead to data loss: the PVC remains Bound, the VM continues running
with cached data, but the LINSTOR resource definition is deleted.

## Fix

Add a safety check at the beginning of `deleteResourceDefinitionAndGroupIfUnused()`:
query the Kubernetes API for the PV (by name, which matches the LINSTOR resource
name). If the PV exists, is not being deleted, and is Bound to a PVC that is also
not being deleted -- abort the RD deletion.

Uses the existing `dynamic.Interface` client pattern already used elsewhere in the
codebase.