### PR TITLE
fix: reclaim incremental S3 backups instead of failing to delete them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `snap.linstor.csi.linbit.com/max-increments` and
+  `snap.linstor.csi.linbit.com/full-snapshot-after` snapshot class parameters to
+  bound the length / age of incremental S3 backup chains, forcing a fresh full
+  backup so that older backups become reclaimable.
+
+### Fixed
+
+- Deletion of incremental S3 backups no longer fails permanently when a backup
+  is still the base of a newer increment. The delete is deferred and retried so
+  the chain drains newest-first instead of leaking backups forever.
+
 ## [1.11.2] - 2026-05-12
 
 ### Changed

--- a/examples/k8s/volume-snapshot-class.yaml
+++ b/examples/k8s/volume-snapshot-class.yaml
@@ -18,6 +18,12 @@ parameters:
   # Delete local copy of the snapshot after uploading completes
   snap.linstor.csi.linbit.com/delete-local: "true"
   snap.linstor.csi.linbit.com/allow-incremental: "false"
+  # When incremental backups are enabled, bound the chain so that older backups
+  # eventually become reclaimable. Start a fresh full backup once the chain has
+  # this many increments (omit or 0 = no limit)...
+  # snap.linstor.csi.linbit.com/max-increments: "10"
+  # ...and/or once the chain's full backup is older than this duration.
+  # snap.linstor.csi.linbit.com/full-snapshot-after: "168h"
   snap.linstor.csi.linbit.com/s3-bucket: snapshot-bucket
   snap.linstor.csi.linbit.com/s3-endpoint: s3.us-west-1.amazonaws.com
   snap.linstor.csi.linbit.com/s3-signing-region: us-west-1

--- a/pkg/client/linstor.go
+++ b/pkg/client/linstor.go
@@ -1033,10 +1033,27 @@ func (s *Linstor) reconcileBackup(ctx context.Context, id string, params *volume
 		}
 
 		if info == nil {
+			incremental := params.AllowIncremental
+
+			// Bound the chain length/age when requested: forcing a fresh full
+			// starts a new chain so older backups eventually become reclaimable.
+			if incremental && (params.MaxIncrements > 0 || params.FullSnapshotAfter > 0) {
+				forceFull, err := s.backupChainExhausted(ctx, params, sourceVolId)
+				if err != nil {
+					return nil, err
+				}
+
+				if forceFull {
+					log.WithField("resource", sourceVolId).Info("incremental backup chain limit reached, forcing a full backup")
+
+					incremental = false
+				}
+			}
+
 			_, err := s.client.Backup.Create(ctx, params.RemoteName, lapi.BackupCreate{
 				RscName:     sourceVolId,
 				SnapName:    id,
-				Incremental: params.AllowIncremental,
+				Incremental: incremental,
 			})
 			if err != nil {
 				return nil, fmt.Errorf("error creating S3 backup: %w", err)
@@ -1095,6 +1112,128 @@ func (s *Linstor) reconcileBackup(ctx context.Context, id string, params *volume
 	default:
 		return nil, fmt.Errorf("unsupported snapshot type '%s', don't know how to create a backup", params.Type)
 	}
+}
+
+// backupChainExhausted reports whether the next S3 backup of rscName should be a
+// full backup instead of an incremental, based on the MaxIncrements and
+// FullSnapshotAfter snapshot parameters. It reconstructs the current incremental
+// chain from the backups already present on the remote (following based_on_id)
+// and returns true once the chain has at least MaxIncrements increments or its
+// full backup is older than FullSnapshotAfter. It returns false when there are
+// no backups yet (the next backup is full regardless).
+func (s *Linstor) backupChainExhausted(ctx context.Context, params *volume.SnapshotParameters, rscName string) (bool, error) {
+	backups, err := s.client.Backup.GetAll(ctx, params.RemoteName, rscName, "")
+	if err != nil {
+		if lapi.IsApiCallError(err, lapiconsts.FailInvldRemoteName) {
+			// No remote yet -> nothing to base an incremental on.
+			return false, nil
+		}
+
+		return false, fmt.Errorf("failed to list backups while determining incremental chain length: %w", err)
+	}
+
+	if backups == nil || len(backups.Linstor) == 0 {
+		return false, nil
+	}
+
+	increments, fullStart := incrementChainLength(backups.Linstor, rscName)
+
+	if params.MaxIncrements > 0 && increments >= params.MaxIncrements {
+		return true, nil
+	}
+
+	if params.FullSnapshotAfter > 0 && !fullStart.IsZero() && time.Since(fullStart) >= params.FullSnapshotAfter {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// referencedBackupIDs returns the set of backup IDs that are the base of another
+// (newer) incremental backup in byID. A backup in this set must not be deleted
+// on its own, as the increment based on it would be left dangling.
+//
+// Note that "based_on_id" carries a ".meta" suffix that the backup ID / map key
+// does not, so it has to be stripped before comparing (a quirk of the LINSTOR
+// backup REST API).
+func referencedBackupIDs(byID map[string]lapi.Backup) map[string]bool {
+	referenced := make(map[string]bool, len(byID))
+
+	for id := range byID {
+		if base := byID[id].BasedOnId; base != "" {
+			referenced[strings.TrimSuffix(base, ".meta")] = true
+		}
+	}
+
+	return referenced
+}
+
+// incrementChainLength reconstructs the current incremental backup chain for
+// rscName from byID and returns the number of increments in it (0 for a
+// full-only chain) together with the start time of the chain's full backup. A
+// new backup is based on the most recently completed backup, so the chain is
+// walked back from there following based_on_id.
+func incrementChainLength(byID map[string]lapi.Backup, rscName string) (int, time.Time) {
+	var (
+		leafID string
+		leafTS time.Time
+	)
+
+	for id := range byID {
+		b := byID[id]
+		// Only consider completed backups of this resource: a new incremental is
+		// based on the most recent successful backup, so in-progress or failed
+		// entries must not be picked as the chain leaf or skew its length.
+		if b.OriginRsc != rscName || !b.Success {
+			continue
+		}
+
+		ts := backupTimestamp(&b)
+		if leafID == "" || ts.After(leafTS) {
+			leafID, leafTS = id, ts
+		}
+	}
+
+	if leafID == "" {
+		return 0, time.Time{}
+	}
+
+	increments := 0
+	fullStart := time.Time{}
+	seen := make(map[string]bool, len(byID))
+
+	for cur := leafID; cur != "" && !seen[cur]; {
+		seen[cur] = true
+
+		b, ok := byID[cur]
+		if !ok {
+			break
+		}
+
+		if b.BasedOnId == "" {
+			fullStart = backupTimestamp(&b)
+			break
+		}
+
+		increments++
+		cur = strings.TrimSuffix(b.BasedOnId, ".meta")
+	}
+
+	return increments, fullStart
+}
+
+// backupTimestamp returns the most meaningful timestamp for ordering backups,
+// preferring the finished time and falling back to the start time.
+func backupTimestamp(b *lapi.Backup) time.Time {
+	if b.FinishedTimestamp != nil {
+		return b.FinishedTimestamp.Time
+	}
+
+	if b.StartTimestamp != nil {
+		return b.StartTimestamp.Time
+	}
+
+	return time.Time{}
 }
 
 func (s *Linstor) ReconcileRemote(ctx context.Context, params *volume.SnapshotParameters) error {
@@ -1174,13 +1313,22 @@ func (s *Linstor) SnapDelete(ctx context.Context, snap *volume.SnapshotId) error
 	if snap.Type == volume.SnapshotTypeS3 {
 		log.WithField("remote", snap.Remote).Debug("deleting backup from remote")
 
-		backups, err := s.client.Backup.GetAll(ctx, snap.Remote, snap.SourceName, snap.SnapshotName)
+		// List all backups for the resource (not just this snapshot's): an
+		// incremental is "based on" an earlier backup, and LINSTOR refuses to
+		// delete one another increment still depends on, so we need the full set.
+		backups, err := s.client.Backup.GetAll(ctx, snap.Remote, snap.SourceName, "")
 		if err != nil && !lapi.IsApiCallError(err, lapiconsts.FailInvldRemoteName) {
 			// Ignore errors caused by missing remotes: no remote -> no snapshots to delete.
 			return fmt.Errorf("failed to list backups for snapshot %s: %w", snap.String(), err)
 		}
 
 		if backups != nil {
+			// Build the set of backup IDs that are the base of another (newer)
+			// incremental backup.
+			referenced := referencedBackupIDs(backups.Linstor)
+
+			// Collect the backups belonging to the snapshot we are deleting.
+			var ownIDs []string
 			for id := range backups.Linstor {
 				// LINSTOR may return some extra results
 				if backups.Linstor[id].OriginRsc != snap.SourceName || backups.Linstor[id].OriginSnap != snap.SnapshotName {
@@ -1188,6 +1336,24 @@ func (s *Linstor) SnapDelete(ctx context.Context, snap *volume.SnapshotId) error
 					continue
 				}
 
+				ownIDs = append(ownIDs, id)
+			}
+
+			// If a backup is still the base of another increment, deleting it
+			// would need a cascade that also drops the increments we want to keep.
+			// Defer instead by returning a retryable error (this also skips the
+			// local cleanup below); the external-snapshotter retries until the
+			// dependents are gone and the chain drains newest-first.
+			for _, id := range ownIDs {
+				if referenced[id] {
+					log.WithField("remote_id", id).Info("backup is still the base of a newer incremental backup, deferring deletion")
+
+					return fmt.Errorf("backup %s for snapshot %s is still the base of a newer incremental backup; "+
+						"deferring deletion until the dependent backups are removed", id, snap.String())
+				}
+			}
+
+			for _, id := range ownIDs {
 				err := s.client.Backup.DeleteAll(ctx, snap.Remote, lapi.BackupDeleteOpts{
 					ID: id,
 				})

--- a/pkg/client/linstor_test.go
+++ b/pkg/client/linstor_test.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	lapiconsts "github.com/LINBIT/golinstor"
 	lapi "github.com/LINBIT/golinstor/client"
@@ -574,6 +575,126 @@ func TestGetSnapshotRemoteAndReadiness(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, tcase.expectedRemote, remote)
 			assert.Equal(t, tcase.expectedReady, ready)
+		})
+	}
+}
+
+// backup is a small helper to build a completed lapi.Backup with the fields the
+// chain logic cares about. finished is minutes since an arbitrary epoch.
+func backup(id, rsc, basedOn string, finishedMin int) lapi.Backup {
+	ts := time.Date(2026, 1, 1, 0, finishedMin, 0, 0, time.UTC)
+
+	return lapi.Backup{
+		Id:                id,
+		OriginRsc:         rsc,
+		BasedOnId:         basedOn,
+		Success:           true,
+		FinishedTimestamp: &lapi.TimeStampMs{Time: ts},
+	}
+}
+
+func TestReferencedBackupIDs(t *testing.T) {
+	t.Parallel()
+
+	const rsc = "pvc-1"
+
+	// full <- inc1 <- inc2. based_on_id carries a ".meta" suffix the id does not.
+	full := backup("pvc-1_back_001^snapA", rsc, "", 0)
+	inc1 := backup("pvc-1_back_002^snapB", rsc, "pvc-1_back_001^snapA.meta", 1)
+	inc2 := backup("pvc-1_back_003^snapC", rsc, "pvc-1_back_002^snapB.meta", 2)
+
+	byID := map[string]lapi.Backup{full.Id: full, inc1.Id: inc1, inc2.Id: inc2}
+
+	referenced := referencedBackupIDs(byID)
+
+	assert.True(t, referenced[full.Id], "full is the base of inc1, must be referenced")
+	assert.True(t, referenced[inc1.Id], "inc1 is the base of inc2, must be referenced")
+	assert.False(t, referenced[inc2.Id], "inc2 is the leaf, must not be referenced")
+	assert.Len(t, referenced, 2)
+}
+
+func TestReferencedBackupIDs_FullOnly(t *testing.T) {
+	t.Parallel()
+
+	full := backup("pvc-1_back_001^snapA", "pvc-1", "", 0)
+	referenced := referencedBackupIDs(map[string]lapi.Backup{full.Id: full})
+
+	assert.Empty(t, referenced, "a lone full backup references nothing")
+}
+
+func TestIncrementChainLength(t *testing.T) {
+	t.Parallel()
+
+	const rsc = "pvc-1"
+
+	full := backup("pvc-1_back_001^snapA", rsc, "", 0)
+	inc1 := backup("pvc-1_back_002^snapB", rsc, "pvc-1_back_001^snapA.meta", 5)
+	inc2 := backup("pvc-1_back_003^snapC", rsc, "pvc-1_back_002^snapB.meta", 10)
+
+	cases := []struct {
+		name           string
+		byID           map[string]lapi.Backup
+		wantIncrements int
+		wantFull       bool
+	}{
+		{
+			name:           "empty",
+			byID:           map[string]lapi.Backup{},
+			wantIncrements: 0,
+			wantFull:       false,
+		},
+		{
+			name:           "full only",
+			byID:           map[string]lapi.Backup{full.Id: full},
+			wantIncrements: 0,
+			wantFull:       true,
+		},
+		{
+			name:           "full + 1 increment",
+			byID:           map[string]lapi.Backup{full.Id: full, inc1.Id: inc1},
+			wantIncrements: 1,
+			wantFull:       true,
+		},
+		{
+			name:           "full + 2 increments",
+			byID:           map[string]lapi.Backup{full.Id: full, inc1.Id: inc1, inc2.Id: inc2},
+			wantIncrements: 2,
+			wantFull:       true,
+		},
+		{
+			name:           "other resource ignored",
+			byID:           map[string]lapi.Backup{full.Id: full, "other": backup("other_back_001^x", "pvc-2", "", 99)},
+			wantIncrements: 0,
+			wantFull:       true,
+		},
+		{
+			name: "in-progress backup ignored as leaf",
+			byID: map[string]lapi.Backup{
+				full.Id: full,
+				inc1.Id: inc1,
+				// A newer but not-yet-successful incremental must not be counted.
+				"pvc-1_back_999^snapInflight": func() lapi.Backup {
+					b := backup("pvc-1_back_999^snapInflight", rsc, "pvc-1_back_002^snapB.meta", 60)
+					b.Success = false
+					b.Shipping = true
+
+					return b
+				}(),
+			},
+			wantIncrements: 1,
+			wantFull:       true,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			increments, fullStart := incrementChainLength(tt.byID, rsc)
+			assert.Equal(t, tt.wantIncrements, increments)
+			assert.Equal(t, tt.wantFull, !fullStart.IsZero(), "full start time present")
+
+			if tt.wantFull {
+				assert.Equal(t, full.FinishedTimestamp.Time, fullStart)
+			}
 		})
 	}
 }

--- a/pkg/volume/snapshot_params.go
+++ b/pkg/volume/snapshot_params.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 
@@ -22,19 +23,21 @@ const (
 )
 
 type SnapshotParameters struct {
-	Type                     SnapshotType `json:"type,omitempty"`
-	AllowIncremental         bool         `json:"allow-incremental"`
-	RemoteName               string       `json:"remote-name,omitempty"`
-	DeleteLocal              bool         `json:"delete-local,omitempty"`
-	S3Endpoint               string       `json:"s3-endpoint,omitempty"`
-	S3Bucket                 string       `json:"s3-bucket,omitempty"`
-	S3SigningRegion          string       `json:"s3-signing-region,omitempty"`
-	S3UsePathStyle           bool         `json:"s3-use-path-style"`
-	S3AccessKey              string       `json:"-"`
-	S3SecretKey              string       `json:"-"`
-	LinstorTargetUrl         string       `json:"linstor-target-url,omitempty"`
-	LinstorTargetClusterID   string       `json:"linstor-target-cluster-id,omitempty"`
-	LinstorTargetStoragePool string       `json:"linstor-target-storage-pool,omitempty"`
+	Type                     SnapshotType  `json:"type,omitempty"`
+	AllowIncremental         bool          `json:"allow-incremental"`
+	MaxIncrements            int           `json:"max-increments,omitempty"`
+	FullSnapshotAfter        time.Duration `json:"full-snapshot-after,omitempty"`
+	RemoteName               string        `json:"remote-name,omitempty"`
+	DeleteLocal              bool          `json:"delete-local,omitempty"`
+	S3Endpoint               string        `json:"s3-endpoint,omitempty"`
+	S3Bucket                 string        `json:"s3-bucket,omitempty"`
+	S3SigningRegion          string        `json:"s3-signing-region,omitempty"`
+	S3UsePathStyle           bool          `json:"s3-use-path-style"`
+	S3AccessKey              string        `json:"-"`
+	S3SecretKey              string        `json:"-"`
+	LinstorTargetUrl         string        `json:"linstor-target-url,omitempty"`
+	LinstorTargetClusterID   string        `json:"linstor-target-cluster-id,omitempty"`
+	LinstorTargetStoragePool string        `json:"linstor-target-storage-pool,omitempty"`
 }
 
 func NewSnapshotParameters(params, secrets map[string]string) (*SnapshotParameters, error) {
@@ -70,6 +73,28 @@ func NewSnapshotParameters(params, secrets map[string]string) (*SnapshotParamete
 			}
 
 			p.AllowIncremental = b
+		case "/max-increments":
+			n, err := strconv.Atoi(v)
+			if err != nil {
+				return nil, fmt.Errorf("invalid %s%s: %w", linstor.SnapshotParameterNamespace, k, err)
+			}
+
+			if n < 0 {
+				return nil, fmt.Errorf("%s%s must not be negative", linstor.SnapshotParameterNamespace, k)
+			}
+
+			p.MaxIncrements = n
+		case "/full-snapshot-after":
+			d, err := time.ParseDuration(v)
+			if err != nil {
+				return nil, fmt.Errorf("invalid %s%s: %w", linstor.SnapshotParameterNamespace, k, err)
+			}
+
+			if d < 0 {
+				return nil, fmt.Errorf("%s%s must not be negative", linstor.SnapshotParameterNamespace, k)
+			}
+
+			p.FullSnapshotAfter = d
 		case "/remote-name":
 			p.RemoteName = v
 		case "/s3-endpoint":
@@ -115,6 +140,8 @@ func (s *SnapshotParameters) String() string {
 	return fmt.Sprint(SnapshotParameters{
 		Type:                     s.Type,
 		AllowIncremental:         s.AllowIncremental,
+		MaxIncrements:            s.MaxIncrements,
+		FullSnapshotAfter:        s.FullSnapshotAfter,
 		RemoteName:               s.RemoteName,
 		S3Endpoint:               s.S3Endpoint,
 		S3Bucket:                 s.S3Bucket,

--- a/pkg/volume/snapshot_params_test.go
+++ b/pkg/volume/snapshot_params_test.go
@@ -3,6 +3,7 @@ package volume_test
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -50,6 +51,41 @@ func TestNewSnapshotParameters(t *testing.T) {
 				S3SecretKey:      "password",
 				S3UsePathStyle:   true,
 			},
+		},
+		{
+			name: "s3-with-chain-bounds",
+			rawParameters: map[string]string{
+				linstor.SnapshotParameterNamespace + "/type":                "S3",
+				linstor.SnapshotParameterNamespace + "/allow-incremental":   "true",
+				linstor.SnapshotParameterNamespace + "/remote-name":         "my-remote",
+				linstor.SnapshotParameterNamespace + "/max-increments":      "10",
+				linstor.SnapshotParameterNamespace + "/full-snapshot-after": "168h",
+			},
+			expected: &volume.SnapshotParameters{
+				Type:              volume.SnapshotTypeS3,
+				RemoteName:        "my-remote",
+				AllowIncremental:  true,
+				MaxIncrements:     10,
+				FullSnapshotAfter: 168 * time.Hour,
+			},
+		},
+		{
+			name: "s3-invalid-max-increments",
+			rawParameters: map[string]string{
+				linstor.SnapshotParameterNamespace + "/type":           "S3",
+				linstor.SnapshotParameterNamespace + "/remote-name":    "my-remote",
+				linstor.SnapshotParameterNamespace + "/max-increments": "-1",
+			},
+			expectedErr: fmt.Sprintf("%s/max-increments must not be negative", linstor.SnapshotParameterNamespace),
+		},
+		{
+			name: "s3-invalid-full-snapshot-after",
+			rawParameters: map[string]string{
+				linstor.SnapshotParameterNamespace + "/type":                "S3",
+				linstor.SnapshotParameterNamespace + "/remote-name":         "my-remote",
+				linstor.SnapshotParameterNamespace + "/full-snapshot-after": "not-a-duration",
+			},
+			expectedErr: fmt.Sprintf("invalid %s/full-snapshot-after: time: invalid duration \"not-a-duration\"", linstor.SnapshotParameterNamespace),
 		},
 		{
 			name: "s3-without-name",


### PR DESCRIPTION
## Problem

Closes #324.

With `allow-incremental: "true"` on an S3 `VolumeSnapshotClass`, LINSTOR ships a full backup followed by a chain of incrementals. When an old backup expires the driver is asked to delete it, but LINSTOR refuses because it is the *base* of a later incremental:

```
... should be deleted, but at least ... is referencing it. Use --cascading to delete recursively
```

The delete never succeeds, so nothing in the chain is ever reclaimed — reported downstream as unbounded snapshot growth.

## Changes

**1. Defer deletion of a still-referenced base.** `SnapDelete` now lists all of the resource's backups and, if the one being deleted is still the base of another increment (`based_on_id`), returns a retryable error instead of failing. The
external-snapshotter retries, so the chain drains newest-first with no orphaned data and no cascading delete of increments we want to keep. (`based_on_id` carries a `.meta` suffix the backup id does not, which is stripped before comparing.)

**2. Bound the chain (opt-in).** Two new parameters force a fresh full backup so old chains become reclaimable under rolling retention:

| Parameter | Meaning |
|---|---|
| `snap.linstor.csi.linbit.com/max-increments` | start a new full once the chain has this many increments (unset/`0` = no limit) |
| `snap.linstor.csi.linbit.com/full-snapshot-after` | force a full once the chain's full backup is older than this duration |

Without this, a retained newer increment pins the chain back to the original full and nothing is reclaimed.

## Testing

- Unit tests for leaf detection (incl. the `.meta` suffix), chain-length calculation (incl. in-progress/failed backups), and parameter parsing.
- Manually verified against LINSTOR + MinIO: reproduced the issue, confirmed the chain drains to zero with the fix, and exercised both bounding parameters and incremental restore.

## Open questions

- Default for `max-increments`: opt-in (as here) vs. a sensible default-on value so a stock incremental schedule self-reclaims — §1 alone does not bound steady-state growth.
- Deferral signal: retryable error (as here) vs. another mechanism so the `VolumeSnapshotContent` is not held open during the overhang.

## Compatibility

Requires a LINSTOR backup API that populates `based_on_id`. No new RBAC, CRDs, or dependencies; behaviour is unchanged for full-only backups and any backup with no dependents.