### PR TITLE
fix: verify deployed device sizes when retrying ControllerExpandVolume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deletion of incremental S3 backups no longer fails permanently when a backup
   is still the base of a newer increment. The delete is deferred and retried so
   the chain drains newest-first instead of leaking backups forever.
+- `ControllerExpandVolume` no longer reports success based on the volume
+  definition size alone. A previous expand attempt may update the volume
+  definition while resizing the deployed DRBD devices fails (for example
+  because a replica was not UpToDate at that moment); the retried call then
+  found a matching volume definition and reported success, leaving the block
+  device at its old size while the CO considered the volume expanded. The
+  retry now verifies the usable size reported by the deployed volumes and
+  keeps failing until the devices have actually been resized.
 
 ## [1.11.2] - 2026-05-12
 

--- a/pkg/client/linstor.go
+++ b/pkg/client/linstor.go
@@ -2759,7 +2759,7 @@ func (s *Linstor) ControllerExpand(ctx context.Context, vol *volume.Info) error 
 	}
 
 	if volumeDefinitionModify.SizeKib == volumeDefinitions[0].SizeKib {
-		return nil
+		return s.verifyExpandedSize(ctx, vol.ID, volumeDefinitionModify.SizeKib)
 	}
 
 	if volumeDefinitionModify.SizeKib < volumeDefinitions[0].SizeKib {
@@ -2769,6 +2769,43 @@ func (s *Linstor) ControllerExpand(ctx context.Context, vol *volume.Info) error 
 	err = s.client.ResourceDefinitions.ModifyVolumeDefinition(ctx, vol.ID, 0, volumeDefinitionModify)
 	if err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// verifyExpandedSize checks that the deployed volumes of a resource actually report
+// the expected usable size.
+//
+// The size of the volume definition and the size of the deployed (DRBD) devices can
+// disagree: a previous expand attempt may have updated the volume definition while
+// resizing the deployed devices failed, for example because a replica was not
+// UpToDate at that moment. ControllerExpandVolume is retried by the CO with the same
+// arguments, so returning success based on the volume definition alone would
+// silently leave the block device at its old size while the CO considers the volume
+// expanded. Returning an error instead keeps the CO retrying until LINSTOR has
+// resized the devices on all nodes.
+func (s *Linstor) verifyExpandedSize(ctx context.Context, volId string, expectedSizeKib uint64) error {
+	view, err := s.client.Resources.GetResourceView(ctx, &lapi.ListOpts{Resource: []string{volId}})
+	if err != nil {
+		return fmt.Errorf("failed to verify deployed sizes of %s: %w", volId, err)
+	}
+
+	for i := range view {
+		for j := range view[i].Volumes {
+			deployed := &view[i].Volumes[j]
+			if deployed.VolumeNumber != 0 {
+				continue
+			}
+
+			// A reported size of 0 means the satellite could not report a device size
+			// (node offline, device not deployed). Skip those instead of blocking the
+			// expand operation forever.
+			if deployed.UsableSizeKib != 0 && uint64(deployed.UsableSizeKib) < expectedSizeKib {
+				return fmt.Errorf("volume %s on node %s reports a usable size of %d KiB, expected at least %d KiB: expansion has not completed on all nodes",
+					volId, view[i].NodeName, deployed.UsableSizeKib, expectedSizeKib)
+			}
+		}
 	}
 
 	return nil

--- a/pkg/client/linstor_test.go
+++ b/pkg/client/linstor_test.go
@@ -23,6 +23,7 @@ package client
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -697,4 +698,100 @@ func TestIncrementChainLength(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLinstor_ControllerExpand(t *testing.T) {
+	t.Parallel()
+
+	const expandedSizeKib = 10 * 1024 * 1024 // 10 GiB
+	expandedVol := &volume.Info{ID: ExampleResourceID, DeviceBytes: map[int]int64{0: expandedSizeKib * 1024}}
+
+	resourceView := func(usableSizesKib ...int64) []lapi.ResourceWithVolumes {
+		view := make([]lapi.ResourceWithVolumes, len(usableSizesKib))
+		for i, size := range usableSizesKib {
+			view[i] = lapi.ResourceWithVolumes{
+				Resource: lapi.Resource{Name: ExampleResourceID, NodeName: fmt.Sprintf("node-%d", i+1)},
+				Volumes:  []lapi.Volume{{VolumeNumber: 0, UsableSizeKib: size}},
+			}
+		}
+
+		return view
+	}
+
+	t.Run("fresh expand modifies the volume definition", func(t *testing.T) {
+		rd := mocks.ResourceDefinitionProvider{}
+		rd.ExpectedCalls = []*mock.Call{
+			{Method: "GetVolumeDefinitions", Arguments: mock.Arguments{mock.Anything, ExampleResourceID}, ReturnArguments: mock.Arguments{[]lapi.VolumeDefinition{{SizeKib: 4 * 1024 * 1024}}, nil}},
+			{Method: "ModifyVolumeDefinition", Arguments: mock.Arguments{mock.Anything, ExampleResourceID, 0, lapi.VolumeDefinitionModify{SizeKib: expandedSizeKib}}, ReturnArguments: mock.Arguments{nil}},
+		}
+		cl := Linstor{client: &lc.HighLevelClient{Client: &lapi.Client{ResourceDefinitions: &rd}}, log: logrus.WithField("test", t.Name())}
+
+		err := cl.ControllerExpand(context.Background(), expandedVol)
+		assert.NoError(t, err)
+		rd.AssertExpectations(t)
+	})
+
+	t.Run("retry succeeds when all devices report the expanded size", func(t *testing.T) {
+		rd := mocks.ResourceDefinitionProvider{}
+		rd.ExpectedCalls = []*mock.Call{
+			{Method: "GetVolumeDefinitions", Arguments: mock.Arguments{mock.Anything, ExampleResourceID}, ReturnArguments: mock.Arguments{[]lapi.VolumeDefinition{{SizeKib: expandedSizeKib}}, nil}},
+		}
+		r := mocks.ResourceProvider{}
+		r.ExpectedCalls = []*mock.Call{
+			{Method: "GetResourceView", Arguments: mock.Arguments{mock.Anything, &lapi.ListOpts{Resource: []string{ExampleResourceID}}}, ReturnArguments: mock.Arguments{resourceView(expandedSizeKib, expandedSizeKib+8, expandedSizeKib), nil}},
+		}
+		cl := Linstor{client: &lc.HighLevelClient{Client: &lapi.Client{ResourceDefinitions: &rd, Resources: &r}}, log: logrus.WithField("test", t.Name())}
+
+		err := cl.ControllerExpand(context.Background(), expandedVol)
+		assert.NoError(t, err)
+		rd.AssertExpectations(t)
+		r.AssertExpectations(t)
+	})
+
+	t.Run("retry fails when a device was not resized", func(t *testing.T) {
+		rd := mocks.ResourceDefinitionProvider{}
+		rd.ExpectedCalls = []*mock.Call{
+			{Method: "GetVolumeDefinitions", Arguments: mock.Arguments{mock.Anything, ExampleResourceID}, ReturnArguments: mock.Arguments{[]lapi.VolumeDefinition{{SizeKib: expandedSizeKib}}, nil}},
+		}
+		r := mocks.ResourceProvider{}
+		r.ExpectedCalls = []*mock.Call{
+			{Method: "GetResourceView", Arguments: mock.Arguments{mock.Anything, &lapi.ListOpts{Resource: []string{ExampleResourceID}}}, ReturnArguments: mock.Arguments{resourceView(expandedSizeKib, 4*1024*1024), nil}},
+		}
+		cl := Linstor{client: &lc.HighLevelClient{Client: &lapi.Client{ResourceDefinitions: &rd, Resources: &r}}, log: logrus.WithField("test", t.Name())}
+
+		err := cl.ControllerExpand(context.Background(), expandedVol)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "node-2")
+		rd.AssertExpectations(t)
+		r.AssertExpectations(t)
+	})
+
+	t.Run("devices without a reported size are ignored", func(t *testing.T) {
+		rd := mocks.ResourceDefinitionProvider{}
+		rd.ExpectedCalls = []*mock.Call{
+			{Method: "GetVolumeDefinitions", Arguments: mock.Arguments{mock.Anything, ExampleResourceID}, ReturnArguments: mock.Arguments{[]lapi.VolumeDefinition{{SizeKib: expandedSizeKib}}, nil}},
+		}
+		r := mocks.ResourceProvider{}
+		r.ExpectedCalls = []*mock.Call{
+			{Method: "GetResourceView", Arguments: mock.Arguments{mock.Anything, &lapi.ListOpts{Resource: []string{ExampleResourceID}}}, ReturnArguments: mock.Arguments{resourceView(expandedSizeKib, 0), nil}},
+		}
+		cl := Linstor{client: &lc.HighLevelClient{Client: &lapi.Client{ResourceDefinitions: &rd, Resources: &r}}, log: logrus.WithField("test", t.Name())}
+
+		err := cl.ControllerExpand(context.Background(), expandedVol)
+		assert.NoError(t, err)
+		rd.AssertExpectations(t)
+		r.AssertExpectations(t)
+	})
+
+	t.Run("shrinking is rejected", func(t *testing.T) {
+		rd := mocks.ResourceDefinitionProvider{}
+		rd.ExpectedCalls = []*mock.Call{
+			{Method: "GetVolumeDefinitions", Arguments: mock.Arguments{mock.Anything, ExampleResourceID}, ReturnArguments: mock.Arguments{[]lapi.VolumeDefinition{{SizeKib: 2 * expandedSizeKib}}, nil}},
+		}
+		cl := Linstor{client: &lc.HighLevelClient{Client: &lapi.Client{ResourceDefinitions: &rd}}, log: logrus.WithField("test", t.Name())}
+
+		err := cl.ControllerExpand(context.Background(), expandedVol)
+		assert.Error(t, err)
+		rd.AssertExpectations(t)
+	})
 }


### PR DESCRIPTION
# fix: verify deployed device sizes when retrying ControllerExpandVolume

## Problem

`ControllerExpand` short-circuits when the volume definition already matches the requested size:

```go
if volumeDefinitionModify.SizeKib == volumeDefinitions[0].SizeKib {
    return nil
}
```

This is unsafe when a previous expand **committed the new volume-definition size but the deployed DRBD device was never actually resized**. The CO (external-resizer) retries `ControllerExpandVolume` with the same arguments, the retry finds a matching volume definition, and reports success — leaving the PVC marked expanded while the block device keeps its old size. For block volumes `NodeExpansionRequired` is `false`, so no node-side step ever catches up.

## How we hit it (production)

LINSTOR/DRBD backend. The deployed DRBD device resize failed on a satellite (a stale DRBD peer left behind by an unrelated `migrate-disk` blocked `drbdadm resize`) **after** LINSTOR had already committed the new volume-definition size. The CSI expand call returned an error, but the volume definition was at the new size. On the retry, the short-circuit above returned success. Result: a 50Gi PVC on a 4Gi DRBD device, silently — the VM booted with a 4Gi disk.

## Scope (please read the discussion)

As @WanzenBug correctly noted, the underlying inconsistency is in **linstor-server**, not the CSI driver: the volume-definition is committed before the deployed device resize is confirmed, and the same-size path of `ModifyVolumeDefinition` is a silent no-op that never re-checks or re-drives the deployed devices. I traced the exact paths in the comment thread.

This PR is therefore a **CSI-side defense-in-depth guard**: it makes the inconsistency visible from the CO (keeps the expand failing instead of silently succeeding) on any LINSTOR version. Happy to have it superseded by / moved to a server-side fix — see comments.

## Fix

When the volume definition already matches the requested size, verify that the deployed volumes actually report the expected usable size (`GetResourceView` filtered on the resource) before returning success. If any device that reports a size is still smaller, return an error so the CO keeps retrying. Devices reporting a usable size of 0 (offline satellite, undeployed device) are skipped, so an unreachable node cannot block expansion forever.

The fresh-expand path is unchanged: `ModifyVolumeDefinition` already surfaces resize errors synchronously.

## Testing

- New unit tests for `ControllerExpand`: fresh expand, successful retry verification, retry with an under-sized device (error, names the node), devices without a reported size (ignored), and shrink rejection.
- `go test ./...` passes; `gofumpt` clean.
- Reproduced on a LINSTOR 1.33 / DRBD 9 cluster (linstor-csi v1.10.6): with this check the retry keeps failing (visible `VolumeResizeFailed` events) until the device is actually resized, instead of silently succeeding.
