### PR TITLE
Improve test stability

### DIFF
--- a/cmd/linstor-csi/linstor-csi.go
+++ b/cmd/linstor-csi/linstor-csi.go
@@ -19,12 +19,15 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"flag"
 	"net/http"
 	"net/url"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	linstor "github.com/LINBIT/golinstor"
@@ -142,7 +145,6 @@ func main() {
 
 	opts := []func(*driver.Driver) error{
 		driver.Assignments(linstorClient),
-		driver.Endpoint(*csiEndpoint),
 		driver.LogLevel(*logLevel),
 		driver.LogOut(logOut),
 		driver.Mounter(linstorClient),
@@ -179,10 +181,15 @@ func main() {
 		log.Fatal(err)
 	}
 
-	//nolint:errcheck
-	defer drv.Stop()
+	listener, err := driver.Listen(*csiEndpoint)
+	if err != nil {
+		log.Fatal(err)
+	}
 
-	if err := drv.Run(); err != nil {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	if err := drv.Serve(ctx, listener); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -315,7 +315,7 @@ func DisableRWXBlockValidation() func(*Driver) error {
 }
 
 // GetPluginInfo https://github.com/container-storage-interface/spec/blob/v1.9.0/spec.md#getplugininfo
-func (d Driver) GetPluginInfo(ctx context.Context, req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {
+func (d *Driver) GetPluginInfo(ctx context.Context, req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {
 	return &csi.GetPluginInfoResponse{
 		Name:          d.name,
 		VendorVersion: d.version,
@@ -323,7 +323,7 @@ func (d Driver) GetPluginInfo(ctx context.Context, req *csi.GetPluginInfoRequest
 }
 
 // GetPluginCapabilities https://github.com/container-storage-interface/spec/blob/v1.9.0/spec.md#getplugincapabilities
-func (d Driver) GetPluginCapabilities(ctx context.Context, req *csi.GetPluginCapabilitiesRequest) (*csi.GetPluginCapabilitiesResponse, error) {
+func (d *Driver) GetPluginCapabilities(ctx context.Context, req *csi.GetPluginCapabilitiesRequest) (*csi.GetPluginCapabilitiesResponse, error) {
 	return &csi.GetPluginCapabilitiesResponse{
 		Capabilities: []*csi.PluginCapability{
 			{Type: &csi.PluginCapability_Service_{
@@ -351,22 +351,22 @@ func (d Driver) GetPluginCapabilities(ctx context.Context, req *csi.GetPluginCap
 }
 
 // Probe https://github.com/container-storage-interface/spec/blob/v1.9.0/spec.md#probe
-func (d Driver) Probe(ctx context.Context, req *csi.ProbeRequest) (*csi.ProbeResponse, error) {
+func (d *Driver) Probe(ctx context.Context, req *csi.ProbeRequest) (*csi.ProbeResponse, error) {
 	return &csi.ProbeResponse{}, nil
 }
 
 // NodeStageVolume https://github.com/container-storage-interface/spec/blob/v1.9.0/spec.md#nodestagevolume
-func (d Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
+func (d *Driver) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "")
 }
 
 // NodeUnstageVolume https://github.com/container-storage-interface/spec/blob/v1.9.0/spec.md#nodeunstagevolume
-func (d Driver) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
+func (d *Driver) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "")
 }
 
 // NodePublishVolume https://github.com/container-storage-interface/spec/blob/v1.9.0/spec.md#nodepublishvolume
-func (d Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
+func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest) (*csi.NodePublishVolumeResponse, error) {
 	if req.GetVolumeId() == "" {
 		return &csi.NodePublishVolumeResponse{}, missingAttr("NodePublishVolume", req.GetVolumeId(), "VolumeId")
 	}
@@ -465,7 +465,7 @@ func (d Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolum
 }
 
 // NodeUnpublishVolume https://github.com/container-storage-interface/spec/blob/v1.9.0/spec.md#nodeunpublishvolume
-func (d Driver) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
+func (d *Driver) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublishVolumeRequest) (*csi.NodeUnpublishVolumeResponse, error) {
 	if req.GetVolumeId() == "" {
 		return nil, missingAttr("NodeUnpublishVolume", req.GetVolumeId(), "VolumeId")
 	}
@@ -483,7 +483,7 @@ func (d Driver) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublishV
 }
 
 // NodeGetVolumeStats https://github.com/container-storage-interface/spec/blob/v1.9.0/spec.md#nodegetvolumestats
-func (d Driver) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
+func (d *Driver) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
 	if req.GetVolumeId() == "" {
 		return nil, missingAttr("NodeGetVolumeStats", req.GetVolumeId(), "VolumeId")
 	}
@@ -525,7 +525,7 @@ func (d Driver) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeSt
 }
 
 // NodeGetCapabilities https://github.com/container-storage-interface/spec/blob/v1.9.0/spec.md#nodegetcapabilities
-func (d Driver) NodeGetCapabilities(context.Context, *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, error) {
+func (d *Driver) NodeGetCapabilities(context.Context, *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, error) {
 	return &csi.NodeGetCapabilitiesResponse{
 		Capabilities: []*csi.NodeServiceCapability{
 			{
@@ -547,7 +547,7 @@ func (d Driver) NodeGetCapabilities(context.Context, *csi.NodeGetCapabilitiesReq
 }
 
 // NodeGetInfo https://github.com/container-storage-interface/spec/blob/v1.9.0/spec.md#nodegetinfo
-func (d Driver) NodeGetInfo(ctx context.Context, _ *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
+func (d *Driver) NodeGetInfo(ctx context.Context, _ *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
 	topology, err := d.NodeInformer.GetNodeTopologies(ctx, d.nodeID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve node topology: %w", err)
@@ -561,7 +561,7 @@ func (d Driver) NodeGetInfo(ctx context.Context, _ *csi.NodeGetInfoRequest) (*cs
 }
 
 // CreateVolume https://github.com/container-storage-interface/spec/blob/v1.9.0/spec.md#createvolume
-func (d Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
+func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
 	if req.GetName() == "" {
 		return nil, missingAttr("CreateVolume", req.GetName(), "Name")
 	}
@@ -711,7 +711,7 @@ func (d Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) 
 }
 
 // DeleteVolume https://github.com/container-storage-interface/spec/blob/v1.9.0/spec.md#deletevolume
-func (d Driver) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest) (*csi.DeleteVolumeResponse, error) {
+func (d *Driver) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest) (*csi.DeleteVolumeResponse, error) {
 	if req.GetVolumeId() == "" {
 		return nil, missingAttr("DeleteVolume", req.GetVolumeId(), "VolumeId")
 	}
@@ -730,7 +730,7 @@ func (d Driver) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest) 
 }
 
 // ControllerPublishVolume https://github.com/container-storage-interface/spec/blob/v1.9.0/spec.md#controllerpublishvolume
-func (d Driver) ControllerPublishVolume(ctx context.Context, req *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error) {
+func (d *Driver) ControllerPublishVolume(ctx context.Context, req *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error) {
 	if req.GetVolumeId() == "" {
 		return nil, missingAttr("ControllerPublishVolume", req.GetVolumeId(), "VolumeId")
 	}
@@ -800,7 +800,7 @@ func (d Driver) ControllerPublishVolume(ctx context.Context, req *csi.Controller
 }
 
 // ControllerUnpublishVolume https://github.com/container-storage-interface/spec/blob/v1.9.0/spec.md#controllerunpublishvolume
-func (d Driver) ControllerUnpublishVolume(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest) (*csi.ControllerUnpublishVolumeResponse, error) {
+func (d *Driver) ControllerUnpublishVolume(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest) (*csi.ControllerUnpublishVolumeResponse, error) {
 	if req.GetVolumeId() == "" {
 		return nil, missingAttr("ControllerUnpublishVolume", req.GetVolumeId(), "VolumeId")
 	}
@@ -817,7 +817,7 @@ func (d Driver) ControllerUnpublishVolume(ctx context.Context, req *csi.Controll
 }
 
 // ValidateVolumeCapabilities https://github.com/container-storage-interface/spec/blob/v1.9.0/spec.md#validatevolumecapabilities
-func (d Driver) ValidateVolumeCapabilities(ctx context.Context, req *csi.ValidateVolumeCapabilitiesRequest) (*csi.ValidateVolumeCapabilitiesResponse, error) {
+func (d *Driver) ValidateVolumeCapabilities(ctx context.Context, req *csi.ValidateVolumeCapabilitiesRequest) (*csi.ValidateVolumeCapabilitiesResponse, error) {
 	if req.GetVolumeId() == "" {
 		return nil, missingAttr("ValidateVolumeCapabilities", req.GetVolumeId(), "volumeId")
 	}
@@ -864,7 +864,7 @@ func (d Driver) ValidateVolumeCapabilities(ctx context.Context, req *csi.Validat
 }
 
 // ListVolumes https://github.com/container-storage-interface/spec/blob/v1.9.0/spec.md#listvolumes
-func (d Driver) ListVolumes(ctx context.Context, req *csi.ListVolumesRequest) (*csi.ListVolumesResponse, error) {
+func (d *Driver) ListVolumes(ctx context.Context, req *csi.ListVolumesRequest) (*csi.ListVolumesResponse, error) {
 	volumes, err := d.Storage.ListAllWithStatus(ctx)
 	if err != nil {
 		return &csi.ListVolumesResponse{}, status.Errorf(codes.Aborted, "ListVolumes failed: %v", err)
@@ -915,7 +915,7 @@ func (d Driver) ListVolumes(ctx context.Context, req *csi.ListVolumesRequest) (*
 }
 
 // GetCapacity https://github.com/container-storage-interface/spec/blob/v1.9.0/spec.md#getcapacity
-func (d Driver) GetCapacity(ctx context.Context, req *csi.GetCapacityRequest) (*csi.GetCapacityResponse, error) {
+func (d *Driver) GetCapacity(ctx context.Context, req *csi.GetCapacityRequest) (*csi.GetCapacityResponse, error) {
 	params, err := volume.NewParameters(req.GetParameters(), d.topologyPrefix)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid parameters: %v", err)
@@ -950,7 +950,7 @@ func (d Driver) GetCapacity(ctx context.Context, req *csi.GetCapacityRequest) (*
 }
 
 // ControllerGetCapabilities https://github.com/container-storage-interface/spec/blob/v1.9.0/spec.md#controllergetcapabilities
-func (d Driver) ControllerGetCapabilities(ctx context.Context, req *csi.ControllerGetCapabilitiesRequest) (*csi.ControllerGetCapabilitiesResponse, error) {
+func (d *Driver) ControllerGetCapabilities(ctx context.Context, req *csi.ControllerGetCapabilitiesRequest) (*csi.ControllerGetCapabilitiesResponse, error) {
 	return &csi.ControllerGetCapabilitiesResponse{
 		Capabilities: []*csi.ControllerServiceCapability{
 			// Tell the CO we can create and delete volumes.
@@ -1020,7 +1020,7 @@ func (d Driver) ControllerGetCapabilities(ctx context.Context, req *csi.Controll
 }
 
 // CreateSnapshot https://github.com/container-storage-interface/spec/blob/v1.9.0/spec.md#createsnapshot
-func (d Driver) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotRequest) (*csi.CreateSnapshotResponse, error) {
+func (d *Driver) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotRequest) (*csi.CreateSnapshotResponse, error) {
 	// Delegate to the group snapshot implementation
 	resp, err := d.CreateVolumeGroupSnapshot(ctx, &csi.CreateVolumeGroupSnapshotRequest{
 		Name:            req.GetName(),
@@ -1042,7 +1042,7 @@ func (d Driver) CreateSnapshot(ctx context.Context, req *csi.CreateSnapshotReque
 }
 
 // DeleteSnapshot https://github.com/container-storage-interface/spec/blob/v1.9.0/spec.md#deletesnapshot
-func (d Driver) DeleteSnapshot(ctx context.Context, req *csi.DeleteSnapshotRequest) (*csi.DeleteSnapshotResponse, error) {
+func (d *Driver) DeleteSnapshot(ctx context.Context, req *csi.DeleteSnapshotRequest) (*csi.DeleteSnapshotResponse, error) {
 	if req.GetSnapshotId() == "" {
 		return nil, missingAttr("DeleteSnapshot", req.GetSnapshotId(), "SnapshotId")
 	}
@@ -1068,7 +1068,7 @@ func (d Driver) DeleteSnapshot(ctx context.Context, req *csi.DeleteSnapshotReque
 }
 
 // ListSnapshots https://github.com/container-storage-interface/spec/blob/v1.9.0/spec.md#listsnapshots
-func (d Driver) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsRequest) (*csi.ListSnapshotsResponse, error) {
+func (d *Driver) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsRequest) (*csi.ListSnapshotsResponse, error) {
 	limit := int(req.GetMaxEntries())
 	start, err := parseAsInt(req.GetStartingToken())
 	if err != nil {
@@ -1133,7 +1133,7 @@ func (d Driver) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsRequest
 }
 
 // NodeExpandVolume https://github.com/container-storage-interface/spec/blob/v1.9.0/spec.md#nodeexpandvolume
-func (d Driver) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolumeRequest) (*csi.NodeExpandVolumeResponse, error) {
+func (d *Driver) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolumeRequest) (*csi.NodeExpandVolumeResponse, error) {
 	d.log.WithFields(logrus.Fields{
 		"NodeExpandVolume": fmt.Sprintf("%+v", req),
 	}).Debug("Node expand volume")
@@ -1159,7 +1159,7 @@ func (d Driver) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolumeR
 }
 
 // ControllerExpandVolume https://github.com/container-storage-interface/spec/blob/v1.9.0/spec.md#controllerexpandvolume
-func (d Driver) ControllerExpandVolume(ctx context.Context, req *csi.ControllerExpandVolumeRequest) (*csi.ControllerExpandVolumeResponse, error) {
+func (d *Driver) ControllerExpandVolume(ctx context.Context, req *csi.ControllerExpandVolumeRequest) (*csi.ControllerExpandVolumeResponse, error) {
 	if req.GetVolumeId() == "" {
 		return nil, missingAttr("ControllerExpandVolume", req.GetVolumeId(), "VolumeId")
 	}
@@ -1209,7 +1209,7 @@ func (d Driver) ControllerExpandVolume(ctx context.Context, req *csi.ControllerE
 }
 
 // ControllerGetVolume https://github.com/container-storage-interface/spec/blob/v1.9.0/spec.md#controllergetvolume
-func (d Driver) ControllerGetVolume(ctx context.Context, req *csi.ControllerGetVolumeRequest) (*csi.ControllerGetVolumeResponse, error) {
+func (d *Driver) ControllerGetVolume(ctx context.Context, req *csi.ControllerGetVolumeRequest) (*csi.ControllerGetVolumeResponse, error) {
 	vol, err := d.Storage.FindByID(ctx, req.GetVolumeId())
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to find volume '%s': %v", req.GetVolumeId(), err)
@@ -1236,12 +1236,12 @@ func (d Driver) ControllerGetVolume(ctx context.Context, req *csi.ControllerGetV
 }
 
 // ControllerModifyVolume https://github.com/container-storage-interface/spec/blob/v1.9.0/spec.md#controllermodifyvolume
-func (d Driver) ControllerModifyVolume(ctx context.Context, req *csi.ControllerModifyVolumeRequest) (*csi.ControllerModifyVolumeResponse, error) {
+func (d *Driver) ControllerModifyVolume(ctx context.Context, req *csi.ControllerModifyVolumeRequest) (*csi.ControllerModifyVolumeResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "")
 }
 
 // GroupControllerGetCapabilities https://github.com/container-storage-interface/spec/blob/v1.11.0/spec.md#groupcontrollergetcapabilities
-func (d Driver) GroupControllerGetCapabilities(ctx context.Context, in *csi.GroupControllerGetCapabilitiesRequest) (*csi.GroupControllerGetCapabilitiesResponse, error) {
+func (d *Driver) GroupControllerGetCapabilities(ctx context.Context, in *csi.GroupControllerGetCapabilitiesRequest) (*csi.GroupControllerGetCapabilitiesResponse, error) {
 	return &csi.GroupControllerGetCapabilitiesResponse{
 		Capabilities: []*csi.GroupControllerServiceCapability{
 			{
@@ -1256,7 +1256,7 @@ func (d Driver) GroupControllerGetCapabilities(ctx context.Context, in *csi.Grou
 }
 
 // CreateVolumeGroupSnapshot https://github.com/container-storage-interface/spec/blob/v1.11.0/spec.md#createvolumegroupsnapshot
-func (d Driver) CreateVolumeGroupSnapshot(ctx context.Context, req *csi.CreateVolumeGroupSnapshotRequest) (*csi.CreateVolumeGroupSnapshotResponse, error) {
+func (d *Driver) CreateVolumeGroupSnapshot(ctx context.Context, req *csi.CreateVolumeGroupSnapshotRequest) (*csi.CreateVolumeGroupSnapshotResponse, error) {
 	if req.GetName() == "" {
 		return nil, missingAttr("CreateVolumeGroupSnapshot", req.GetName(), "Name")
 	}
@@ -1373,7 +1373,7 @@ func (d Driver) CreateVolumeGroupSnapshot(ctx context.Context, req *csi.CreateVo
 }
 
 // DeleteVolumeGroupSnapshot https://github.com/container-storage-interface/spec/blob/v1.11.0/spec.md#deletevolumegroupsnapshot
-func (d Driver) DeleteVolumeGroupSnapshot(ctx context.Context, req *csi.DeleteVolumeGroupSnapshotRequest) (*csi.DeleteVolumeGroupSnapshotResponse, error) {
+func (d *Driver) DeleteVolumeGroupSnapshot(ctx context.Context, req *csi.DeleteVolumeGroupSnapshotRequest) (*csi.DeleteVolumeGroupSnapshotResponse, error) {
 	if req.GetGroupSnapshotId() == "" {
 		return nil, missingAttr("DeleteVolumeGroupSnapshot", req.GetGroupSnapshotId(), "GroupSnapshotId")
 	}
@@ -1393,7 +1393,7 @@ func (d Driver) DeleteVolumeGroupSnapshot(ctx context.Context, req *csi.DeleteVo
 }
 
 // GetVolumeGroupSnapshot https://github.com/container-storage-interface/spec/blob/v1.11.0/spec.md#getvolumegroupsnapshot
-func (d Driver) GetVolumeGroupSnapshot(ctx context.Context, req *csi.GetVolumeGroupSnapshotRequest) (*csi.GetVolumeGroupSnapshotResponse, error) {
+func (d *Driver) GetVolumeGroupSnapshot(ctx context.Context, req *csi.GetVolumeGroupSnapshotRequest) (*csi.GetVolumeGroupSnapshotResponse, error) {
 	if req.GetGroupSnapshotId() == "" {
 		return nil, missingAttr("GetVolumeGroupSnapshot", req.GetGroupSnapshotId(), "GroupSnapshotId")
 	}
@@ -1441,7 +1441,7 @@ func AggregateGroupSnapshot(id string, snapshots ...*volume.Snapshot) *csi.Volum
 }
 
 // Run the server.
-func (d Driver) Run() error {
+func (d *Driver) Run() error {
 	d.log.Debug("Preparing to start server")
 
 	u, err := url.Parse(d.endpoint)
@@ -1511,13 +1511,13 @@ func (d Driver) Run() error {
 }
 
 // Stop the server.
-func (d Driver) Stop() error {
+func (d *Driver) Stop() error {
 	d.srv.GracefulStop()
 	d.cancel()
 	return nil
 }
 
-func (d Driver) createNewVolume(ctx context.Context, info *volume.Info, params *volume.Parameters, req *csi.CreateVolumeRequest, nfsExport bool) (*csi.CreateVolumeResponse, error) {
+func (d *Driver) createNewVolume(ctx context.Context, info *volume.Info, params *volume.Parameters, req *csi.CreateVolumeRequest, nfsExport bool) (*csi.CreateVolumeResponse, error) {
 	logger := d.log.WithFields(logrus.Fields{
 		"volume": info.ID,
 	})
@@ -1659,7 +1659,7 @@ func findMatchingSnapshotClassName(snapId string, contents ...unstructured.Unstr
 	return ""
 }
 
-func (d Driver) maybeGetSnapshotParameters(ctx context.Context, snapshotID string) (*volume.SnapshotParameters, error) {
+func (d *Driver) maybeGetSnapshotParameters(ctx context.Context, snapshotID string) (*volume.SnapshotParameters, error) {
 	if d.kubeClient == nil {
 		return nil, nil
 	}
@@ -1693,7 +1693,7 @@ func (d Driver) maybeGetSnapshotParameters(ctx context.Context, snapshotID strin
 
 // maybeDeleteLocalSnapshot deletes the local portion of a snapshot according to their volume.SnapshotParameters.
 // It will not delete a snapshot that is not ready, does not have a remote target, or where local deletion is disabled.
-func (d Driver) maybeDeleteLocalSnapshot(ctx context.Context, snap *volume.Snapshot, params *volume.SnapshotParameters) error {
+func (d *Driver) maybeDeleteLocalSnapshot(ctx context.Context, snap *volume.Snapshot, params *volume.SnapshotParameters) error {
 	if !snap.ReadyToUse {
 		return nil
 	}
@@ -1737,7 +1737,7 @@ func parseAsInt(s string) (int, error) {
 // failpathDelete deletes volumes and logs if that fails. Mostly useful
 // in error paths where we need to report the original error and not the
 // possible error from trying to clean up from that original error.
-func (d Driver) failpathDelete(ctx context.Context, volId string) {
+func (d *Driver) failpathDelete(ctx context.Context, volId string) {
 	if err := d.Storage.Delete(ctx, volId); err != nil {
 		d.log.WithFields(logrus.Fields{
 			"volume": volId,
@@ -1749,7 +1749,7 @@ func (d Driver) failpathDelete(ctx context.Context, volId string) {
 // * The fsType for the volume, or "" for block volumes
 // * If this volume should be exported via NFS or not
 // * validation errors
-func (d Driver) validateCapabilities(caps []*csi.VolumeCapability) (string, bool, error) {
+func (d *Driver) validateCapabilities(caps []*csi.VolumeCapability) (string, bool, error) {
 	var mountCaps, blockCaps []*csi.VolumeCapability
 
 	for _, capability := range caps {

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -69,15 +69,11 @@ type Driver struct {
 	NodeInformer  volume.NodeInformer
 	kubeClient    dynamic.Interface
 	nfsExporter   *NfsExporter
-	cancel        context.CancelFunc
-	srv           *grpc.Server
 	log           *logrus.Entry
 	version       string
 	// name distingushes the driver from other drivers and is used to mark
 	// volumes so that volumes provisioned by another driver are not interfered with.
 	name string
-	// endpoint is the socket over which all CSI calls are requested and responded to.
-	endpoint string
 	// nodeID is the hostname of the node where this plugin is running locally.
 	nodeID string
 	// topologyPrefix is the name
@@ -117,8 +113,6 @@ func NewDriver(options ...func(*Driver) error) (*Driver, error) {
 
 	d.log.Logger.SetOutput(ioutil.Discard)
 	d.log.Logger.SetFormatter(&logrus.TextFormatter{})
-
-	d.endpoint = fmt.Sprintf("unix:///var/lib/kubelet/plugins/%s/csi.sock", d.name)
 
 	// Run options functions.
 	for _, opt := range options {
@@ -197,14 +191,6 @@ func NodeInformer(n volume.NodeInformer) func(*Driver) error {
 func NodeID(nodeID string) func(*Driver) error {
 	return func(d *Driver) error {
 		d.nodeID = nodeID
-		return nil
-	}
-}
-
-// Endpoint configures the driver name.
-func Endpoint(ep string) func(*Driver) error {
-	return func(d *Driver) error {
-		d.endpoint = ep
 		return nil
 	}
 }
@@ -1440,13 +1426,13 @@ func AggregateGroupSnapshot(id string, snapshots ...*volume.Snapshot) *csi.Volum
 	}
 }
 
-// Run the server.
-func (d *Driver) Run() error {
-	d.log.Debug("Preparing to start server")
-
-	u, err := url.Parse(d.endpoint)
+// Listen creates a listener for the given CSI endpoint, which must be a unix
+// domain socket URL. A stale socket file from a previous run is removed first.
+// Binding before Serve runs avoids racing clients against server startup.
+func Listen(endpoint string) (net.Listener, error) {
+	u, err := url.Parse(endpoint)
 	if err != nil {
-		return fmt.Errorf("unable to parse address: %q", err)
+		return nil, fmt.Errorf("unable to parse address: %w", err)
 	}
 
 	addr := path.Join(u.Host, filepath.FromSlash(u.Path))
@@ -1456,16 +1442,19 @@ func (d *Driver) Run() error {
 
 	// csi plugins talk only over unix sockets currently
 	if u.Scheme != "unix" {
-		return fmt.Errorf("currently only unix domain sockets are supported, have: %s", u.Scheme)
+		return nil, fmt.Errorf("currently only unix domain sockets are supported, have: %s", u.Scheme)
 	}
 	if err = os.Remove(addr); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("failed to remove previously used unix domain socket file %s, error: %v", addr, err)
+		return nil, fmt.Errorf("failed to remove previously used unix domain socket file %s, error: %w", addr, err)
 	}
 
-	listener, err := net.Listen(u.Scheme, addr)
-	if err != nil {
-		return fmt.Errorf("failed to listen: %v", err)
-	}
+	return net.Listen(u.Scheme, addr)
+}
+
+// Serve handles CSI requests on listener, blocking until ctx is cancelled (the
+// server is then stopped gracefully) or a fatal error occurs.
+func (d *Driver) Serve(ctx context.Context, listener net.Listener) error {
+	d.log.Debug("Preparing to start server")
 
 	// type UnaryServerInterceptor func(ctx context.Context, req interface{}, info *UnaryServerInfo, handler UnaryHandler) (resp interface{}, err error)
 	errHandler := func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
@@ -1488,9 +1477,6 @@ func (d *Driver) Run() error {
 		return resp, err
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	d.cancel = cancel
-
 	if d.kubeClient != nil && d.resyncAfter > 0 {
 		err := ReconcileVolumeSnapshotClass(ctx, d.kubeClient, d.Snapshots, d.log, d.resyncAfter)
 		if err != nil {
@@ -1498,23 +1484,21 @@ func (d *Driver) Run() error {
 		}
 	}
 
-	d.srv = grpc.NewServer(grpc.UnaryInterceptor(errHandler))
-	csi.RegisterIdentityServer(d.srv, d)
-	csi.RegisterControllerServer(d.srv, d)
-	csi.RegisterNodeServer(d.srv, d)
-	csi.RegisterGroupControllerServer(d.srv, d)
+	srv := grpc.NewServer(grpc.UnaryInterceptor(errHandler))
+	csi.RegisterIdentityServer(srv, d)
+	csi.RegisterControllerServer(srv, d)
+	csi.RegisterNodeServer(srv, d)
+	csi.RegisterGroupControllerServer(srv, d)
+
+	// Stop the server gracefully once the caller cancels the context.
+	stop := context.AfterFunc(ctx, srv.GracefulStop)
+	defer stop()
 
 	d.log.WithFields(logrus.Fields{
-		"address": addr,
+		"address": listener.Addr(),
 	}).Info("server started")
-	return d.srv.Serve(listener)
-}
 
-// Stop the server.
-func (d *Driver) Stop() error {
-	d.srv.GracefulStop()
-	d.cancel()
-	return nil
+	return srv.Serve(listener)
 }
 
 func (d *Driver) createNewVolume(ctx context.Context, info *volume.Info, params *volume.Parameters, req *csi.CreateVolumeRequest, nfsExport bool) (*csi.CreateVolumeResponse, error) {

--- a/pkg/driver/driver_test.go
+++ b/pkg/driver/driver_test.go
@@ -37,7 +37,6 @@ func TestDriver(t *testing.T) {
 	}
 
 	driver, err := NewDriver(
-		Endpoint(*csiEndpoint),
 		LogLevel(*logLevel),
 		LogOut(logFile),
 		Name("linstor.csi.linbit.com-test"),
@@ -95,9 +94,16 @@ func TestDriver(t *testing.T) {
 		}
 	}
 
-	// run your driver
+	// Bind the socket synchronously so the sanity suite cannot race the
+	// server startup: once Listen returns, the socket accepts connections.
+	listener, err := Listen(*csiEndpoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// t.Context() is cancelled when the test finishes, stopping the server.
 	//nolint:errcheck
-	go driver.Run()
+	go driver.Serve(t.Context(), listener)
 
 	mntDir, err := ioutil.TempDir("", "mnt")
 	if err != nil {


### PR DESCRIPTION
The sanity suite started the driver with `go driver.Run()`, which created the unix socket inside the goroutine. On loaded CI runners the test could dial the socket before it was bound; gRPC then backed off and the next retry landed past the suite's 60s connect deadline, failing with "Connection timed out".
    
Split Run() into a package-level Listen() that binds the socket synchronously and a Serve(ctx, listener) method. Callers create the listener first, so the socket accepts connections before Serve runs. Serve takes a context and stops the server gracefully on cancellation, replacing Stop().
