### PR TITLE
feat(attach): force Protocol C on dual-attach for Protocol-A/B resources

### DIFF
--- a/pkg/client/linstor.go
+++ b/pkg/client/linstor.go
@@ -653,11 +653,35 @@ func (s *Linstor) Attach(ctx context.Context, volId, node string, rwxBlock bool)
 	}
 
 	if otherResInUse > 0 && rwxBlock {
-		rdPropsModify := lapi.GenericPropsModify{OverrideProps: map[string]string{
+		rdProps := map[string]string{
 			linstor.PropertyAllowTwoPrimaries: "yes",
-		}}
+		}
 
-		err = s.client.ResourceDefinitions.Modify(ctx, volId, rdPropsModify)
+		// DRBD requires Protocol C whenever allow-two-primaries is enabled.
+		// If the resource is configured with Protocol A or B (typically
+		// through its resource-group), drbdadm adjust on the satellites
+		// fails with "Protocol C required" (errno 139) and live migration
+		// cannot proceed. Override Protocol to C on the resource-definition
+		// itself so it applies to every connection (including diskless
+		// peers, e.g. a TieBreaker). The marker lets Detach revert exactly
+		// the override we installed without disturbing operator-set props.
+		proto, protoErr := s.getEffectiveDrbdProtocol(ctx, volId)
+		if protoErr != nil {
+			s.log.WithError(protoErr).WithField("volume", volId).
+				Warn("failed to determine effective DRBD protocol; skipping Protocol=C override for dual-attach")
+		} else if proto == "A" || proto == "B" {
+			s.log.WithFields(logrus.Fields{
+				"volume":   volId,
+				"protocol": proto,
+			}).Info("installing Protocol=C override on resource-definition for dual-attach")
+
+			rdProps[linstor.PropertyDrbdNetProtocol] = "C"
+			rdProps[linstor.PropertyCsiProtocolOverride] = "yes"
+		}
+
+		err = s.client.ResourceDefinitions.Modify(ctx, volId, lapi.GenericPropsModify{
+			OverrideProps: rdProps,
+		})
 		if err != nil {
 			return "", err
 		}
@@ -774,11 +798,26 @@ func (s *Linstor) Detach(ctx context.Context, volId, node string) error {
 	}
 
 	if resInUse == 1 {
-		rdPropsModify := lapi.GenericPropsModify{DeleteProps: []string{
-			linstor.PropertyAllowTwoPrimaries,
-		}}
+		deleteProps := []string{linstor.PropertyAllowTwoPrimaries}
 
-		err = s.client.ResourceDefinitions.Modify(ctx, volId, rdPropsModify)
+		// Drop the Protocol=C override only if Attach installed it (gated by
+		// our marker), so an operator-set Protocol property on the
+		// resource-definition is preserved.
+		rd, getErr := s.client.ResourceDefinitions.Get(ctx, volId)
+		if getErr != nil {
+			log.WithError(getErr).Warn("failed to fetch resource-definition props; skipping Protocol=C override removal")
+		} else if rd.Props[linstor.PropertyCsiProtocolOverride] != "" {
+			log.Info("removing Protocol=C override from resource-definition")
+
+			deleteProps = append(deleteProps,
+				linstor.PropertyDrbdNetProtocol,
+				linstor.PropertyCsiProtocolOverride,
+			)
+		}
+
+		err = s.client.ResourceDefinitions.Modify(ctx, volId, lapi.GenericPropsModify{
+			DeleteProps: deleteProps,
+		})
 		if err != nil {
 			return nil404(err)
 		}
@@ -803,6 +842,33 @@ func (s *Linstor) Detach(ctx context.Context, volId, node string) error {
 	log.Info("removing temporary resource")
 
 	return nil404(s.client.Resources.Delete(ctx, volId, node))
+}
+
+// getEffectiveDrbdProtocol returns the DRBD network protocol ("A", "B" or "C")
+// that LINSTOR will hand to drbdadm for the given resource. Resource-definition
+// properties take precedence; otherwise the value is inherited from the
+// resource-group. An empty string is returned when neither level sets the
+// property (LINSTOR's compiled-in default is "C").
+func (s *Linstor) getEffectiveDrbdProtocol(ctx context.Context, volId string) (string, error) {
+	rd, err := s.client.ResourceDefinitions.Get(ctx, volId)
+	if err != nil {
+		return "", err
+	}
+
+	if v, ok := rd.Props[linstor.PropertyDrbdNetProtocol]; ok {
+		return v, nil
+	}
+
+	if rd.ResourceGroupName == "" {
+		return "", nil
+	}
+
+	rg, err := s.client.ResourceGroups.Get(ctx, rd.ResourceGroupName)
+	if err != nil {
+		return "", err
+	}
+
+	return rg.Props[linstor.PropertyDrbdNetProtocol], nil
 }
 
 // CapacityBytes returns the amount of free space in the storage pool specified by the params and topology.

--- a/pkg/linstor/const.go
+++ b/pkg/linstor/const.go
@@ -44,6 +44,19 @@ const (
 	// PropertyAllowTwoPrimaries is DRBD option to allow second primary. Mainly used for live-migration.
 	PropertyAllowTwoPrimaries = lc.NamespcDrbdNetOptions + "/allow-two-primaries"
 
+	// PropertyDrbdNetProtocol is the DRBD network replication protocol option
+	// (A = async, B = semi-sync, C = sync). DRBD requires Protocol C whenever
+	// allow-two-primaries is enabled, otherwise drbdadm adjust fails with
+	// "Protocol C required" (errno 139).
+	PropertyDrbdNetProtocol = lc.NamespcDrbdNetOptions + "/protocol"
+
+	// PropertyCsiProtocolOverride marks a resource-connection where this driver
+	// has installed a temporary Protocol=C override to make a Protocol-A/B
+	// resource compatible with allow-two-primaries during live migration. The
+	// marker lets us safely remove only the overrides we set, without touching
+	// connection-level overrides installed by the operator.
+	PropertyCsiProtocolOverride = lc.NamespcAuxiliary + "/csi-protocol-override"
+
 	// CreatedForTemporaryDisklessAttach marks a resource as temporary, i.e. it should be removed after it is no longer
 	// needed.
 	CreatedForTemporaryDisklessAttach = "temporary-diskless-attach"


### PR DESCRIPTION
## Problem

DRBD rejects `allow-two-primaries=yes` on resources configured with Protocol A or B. `drbdadm adjust` fails with `Protocol C required` (errno 139), and any live migration of a KubeVirt VM whose volume sits on a Protocol-A/B resource ends up in a permanent evacuation loop.

This is a real-world setup: operators commonly opt into Protocol A on a per-resource-group basis (e.g. a "replicated-async" StorageClass) for async / WAN replication. That choice silently breaks every subsequent live migration of consumers of those volumes.

## Change

When `allow-two-primaries=yes` is installed on the resource-definition during a second Attach, also install `DrbdOptions/Net/protocol=C` as an override on the resource-definition itself — but only when the resource currently effectively uses Protocol A or B.

The override is set at the resource-definition level (rather than per resource-connection) so it applies to every connection — including connections to diskless peers like a TieBreaker, where a per-pair override would still leave the satellite's adjust failing on the unaltered connection.

A small `Aux/csi-protocol-override` marker is set alongside the protocol override so Detach can safely revert exactly the override we installed, without disturbing a Protocol property an operator may have set on the resource-definition themselves. Once `resInUse == 1` again, the override is dropped and the resource falls back to its resource-group default.

## Compatibility

- No behaviour change for resources that already use Protocol C (the common case).
- No behaviour change for resources that are never attached with allow-two-primaries.
- Idempotent: re-running Attach is a no-op once override is installed.
- Operator-set Protocol overrides on the resource-definition are preserved (gated by the Aux marker).

## Tests

- `go build ./...` clean
- `go vet ./pkg/...` clean
- `go test ./pkg/client/...` passes
- Verified end-to-end on a 3-node cluster (KubeVirt v1.6.3): VM with a PVC backed by a Protocol-A resource-group now live-migrates successfully in a single Attach, with the override installed during dual-attach and removed after Detach. Without the patch the same Attach fails on the satellite with `Protocol C required` and KubeVirt loops on evacuation.