### PR TITLE
fix(utils): match RWX PV lookup by CSI volumeHandle

### DIFF
--- a/pkg/utils/rwx_validation.go
+++ b/pkg/utils/rwx_validation.go
@@ -227,11 +227,9 @@ func findPersistentVolumeByVolumeID(ctx context.Context, kubeClient dynamic.Inte
 
 	for i := range pvList.Items {
 		volumeHandle, found, nestedErr := unstructured.NestedString(pvList.Items[i].Object, "spec", "csi", "volumeHandle")
-		if nestedErr != nil || !found || volumeHandle != volumeID {
-			continue
-		}
-
-		return &pvList.Items[i], nil
+	if volumeHandle == volumeID {
+	     return &pvList.Items[i], nil
+	}
 	}
 
 	return nil, fmt.Errorf("persistentvolume with volumeHandle %q not found", volumeID)

--- a/pkg/utils/rwx_validation.go
+++ b/pkg/utils/rwx_validation.go
@@ -56,8 +56,9 @@ func ValidateRWXBlockAttachment(ctx context.Context, kubeClient dynamic.Interfac
 		return "", nil
 	}
 
-	// Get PV to find PVC reference
-	pv, err := kubeClient.Resource(PVGVR).Get(ctx, volumeID, metav1.GetOptions{})
+	// Get PV to find PVC reference. The CSI volume handle is not guaranteed to match the PV object name,
+	// so fall back to scanning PVs for a matching spec.csi.volumeHandle.
+	pv, err := findPersistentVolumeByVolumeID(ctx, kubeClient, volumeID)
 	if err != nil {
 		log.WithError(err).Warn("cannot validate RWX attachment: failed to get PV")
 		return "", nil
@@ -209,6 +210,31 @@ func ValidateRWXBlockAttachment(ctx context.Context, kubeClient dynamic.Interfac
 	}).Debug("RWX block attachment validated: all pods belong to the same VM (likely live migration)")
 
 	return vmName, nil
+}
+
+func findPersistentVolumeByVolumeID(ctx context.Context, kubeClient dynamic.Interface, volumeID string) (*unstructured.Unstructured, error) {
+	pv, err := kubeClient.Resource(PVGVR).Get(ctx, volumeID, metav1.GetOptions{})
+	if err == nil {
+		if volumeHandle, found, nestedErr := unstructured.NestedString(pv.Object, "spec", "csi", "volumeHandle"); nestedErr == nil && found && volumeHandle == volumeID {
+			return pv, nil
+		}
+	}
+
+	pvList, err := kubeClient.Resource(PVGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range pvList.Items {
+		volumeHandle, found, nestedErr := unstructured.NestedString(pvList.Items[i].Object, "spec", "csi", "volumeHandle")
+		if nestedErr != nil || !found || volumeHandle != volumeID {
+			continue
+		}
+
+		return &pvList.Items[i], nil
+	}
+
+	return nil, fmt.Errorf("persistentvolume with volumeHandle %q not found", volumeID)
 }
 
 // GetVMNameFromPod extracts the VM name from a pod, handling both regular virt-launcher pods

--- a/pkg/utils/rwx_validation_test.go
+++ b/pkg/utils/rwx_validation_test.go
@@ -235,6 +235,33 @@ func TestValidateRWXBlockAttachmentPVNotFound(t *testing.T) {
 	assert.Empty(t, vmName)
 }
 
+func TestValidateRWXBlockAttachmentFindsPVByVolumeHandle(t *testing.T) {
+	scheme := runtime.NewScheme()
+
+	pv := createUnstructuredPV("different-pv-name", "default", "test-pvc")
+	pv.Object["spec"].(map[string]interface{})["csi"].(map[string]interface{})["volumeHandle"] = "test-volume-id"
+
+	objects := []runtime.Object{
+		pv,
+		createUnstructuredPod("virt-launcher-vm1-abc", "default", "test-pvc", map[string]string{KubeVirtVMLabel: "vm1"}, "Running"),
+		createUnstructuredPod("virt-launcher-vm2-xyz", "default", "test-pvc", map[string]string{KubeVirtVMLabel: "vm2"}, "Running"),
+	}
+
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		PodGVR: "PodList",
+		PVGVR:  "PersistentVolumeList",
+	}
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind, objects...)
+
+	logger := logrus.NewEntry(logrus.New())
+	logger.Logger.SetLevel(logrus.DebugLevel)
+
+	vmName, err := ValidateRWXBlockAttachment(context.Background(), client, logger, "test-volume-id")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "different VMs")
+	assert.Empty(t, vmName)
+}
+
 // createUnstructuredPod creates an unstructured pod object for testing.
 func createUnstructuredPod(name, namespace, pvcName string, labels map[string]string, phase string) *unstructured.Unstructured {
 	pod := &unstructured.Unstructured{


### PR DESCRIPTION
follow-up to #439

Bug
RWX block validation looks up the PV by `volumeID` as if that was the PV object name.
If `metadata.name` and `spec.csi.volumeHandle` differ, the check just misses the PV and bails. Kinda sneaky.

Fix
Fall back to listing PVs and match by `spec.csi.volumeHandle`.
Add a regression test for that case too.

Repro
1. Create a CSI PV where `metadata.name` is not equal to `spec.csi.volumeHandle`.
2. Bind it to a PVC used by 2 pods from different KubeVirt VMs.
3. On `master`, `ControllerPublishVolume` skips the RWX check, so the bad attach can slip through.
4. With this patch, the driver finds the PV by `volumeHandle` and returns `FailedPrecondition`.

Test
`go test ./...`
