### PR TITLE
refactor: inject Kubernetes client from main

### DIFF
--- a/cmd/linstor-csi/linstor-csi.go
+++ b/cmd/linstor-csi/linstor-csi.go
@@ -39,6 +39,7 @@ import (
 	"github.com/piraeusdatastore/linstor-csi/pkg/client"
 	"github.com/piraeusdatastore/linstor-csi/pkg/driver"
 	lc "github.com/piraeusdatastore/linstor-csi/pkg/linstor/highlevelclient"
+	"github.com/piraeusdatastore/linstor-csi/pkg/utils"
 	"github.com/piraeusdatastore/linstor-csi/pkg/volume"
 )
 
@@ -143,16 +144,24 @@ func main() {
 		log.Fatal(err)
 	}
 
+	// Build the Kubernetes clients once. They are nil when not running in Kubernetes; features that need
+	// them (RWX, snapshot-class syncing, RWX-block validation) handle their absence.
+	kubeTyped, kubeDynamic, kubeErr := utils.KubernetesClient()
+
 	opts := []func(*driver.Driver) error{
 		driver.LogLevel(*logLevel),
 		driver.LogOut(logOut),
 		driver.NodeID(*node),
 		driver.TopologyPrefix(*propNs),
-		driver.ConfigureKubernetesIfAvailable(),
+		driver.KubeClient(kubeDynamic),
 		driver.ResyncAfter(*resyncAfter),
 	}
 
 	if *enableRWX {
+		if kubeErr != nil {
+			log.Fatalf("RWX support requires running in Kubernetes: %s", kubeErr)
+		}
+
 		if *namespace == "" {
 			content, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 			if err != nil {
@@ -162,7 +171,7 @@ func main() {
 			*namespace = strings.TrimSpace(string(content))
 		}
 
-		opts = append(opts, driver.ConfigureRWX(*namespace, *reactorConfigMapName))
+		opts = append(opts, driver.ConfigureRWX(kubeTyped, *namespace, *reactorConfigMapName))
 	}
 
 	if *disableRWXBlockValidation {

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -49,6 +49,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/piraeusdatastore/linstor-csi/pkg/client"
 	"github.com/piraeusdatastore/linstor-csi/pkg/linstor"
@@ -179,27 +180,17 @@ func LogLevel(s string) func(*Driver) error {
 	}
 }
 
-func ConfigureKubernetesIfAvailable() func(*Driver) error {
+// KubeClient sets the dynamic Kubernetes client used to read PVC/PV objects. It is built once in main
+// (nil when not running in Kubernetes); callers that need Kubernetes access guard on a nil client.
+func KubeClient(client dynamic.Interface) func(*Driver) error {
 	return func(d *Driver) error {
-		_, dyn, err := utils.KubernetesClient()
-		if err != nil {
-			// Not running in kubernetes
-			return nil
-		}
-
-		d.kubeClient = dyn
-
+		d.kubeClient = client
 		return nil
 	}
 }
 
-func ConfigureRWX(namespace, reactorConfigMap string) func(*Driver) error {
+func ConfigureRWX(cl kubernetes.Interface, namespace, reactorConfigMap string) func(*Driver) error {
 	return func(d *Driver) error {
-		cl, _, err := utils.KubernetesClient()
-		if err != nil {
-			return fmt.Errorf("RWX support requires running in Kubernetes: %w", err)
-		}
-
 		d.nfsExporter = &NfsExporter{
 			cl:               cl,
 			namespace:        namespace,


### PR DESCRIPTION
Build the Kubernetes clients once in main and pass them to the driver explicitly: a KubeClient option supplies the dynamic client, and ConfigureRWX takes the typed client as an argument.

This enables the creation of a test suite that relies on some k8s API without actually needing to spin up a kubernetes cluster: A fake client can be injected instead.