### PR TITLE
ci: pass build metadata to cosign via env

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,9 @@ jobs:
             cwd://${{ steps.meta.outputs.bake-file }}
       - name: Sign images
         if: ${{ github.event_name != 'pull_request' }}
+        env:
+          BUILD_METADATA: ${{ steps.bake.outputs.metadata }}
         run: |
-          jq '.[] | select(type=="object") | select(."containerimage.digest") | ."containerimage.digest" as $DIGEST | ."image.name" | split(":")[0] | "\(.)@\($DIGEST)"' -r <<<'${{ steps.bake.outputs.metadata }}' \
+          printf '%s' "$BUILD_METADATA" \
+            | jq '.[] | select(type=="object") | select(."containerimage.digest") | ."containerimage.digest" as $DIGEST | ."image.name" | split(":")[0] | "\(.)@\($DIGEST)"' -r \
             | xargs --no-run-if-empty cosign sign --yes


### PR DESCRIPTION
The sign step inlined the build step's metadata output into the shell with a single-quoted here-string. GitHub expands ${{ }} before the shell parses the script, and with provenance attestation (mode=max) that metadata JSON embeds commit messages. An apostrophe in a commit message closed the single quote, after which the shell failed on the next "(" with a syntax error.

Pass the metadata through a BUILD_METADATA environment variable and read it with printf, so its contents are never parsed by the shell.