### PR TITLE
Monitor NFS export startup

### DIFF
--- a/cmd/nfs-helper/check-socket.go
+++ b/cmd/nfs-helper/check-socket.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func checkSocket(ctx context.Context, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("expected one argument: <resource-name>")
+	}
+
+	resource := args[0]
+
+	config, err := readMetadata(resource)
+	if err != nil {
+		return fmt.Errorf("failed to read resource metadata: %w", err)
+	}
+
+	addr := fmt.Sprintf("localhost:%d", config.Port)
+
+	log.WithField("addr", addr).Info("Waiting for NFS socket")
+
+	for {
+		conn, err := net.DialTimeout("tcp", addr, time.Second)
+		if err == nil {
+			conn.Close()
+			log.WithField("addr", addr).Info("NFS socket is ready")
+
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for NFS socket on %s: %w", addr, ctx.Err())
+		case <-time.After(time.Second):
+		}
+	}
+}

--- a/cmd/nfs-helper/check-socket.go
+++ b/cmd/nfs-helper/check-socket.go
@@ -25,8 +25,9 @@ func checkSocket(ctx context.Context, args []string) error {
 
 	log.WithField("addr", addr).Info("Waiting for NFS socket")
 
+	dialer := &net.Dialer{Timeout: 1 * time.Second}
 	for {
-		conn, err := net.DialTimeout("tcp", addr, time.Second)
+		conn, err := dialer.DialContext(ctx, "tcp", addr)
 		if err == nil {
 			conn.Close()
 			log.WithField("addr", addr).Info("NFS socket is ready")

--- a/cmd/nfs-helper/main.go
+++ b/cmd/nfs-helper/main.go
@@ -25,6 +25,8 @@ func run(ctx context.Context, args ...string) error {
 		return growfs(ctx, args[1:])
 	case "advertise":
 		return advertise(ctx, args[1:])
+	case "check-socket":
+		return checkSocket(ctx, args[1:])
 	default:
 		return fmt.Errorf("unknown command: %s", args[0])
 	}

--- a/nfs/service/nfs-ganesha@.service
+++ b/nfs/service/nfs-ganesha@.service
@@ -9,6 +9,7 @@ RuntimeDirectory=ganesha/%I
 StateDirectory=nfs/ganesha/%I
 ExecStartPre=/usr/bin/nfs-helper generate-ganesha-config %I ${RUNTIME_DIRECTORY}/ganesha.conf
 ExecStart=/usr/bin/ganesha.nfsd -I %f -f ${RUNTIME_DIRECTORY}/ganesha.conf -N NIV_EVENT -p ${RUNTIME_DIRECTORY}/ganesha.pid
+ExecStartPost=/usr/bin/nfs-helper check-socket %I
 
 RestrictNamespaces=yes
 LockPersonality=yes

--- a/nfs/service/nfs-ganesha@.service
+++ b/nfs/service/nfs-ganesha@.service
@@ -10,6 +10,7 @@ StateDirectory=nfs/ganesha/%I
 ExecStartPre=/usr/bin/nfs-helper generate-ganesha-config %I ${RUNTIME_DIRECTORY}/ganesha.conf
 ExecStart=/usr/bin/ganesha.nfsd -I %f -f ${RUNTIME_DIRECTORY}/ganesha.conf -N NIV_EVENT -p ${RUNTIME_DIRECTORY}/ganesha.pid
 ExecStartPost=/usr/bin/nfs-helper check-socket %I
+TimeoutStartSec=15s
 
 RestrictNamespaces=yes
 LockPersonality=yes


### PR DESCRIPTION
There have been reports of exports failing because ganesha somehow starts but does not create the right socket. So add a basic check that runs after the NFS server starts and verifies that it properly came up.

To be honest: I do not like this. This seems like a horrible hack to work around an issue that should not exist. But apparently, NFS servers are fickle beasts :/