### PR TITLE
disable provisioning of RWX volumes without DRBD layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - NFS export failed to set correct address type in IPv6 clusters.
 - Improve fsck check for already mounted filesystem.
 - No longer report the "published nodes" capability.
+- No longer provision RWX volumes without DRBD layer.
 
 ## [1.10.5] - 2025-12-16
 

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -36,6 +36,7 @@ import (
 	"time"
 
 	lc "github.com/LINBIT/golinstor"
+	"github.com/LINBIT/golinstor/devicelayerkind"
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
@@ -597,6 +598,14 @@ func (d Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) 
 		}
 
 		volumeBytes[1] = requiredBytes
+	}
+
+	if len(params.LayerList) > 0 && params.LayerList[0] != devicelayerkind.Drbd {
+		for _, c := range req.GetVolumeCapabilities() {
+			if c.GetAccessMode().GetMode() == csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER {
+				return nil, status.Errorf(codes.InvalidArgument, "ReadWriteMany volumes require a DRBD layer")
+			}
+		}
 	}
 
 	pvcName := req.GetParameters()[ParameterCsiPvcName]


### PR DESCRIPTION
RWX requires NFS controlled by DRBD Reactor, so we always need a DRBD layer for RWX volumes. For block volumes, we do not use NFS, but still without any replication, there is no use for RWX.