### PR TITLE
refactor: introduce typed volume ID

### DIFF
--- a/pkg/client/linstor.go
+++ b/pkg/client/linstor.go
@@ -198,17 +198,18 @@ func (s *Linstor) ListAllWithStatus(ctx context.Context) ([]volume.VolumeStatus,
 	}
 
 	for _, rd := range resDefs {
-		vol := s.resourceDefinitionToVolume(rd)
+		// Listing operates per resource, which maps to the implicit 0th volume of each resource.
+		vol := s.volumeInfoFromResourceDefinition(volume.ID{ResourceName: rd.Name}, rd)
 		if vol != nil {
 			vols = append(vols, volume.VolumeStatus{
 				Info:       *vol,
-				Conditions: ConditionFromResources(resourcesByName[vol.ID]),
+				Conditions: ConditionFromResources(resourcesByName[vol.ResourceName]),
 			})
 		}
 	}
 
 	sort.Slice(vols, func(i, j int) bool {
-		return vols[i].ID < vols[j].ID
+		return vols[i].String() < vols[j].String()
 	})
 
 	return vols, nil
@@ -255,9 +256,11 @@ func (s *Linstor) AllocationSize(requiredBytes, limitBytes int64, fsType string)
 	return volumeSizeKiB * KiB, nil
 }
 
-// resourceDefinitionToVolume reads the serialized volume info on the lapi.ResourceDefinitionWithVolumeDefinition
-// and constructs a pointer to a volume.Info from it.
-func (s *Linstor) resourceDefinitionToVolume(resDef lapi.ResourceDefinitionWithVolumeDefinition) *volume.Info {
+// volumeInfoFromResourceDefinition reads the serialized volume info on the
+// lapi.ResourceDefinitionWithVolumeDefinition and constructs a pointer to the
+// volume.Info identified by id. Returns nil if the resource does not contain the
+// requested volume (i.e. it is not a CSI volume).
+func (s *Linstor) volumeInfoFromResourceDefinition(id volume.ID, resDef lapi.ResourceDefinitionWithVolumeDefinition) *volume.Info {
 	if slices.Contains(resDef.Flags, lapiconsts.FlagCloning) {
 		// Volume is not yet ready
 		return nil
@@ -280,21 +283,21 @@ func (s *Linstor) resourceDefinitionToVolume(resDef lapi.ResourceDefinitionWithV
 		vd := &resDef.VolumeDefinitions[i]
 		deviceBytes[int(*vd.VolumeNumber)] = int64(vd.SizeKib) * KiB
 
-		// Per-VD FS properties should be the same on all VDs, but 0 is the "main" one we care about.
-		if *vd.VolumeNumber == 0 {
+		// Per-VD FS properties should be the same on all VDs, but the one matching the volume id is authoritative.
+		if int(*vd.VolumeNumber) == id.VolumeNumber {
 			if vdFsType := vd.Props[lapiconsts.NamespcFilesystem+"/"+lapiconsts.KeyFsType]; vdFsType != "" {
 				fsType = vdFsType
 			}
 		}
 	}
 
-	if _, ok := deviceBytes[0]; !ok {
+	if _, ok := deviceBytes[id.VolumeNumber]; !ok {
 		// Not a CSI enabled volume
 		return nil
 	}
 
 	return &volume.Info{
-		ID:            resDef.Name,
+		ID:            id,
 		DeviceBytes:   deviceBytes,
 		ResourceGroup: resDef.ResourceGroupName,
 		FsType:        fsType,
@@ -305,22 +308,27 @@ func (s *Linstor) resourceDefinitionToVolume(resDef lapi.ResourceDefinitionWithV
 
 // FindByID retrieves a volume.Info that has an id that matches the CSI volume
 // id. Matches the LINSTOR resource name.
-func (s *Linstor) FindByID(ctx context.Context, id string) (*volume.Info, error) {
+func (s *Linstor) FindByID(ctx context.Context, csiVolumeID string) (*volume.Info, error) {
 	s.log.WithFields(logrus.Fields{
-		"csiVolumeID": id,
+		"csiVolumeID": csiVolumeID,
 	}).Debug("looking up resource by CSI volume id")
 
-	res, err := s.client.ResourceDefinitions.Get(ctx, id)
+	id, err := volume.ParseVolumeId(csiVolumeID)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := s.client.ResourceDefinitions.Get(ctx, id.ResourceName)
 	if err != nil {
 		return nil, nil404(err)
 	}
 
-	vds, err := s.client.ResourceDefinitions.GetVolumeDefinitions(ctx, id)
+	vds, err := s.client.ResourceDefinitions.GetVolumeDefinitions(ctx, id.ResourceName)
 	if err != nil {
 		return nil, nil404(err)
 	}
 
-	return s.resourceDefinitionToVolume(lapi.ResourceDefinitionWithVolumeDefinition{
+	return s.volumeInfoFromResourceDefinition(id, lapi.ResourceDefinitionWithVolumeDefinition{
 		ResourceDefinition: res,
 		VolumeDefinitions:  vds,
 	}), nil
@@ -365,7 +373,7 @@ func (s *Linstor) Create(ctx context.Context, vol *volume.Info, params *volume.P
 
 	logger.Debug("reconcile resource definition for volume")
 
-	_, err = s.reconcileResourceDefinition(ctx, vol.ID, rGroup.Name)
+	_, err = s.reconcileResourceDefinition(ctx, vol.ResourceName, rGroup.Name)
 	if err != nil {
 		logger.Debugf("reconcile resource definition failed: %v", err)
 		return err
@@ -389,7 +397,7 @@ func (s *Linstor) Create(ctx context.Context, vol *volume.Info, params *volume.P
 
 	logger.Debug("reconcile extra properties")
 
-	err = s.client.ResourceDefinitions.Modify(ctx, vol.ID, lapi.GenericPropsModify{OverrideProps: vol.Properties})
+	err = s.client.ResourceDefinitions.Modify(ctx, vol.ResourceName, lapi.GenericPropsModify{OverrideProps: vol.Properties})
 	if err != nil {
 		logger.Debugf("reconcile extra properties failed: %v", err)
 		return err
@@ -414,13 +422,13 @@ func (s *Linstor) Clone(ctx context.Context, vol, src *volume.Info, params *volu
 
 	logger.Debugf("check for clone status")
 
-	status, err := s.client.ResourceDefinitions.CloneStatus(ctx, src.ID, vol.ID)
+	status, err := s.client.ResourceDefinitions.CloneStatus(ctx, src.ResourceName, vol.ResourceName)
 	if err != nil {
 		if errors.Is(err, lapi.NotFoundError) {
 			logger.Debugf("create new cloned volume")
 
-			_, err := s.client.ResourceDefinitions.Clone(ctx, src.ID, lapi.ResourceDefinitionCloneRequest{
-				Name:               vol.ID,
+			_, err := s.client.ResourceDefinitions.Clone(ctx, src.ResourceName, lapi.ResourceDefinitionCloneRequest{
+				Name:               vol.ResourceName,
 				LayerList:          params.LayerList,
 				ResourceGroup:      rGroup.Name,
 				GenericPropsModify: lapi.GenericPropsModify{DeleteProps: []string{linstor.PropertyProvisioningCompletedBy}},
@@ -430,7 +438,7 @@ func (s *Linstor) Clone(ctx context.Context, vol, src *volume.Info, params *volu
 				return err
 			}
 
-			status, err = s.client.ResourceDefinitions.CloneStatus(ctx, src.ID, vol.ID)
+			status, err = s.client.ResourceDefinitions.CloneStatus(ctx, src.ResourceName, vol.ResourceName)
 			if err != nil {
 				logger.Debugf("clone status failed: %v", err)
 				return err
@@ -446,7 +454,7 @@ func (s *Linstor) Clone(ctx context.Context, vol, src *volume.Info, params *volu
 
 		time.Sleep(5 * time.Second)
 
-		status, err = s.client.ResourceDefinitions.CloneStatus(ctx, src.ID, vol.ID)
+		status, err = s.client.ResourceDefinitions.CloneStatus(ctx, src.ResourceName, vol.ResourceName)
 		if err != nil {
 			logger.Debugf("clone status failed: %v", err)
 			return err
@@ -471,7 +479,7 @@ func (s *Linstor) Clone(ctx context.Context, vol, src *volume.Info, params *volu
 
 	logger.Debug("reconcile extra properties")
 
-	err = s.client.ResourceDefinitions.Modify(ctx, vol.ID, lapi.GenericPropsModify{OverrideProps: vol.Properties})
+	err = s.client.ResourceDefinitions.Modify(ctx, vol.ResourceName, lapi.GenericPropsModify{OverrideProps: vol.Properties})
 	if err != nil {
 		logger.Debugf("reconcile extra properties failed: %v", err)
 		return err
@@ -485,13 +493,13 @@ func (s *Linstor) Clone(ctx context.Context, vol, src *volume.Info, params *volu
 // In order to support Snapshots living longer than their volumes, we have to keep the resource definition around while
 // the actual resources are gone. An elegant way to go about this is by simply deleting the volume definition. This
 // hides
-func (s *Linstor) Delete(ctx context.Context, volId string) error {
+func (s *Linstor) Delete(ctx context.Context, id volume.ID) error {
 	s.log.WithFields(logrus.Fields{
-		"volume": volId,
+		"volume": id,
 	}).Info("deleting volume")
 
 	// Disable the BalanceResourceTask for this resource during deletion.
-	err := s.client.ResourceDefinitions.Modify(ctx, volId, lapi.GenericPropsModify{
+	err := s.client.ResourceDefinitions.Modify(ctx, id.ResourceName, lapi.GenericPropsModify{
 		OverrideProps: map[string]string{lapiconsts.KeyBalanceResourcesEnabled: lapiconsts.ValFalse},
 	})
 	if err != nil {
@@ -501,7 +509,7 @@ func (s *Linstor) Delete(ctx context.Context, volId string) error {
 	var resources []lapi.Resource
 
 	for {
-		resources, err = s.client.Resources.GetAll(ctx, volId)
+		resources, err = s.client.Resources.GetAll(ctx, id.ResourceName)
 		if err != nil {
 			return nil404(err)
 		}
@@ -523,14 +531,14 @@ func (s *Linstor) Delete(ctx context.Context, volId string) error {
 	})
 
 	for _, res := range resources {
-		err := s.client.Resources.Delete(ctx, volId, res.NodeName)
+		err := s.client.Resources.Delete(ctx, id.ResourceName, res.NodeName)
 		if err != nil {
 			// If two deletions run in parallel, one could get a 404 message, which we treat as "everything finished"
 			return nil404(err)
 		}
 	}
 
-	vds, err := s.client.ResourceDefinitions.GetVolumeDefinitions(ctx, volId)
+	vds, err := s.client.ResourceDefinitions.GetVolumeDefinitions(ctx, id.ResourceName)
 	if err != nil {
 		return nil404(err)
 	}
@@ -542,7 +550,7 @@ func (s *Linstor) Delete(ctx context.Context, volId string) error {
 
 	for _, vd := range vds {
 		// Delete the volume definition. This indicates the normal deletion is complete.
-		err = s.client.ResourceDefinitions.DeleteVolumeDefinition(ctx, volId, int(*vd.VolumeNumber))
+		err = s.client.ResourceDefinitions.DeleteVolumeDefinition(ctx, id.ResourceName, int(*vd.VolumeNumber))
 		if nil404(err) != nil {
 			// We continue with the cleanup on 404, maybe the previous cleanup was interrupted
 			return err
@@ -550,14 +558,14 @@ func (s *Linstor) Delete(ctx context.Context, volId string) error {
 	}
 
 	// Reset BalanceResourceTask for the case the resource definition is in use by a snapshot.
-	err = s.client.ResourceDefinitions.Modify(ctx, volId, lapi.GenericPropsModify{
+	err = s.client.ResourceDefinitions.Modify(ctx, id.ResourceName, lapi.GenericPropsModify{
 		DeleteProps: []string{lapiconsts.KeyBalanceResourcesEnabled},
 	})
 	if err != nil {
 		return nil404(err)
 	}
 
-	err = s.deleteResourceDefinitionAndGroupIfUnused(ctx, volId)
+	err = s.deleteResourceDefinitionAndGroupIfUnused(ctx, id.ResourceName)
 	if err != nil {
 		return err
 	}
@@ -567,13 +575,13 @@ func (s *Linstor) Delete(ctx context.Context, volId string) error {
 
 // AccessibleTopologies returns a list of pointers to csi.Topology from where the
 // volume is reachable, based on the localStoragePolicy reported by the volume.
-func (s *Linstor) AccessibleTopologies(ctx context.Context, volId string, params *volume.Parameters) ([]*csi.Topology, error) {
+func (s *Linstor) AccessibleTopologies(ctx context.Context, id volume.ID, params *volume.Parameters) ([]*csi.Topology, error) {
 	volumeScheduler, err := s.schedulerByPlacementPolicy(params.PlacementPolicy)
 	if err != nil {
 		return nil, err
 	}
 
-	return volumeScheduler.AccessibleTopologies(ctx, volId, params.AllowRemoteVolumeAccess)
+	return volumeScheduler.AccessibleTopologies(ctx, id.ResourceName, params.AllowRemoteVolumeAccess)
 }
 
 func (s *Linstor) schedulerByPlacementPolicy(policy topology.PlacementPolicy) (scheduler.Interface, error) {
@@ -593,8 +601,8 @@ func (s *Linstor) schedulerByPlacementPolicy(policy topology.PlacementPolicy) (s
 	}
 }
 
-func (s *Linstor) GetLegacyVolumeParameters(ctx context.Context, volId string) (*volume.Parameters, error) {
-	rd, err := s.client.ResourceDefinitions.Get(ctx, volId)
+func (s *Linstor) GetLegacyVolumeParameters(ctx context.Context, id volume.ID) (*volume.Parameters, error) {
+	rd, err := s.client.ResourceDefinitions.Get(ctx, id.ResourceName)
 	if err != nil {
 		return nil, err
 	}
@@ -622,13 +630,13 @@ func (s *Linstor) GetLegacyVolumeParameters(ctx context.Context, volId string) (
 }
 
 // Attach idempotently creates a resource on the given node.
-func (s *Linstor) Attach(ctx context.Context, volId, node string, rwxBlock bool) (string, error) {
+func (s *Linstor) Attach(ctx context.Context, id volume.ID, node string, rwxBlock bool) (string, error) {
 	s.log.WithFields(logrus.Fields{
-		"volume":     volId,
+		"volume":     id,
 		"targetNode": node,
 	}).Info("attaching volume")
 
-	ress, err := s.client.Resources.GetAll(ctx, volId)
+	ress, err := s.client.Resources.GetAll(ctx, id.ResourceName)
 	if err != nil {
 		return "", err
 	}
@@ -664,7 +672,7 @@ func (s *Linstor) Attach(ctx context.Context, volId, node string, rwxBlock bool)
 			linstor.PropertyAllowTwoPrimaries: "yes",
 		}}
 
-		err = s.client.ResourceDefinitions.Modify(ctx, volId, rdPropsModify)
+		err = s.client.ResourceDefinitions.Modify(ctx, id.ResourceName, rdPropsModify)
 		if err != nil {
 			return "", err
 		}
@@ -674,7 +682,7 @@ func (s *Linstor) Attach(ctx context.Context, volId, node string, rwxBlock bool)
 
 	// If the resource is already on the node, don't worry about attaching, unless we also need to activate it.
 	if existingRes == nil || slices.Contains(existingRes.Flags, lapiconsts.FlagRscInactive) {
-		err := s.client.Resources.MakeAvailable(ctx, volId, node, lapi.ResourceMakeAvailable{Diskful: false})
+		err := s.client.Resources.MakeAvailable(ctx, id.ResourceName, node, lapi.ResourceMakeAvailable{Diskful: false})
 
 		if errors.Is(err, lapi.NotFoundError) {
 			// Make-available honors replica-on-same and replicas-on-different. We do not, as the import parts of that
@@ -686,7 +694,7 @@ func (s *Linstor) Attach(ctx context.Context, volId, node string, rwxBlock bool)
 			}
 
 			rCreate := lapi.ResourceCreate{Resource: lapi.Resource{
-				Name:     volId,
+				Name:     id.ResourceName,
 				NodeName: node,
 				Flags:    []string{disklessFlag},
 			}}
@@ -702,7 +710,7 @@ func (s *Linstor) Attach(ctx context.Context, volId, node string, rwxBlock bool)
 			overrideProps[linstor.PropertyCreatedFor] = linstor.CreatedForTemporaryDisklessAttach
 		}
 
-		newRsc, err := s.client.Resources.Get(ctx, volId, node)
+		newRsc, err := s.client.Resources.Get(ctx, id.ResourceName, node)
 		if err != nil {
 			return "", err
 		}
@@ -711,7 +719,7 @@ func (s *Linstor) Attach(ctx context.Context, volId, node string, rwxBlock bool)
 	}
 
 	if len(overrideProps) > 0 {
-		err = s.client.Resources.ModifyVolume(ctx, volId, node, 0, lapi.GenericPropsModify{
+		err = s.client.Resources.ModifyVolume(ctx, id.ResourceName, node, id.VolumeNumber, lapi.GenericPropsModify{
 			OverrideProps: overrideProps,
 		})
 		if err != nil {
@@ -723,11 +731,11 @@ func (s *Linstor) Attach(ctx context.Context, volId, node string, rwxBlock bool)
 		return "", &DeleteInProgressError{
 			Operation: "attach volume",
 			Kind:      "resource",
-			Name:      volId,
+			Name:      id.ResourceName,
 		}
 	}
 
-	vol, err := s.client.Resources.GetVolume(ctx, volId, node, 0)
+	vol, err := s.client.Resources.GetVolume(ctx, id.ResourceName, node, id.VolumeNumber)
 	if err != nil {
 		return "", err
 	}
@@ -761,13 +769,13 @@ func getDisklessFlag(resource *lapi.Resource) string {
 }
 
 // Detach removes a volume from the node.
-func (s *Linstor) Detach(ctx context.Context, volId, node string) error {
+func (s *Linstor) Detach(ctx context.Context, id volume.ID, node string) error {
 	log := s.log.WithFields(logrus.Fields{
-		"volume":     volId,
+		"volume":     id,
 		"targetNode": node,
 	})
 
-	ress, err := s.client.Resources.GetAll(ctx, volId)
+	ress, err := s.client.Resources.GetAll(ctx, id.ResourceName)
 	if err != nil {
 		return nil404(err)
 	}
@@ -785,13 +793,13 @@ func (s *Linstor) Detach(ctx context.Context, volId, node string) error {
 			linstor.PropertyAllowTwoPrimaries,
 		}}
 
-		err = s.client.ResourceDefinitions.Modify(ctx, volId, rdPropsModify)
+		err = s.client.ResourceDefinitions.Modify(ctx, id.ResourceName, rdPropsModify)
 		if err != nil {
 			return nil404(err)
 		}
 	}
 
-	vol, err := s.client.Resources.GetVolume(ctx, volId, node, 0)
+	vol, err := s.client.Resources.GetVolume(ctx, id.ResourceName, node, id.VolumeNumber)
 	if err != nil {
 		return nil404(err)
 	}
@@ -809,7 +817,7 @@ func (s *Linstor) Detach(ctx context.Context, volId, node string) error {
 
 	log.Info("removing temporary resource")
 
-	return nil404(s.client.Resources.Delete(ctx, volId, node))
+	return nil404(s.client.Resources.Delete(ctx, id.ResourceName, node))
 }
 
 // CapacityBytes returns the amount of free space in the storage pool specified by the params and topology.
@@ -946,7 +954,7 @@ func (s *Linstor) CompatibleSnapshotId(name string) string {
 }
 
 // SnapCreate calls LINSTOR to create a new snapshot name "id" or backup of the volume "sourceVolId".
-func (s *Linstor) SnapCreate(ctx context.Context, id string, params *volume.SnapshotParameters, sourceVolIds ...string) ([]*volume.Snapshot, error) {
+func (s *Linstor) SnapCreate(ctx context.Context, id string, params *volume.SnapshotParameters, sourceVolIds ...volume.ID) ([]*volume.Snapshot, error) {
 	var lsnaps []lapi.Snapshot
 
 	var err error
@@ -982,7 +990,7 @@ func (s *Linstor) SnapCreate(ctx context.Context, id string, params *volume.Snap
 	return result, nil
 }
 
-func (s *Linstor) createInClusterSnapshots(ctx context.Context, id string, sourceVolIds ...string) ([]lapi.Snapshot, error) {
+func (s *Linstor) createInClusterSnapshots(ctx context.Context, id string, sourceVolIds ...volume.ID) ([]lapi.Snapshot, error) {
 	log := s.log.WithField("id", id)
 
 	log.Debug("Creating in-cluster snapshot")
@@ -991,7 +999,7 @@ func (s *Linstor) createInClusterSnapshots(ctx context.Context, id string, sourc
 	for _, sourceVolId := range sourceVolIds {
 		snapConfigs = append(snapConfigs, lapi.Snapshot{
 			Name:         id,
-			ResourceName: sourceVolId,
+			ResourceName: sourceVolId.ResourceName,
 		})
 	}
 
@@ -1015,7 +1023,7 @@ func (s *Linstor) createInClusterSnapshots(ctx context.Context, id string, sourc
 }
 
 // reconcileBackup ensure a backup exists at the given remote
-func (s *Linstor) reconcileBackup(ctx context.Context, id string, params *volume.SnapshotParameters, sourceVolIds ...string) ([]lapi.Snapshot, error) {
+func (s *Linstor) reconcileBackup(ctx context.Context, id string, params *volume.SnapshotParameters, sourceVolIds ...volume.ID) ([]lapi.Snapshot, error) {
 	log := s.log.WithField("id", id)
 
 	if len(sourceVolIds) != 1 {
@@ -1034,7 +1042,7 @@ func (s *Linstor) reconcileBackup(ctx context.Context, id string, params *volume
 	switch params.Type {
 	case volume.SnapshotTypeS3:
 		info, err := s.client.Backup.Info(ctx, params.RemoteName, lapi.BackupInfoRequest{
-			SrcRscName:  sourceVolId,
+			SrcRscName:  sourceVolId.ResourceName,
 			SrcSnapName: id,
 		})
 		if nil404(err) != nil {
@@ -1047,7 +1055,7 @@ func (s *Linstor) reconcileBackup(ctx context.Context, id string, params *volume
 			// Bound the chain length/age when requested: forcing a fresh full
 			// starts a new chain so older backups eventually become reclaimable.
 			if incremental && (params.MaxIncrements > 0 || params.FullSnapshotAfter > 0) {
-				forceFull, err := s.backupChainExhausted(ctx, params, sourceVolId)
+				forceFull, err := s.backupChainExhausted(ctx, params, sourceVolId.ResourceName)
 				if err != nil {
 					return nil, err
 				}
@@ -1060,7 +1068,7 @@ func (s *Linstor) reconcileBackup(ctx context.Context, id string, params *volume
 			}
 
 			_, err := s.client.Backup.Create(ctx, params.RemoteName, lapi.BackupCreate{
-				RscName:     sourceVolId,
+				RscName:     sourceVolId.ResourceName,
 				SnapName:    id,
 				Incremental: incremental,
 			})
@@ -1069,7 +1077,7 @@ func (s *Linstor) reconcileBackup(ctx context.Context, id string, params *volume
 			}
 		}
 
-		snap, err := s.client.Resources.GetSnapshot(ctx, sourceVolId, id)
+		snap, err := s.client.Resources.GetSnapshot(ctx, sourceVolId.ResourceName, id)
 		if err != nil {
 			return nil, fmt.Errorf("error fetching snapshot for backup: %w", err)
 		}
@@ -1087,8 +1095,8 @@ func (s *Linstor) reconcileBackup(ctx context.Context, id string, params *volume
 			yes := true
 
 			snapName, err = s.client.Backup.Ship(ctx, params.RemoteName, lapi.BackupShipRequest{
-				SrcRscName:   sourceVolId,
-				DstRscName:   "backup-" + sourceVolId,
+				SrcRscName:   sourceVolId.ResourceName,
+				DstRscName:   "backup-" + sourceVolId.ResourceName,
 				DstStorPool:  params.LinstorTargetStoragePool,
 				DownloadOnly: &yes,
 			})
@@ -1112,7 +1120,7 @@ func (s *Linstor) reconcileBackup(ctx context.Context, id string, params *volume
 			snapName = kv.Props[id]
 		}
 
-		snap, err := s.client.Resources.GetSnapshot(ctx, sourceVolId, snapName)
+		snap, err := s.client.Resources.GetSnapshot(ctx, sourceVolId.ResourceName, snapName)
 		if err != nil {
 			return nil, fmt.Errorf("error fetching snapshot for backup: %w", err)
 		}
@@ -1430,7 +1438,7 @@ func (s *Linstor) VolFromSnap(ctx context.Context, snap *volume.Snapshot, vol *v
 
 	logger.Debug("reconcile resource definition for volume")
 
-	rDef, err := s.reconcileResourceDefinition(ctx, vol.ID, rGroup.Name)
+	rDef, err := s.reconcileResourceDefinition(ctx, vol.ResourceName, rGroup.Name)
 	if err != nil {
 		return err
 	}
@@ -1472,7 +1480,7 @@ func (s *Linstor) VolFromSnap(ctx context.Context, snap *volume.Snapshot, vol *v
 
 	logger.Debug("reconcile extra properties")
 
-	err = s.client.ResourceDefinitions.Modify(ctx, vol.ID, lapi.GenericPropsModify{OverrideProps: vol.Properties})
+	err = s.client.ResourceDefinitions.Modify(ctx, vol.ResourceName, lapi.GenericPropsModify{OverrideProps: vol.Properties})
 	if err != nil {
 		logger.Debugf("reconcile extra properties failed: %v", err)
 		return err
@@ -1753,21 +1761,21 @@ func (s *Linstor) reconcileResourceGroup(ctx context.Context, params *volume.Par
 	return &rg, nil
 }
 
-func (s *Linstor) reconcileResourceDefinition(ctx context.Context, volId, rgName string) (*lapi.ResourceDefinition, error) {
+func (s *Linstor) reconcileResourceDefinition(ctx context.Context, rdName, rgName string) (*lapi.ResourceDefinition, error) {
 	logger := s.log.WithFields(logrus.Fields{
-		"volume": volId,
+		"volume": rdName,
 	})
 	logger.Info("reconcile resource definition for volume")
 
 	logger.Debugf("check if resource definition already exists")
 
-	rd, err := s.client.ResourceDefinitions.Get(ctx, volId)
+	rd, err := s.client.ResourceDefinitions.Get(ctx, rdName)
 	if errors.Is(err, lapi.NotFoundError) {
 		logger.Debugf("resource definition does not exist, create now")
 
 		rdCreate := lapi.ResourceDefinitionCreate{
 			ResourceDefinition: lapi.ResourceDefinition{
-				Name:              volId,
+				Name:              rdName,
 				ResourceGroupName: rgName,
 			},
 		}
@@ -1777,7 +1785,7 @@ func (s *Linstor) reconcileResourceDefinition(ctx context.Context, volId, rgName
 			return nil, err
 		}
 
-		rd, err = s.client.ResourceDefinitions.Get(ctx, volId)
+		rd, err = s.client.ResourceDefinitions.Get(ctx, rdName)
 	}
 
 	if err != nil {
@@ -1788,7 +1796,7 @@ func (s *Linstor) reconcileResourceDefinition(ctx context.Context, volId, rgName
 		return nil, &DeleteInProgressError{
 			Operation: "reconcile resource definition",
 			Kind:      "resource definition",
-			Name:      volId,
+			Name:      rdName,
 		}
 	}
 
@@ -1806,7 +1814,7 @@ func (s *Linstor) reconcileVolumeDefinition(ctx context.Context, info *volume.In
 
 		logger.Debug("check if volume definition already exists")
 
-		vDef, err := s.client.ResourceDefinitions.GetVolumeDefinition(ctx, info.ID, vn)
+		vDef, err := s.client.ResourceDefinitions.GetVolumeDefinition(ctx, info.ResourceName, vn)
 		if errors.Is(err, lapi.NotFoundError) {
 			var props map[string]string
 
@@ -1826,12 +1834,12 @@ func (s *Linstor) reconcileVolumeDefinition(ctx context.Context, info *volume.In
 				},
 			}
 
-			err = s.client.ResourceDefinitions.CreateVolumeDefinition(ctx, info.ID, vdCreate)
+			err = s.client.ResourceDefinitions.CreateVolumeDefinition(ctx, info.ResourceName, vdCreate)
 			if err != nil {
 				return err
 			}
 
-			vDef, err = s.client.ResourceDefinitions.GetVolumeDefinition(ctx, info.ID, vn)
+			vDef, err = s.client.ResourceDefinitions.GetVolumeDefinition(ctx, info.ResourceName, vn)
 		}
 
 		if err != nil {
@@ -1841,7 +1849,7 @@ func (s *Linstor) reconcileVolumeDefinition(ctx context.Context, info *volume.In
 		// We don't support shrinking. This is mostly covered by the provisioner, but with backups there may be
 		// edge cases where the "no shrinking" rule cannot be enforced. So we only allow volume growth here.
 		if vDef.SizeKib < expectedSizeKiB {
-			err := s.client.ResourceDefinitions.ModifyVolumeDefinition(ctx, info.ID, vn, lapi.VolumeDefinitionModify{
+			err := s.client.ResourceDefinitions.ModifyVolumeDefinition(ctx, info.ResourceName, vn, lapi.VolumeDefinitionModify{
 				SizeKib: expectedSizeKiB,
 			})
 			if err != nil {
@@ -1865,7 +1873,7 @@ func (s *Linstor) reconcileResourcePlacement(ctx context.Context, vol *volume.In
 		return err
 	}
 
-	err = volumeScheduler.Create(ctx, vol.ID, params, topologies)
+	err = volumeScheduler.Create(ctx, vol.ResourceName, params, topologies)
 	if err != nil {
 		return err
 	}
@@ -2156,7 +2164,7 @@ func (s *Linstor) FindSnapsBySource(ctx context.Context, sourceVol *volume.Info,
 		Limit:  limit,
 	}
 
-	snaps, err := s.client.Resources.GetSnapshots(ctx, sourceVol.ID, opts)
+	snaps, err := s.client.Resources.GetSnapshots(ctx, sourceVol.ResourceName, opts)
 	if nil404(err) != nil {
 		return nil, fmt.Errorf("failed to fetch list of snapshots: %w", err)
 	}
@@ -2339,13 +2347,13 @@ func (s *Linstor) NodeAvailable(ctx context.Context, node string) error {
 }
 
 // FindAssignmentOnNode returns a pointer to a volume.Assignment for a given node.
-func (s *Linstor) FindAssignmentOnNode(ctx context.Context, volId, node string) (*volume.Assignment, error) {
+func (s *Linstor) FindAssignmentOnNode(ctx context.Context, id volume.ID, node string) (*volume.Assignment, error) {
 	s.log.WithFields(logrus.Fields{
-		"volume":     volId,
+		"volume":     id,
 		"targetNode": node,
 	}).Debug("getting assignment info")
 
-	linVol, err := s.client.Resources.GetVolume(ctx, volId, node, 0)
+	linVol, err := s.client.Resources.GetVolume(ctx, id.ResourceName, node, id.VolumeNumber)
 	if err != nil {
 		return nil, nil404(err)
 	}
@@ -2362,14 +2370,14 @@ func (s *Linstor) FindAssignmentOnNode(ctx context.Context, volId, node string) 
 	return va, nil
 }
 
-func (s *Linstor) Status(ctx context.Context, volId string) (*csi.VolumeCondition, error) {
+func (s *Linstor) Status(ctx context.Context, id volume.ID) (*csi.VolumeCondition, error) {
 	s.log.WithFields(logrus.Fields{
-		"volume": volId,
+		"volume": id,
 	}).Debug("getting assignments")
 
-	ress, err := s.client.Resources.GetResourceView(ctx, &lapi.ListOpts{Resource: []string{volId}})
+	ress, err := s.client.Resources.GetResourceView(ctx, &lapi.ListOpts{Resource: []string{id.ResourceName}})
 	if err != nil {
-		return nil, fmt.Errorf("failed to list resources for '%s': %w", volId, err)
+		return nil, fmt.Errorf("failed to list resources for '%s': %w", id.ResourceName, err)
 	}
 
 	return ConditionFromResources(ress), nil
@@ -2763,23 +2771,23 @@ func (s *Linstor) ControllerExpand(ctx context.Context, vol *volume.Info) error 
 	}).Info("controller expand volume")
 
 	volumeDefinitionModify := lapi.VolumeDefinitionModify{
-		SizeKib: uint64(vol.DeviceBytes[0] / KiB),
+		SizeKib: uint64(vol.Size() / KiB),
 	}
 
-	volumeDefinitions, err := s.client.ResourceDefinitions.GetVolumeDefinitions(ctx, vol.ID)
-	if err != nil || len(volumeDefinitions) < 1 {
-		return fmt.Errorf("get volumeDefinitions failed volumeInfo: %v, err: %v", vol, err)
+	volumeDefinition, err := s.client.ResourceDefinitions.GetVolumeDefinition(ctx, vol.ResourceName, vol.VolumeNumber)
+	if err != nil {
+		return fmt.Errorf("failed to get volume definition '%s' for resize: %w", &vol.ID, err)
 	}
 
-	if volumeDefinitionModify.SizeKib == volumeDefinitions[0].SizeKib {
+	if volumeDefinitionModify.SizeKib == volumeDefinition.SizeKib {
 		return nil
 	}
 
-	if volumeDefinitionModify.SizeKib < volumeDefinitions[0].SizeKib {
-		return fmt.Errorf("storage only support expand does not support reduce.volumeInfo: %v old: %d, new: %d", vol, volumeDefinitions[0].SizeKib, volumeDefinitionModify.SizeKib)
+	if volumeDefinitionModify.SizeKib < volumeDefinition.SizeKib {
+		return fmt.Errorf("storage only support expand does not support reduce.volumeInfo: %v old: %d, new: %d", vol, volumeDefinition.SizeKib, volumeDefinitionModify.SizeKib)
 	}
 
-	err = s.client.ResourceDefinitions.ModifyVolumeDefinition(ctx, vol.ID, 0, volumeDefinitionModify)
+	err = s.client.ResourceDefinitions.ModifyVolumeDefinition(ctx, vol.ResourceName, vol.VolumeNumber, volumeDefinitionModify)
 	if err != nil {
 		return err
 	}

--- a/pkg/client/linstor_test.go
+++ b/pkg/client/linstor_test.go
@@ -177,7 +177,7 @@ func TestLinstor_Attach(t *testing.T) {
 		}
 		cl := Linstor{client: &lc.HighLevelClient{Client: &lapi.Client{Resources: &m}}, log: logrus.WithField("test", t.Name())}
 
-		path, err := cl.Attach(context.Background(), ExampleResourceID, "node-2", false)
+		path, err := cl.Attach(context.Background(), volume.ID{ResourceName: ExampleResourceID}, "node-2", false)
 		assert.NoError(t, err)
 		assert.Equal(t, "/dev/vol1", path)
 		m.AssertExpectations(t)
@@ -196,7 +196,7 @@ func TestLinstor_Attach(t *testing.T) {
 		}
 		cl := Linstor{client: &lc.HighLevelClient{Client: &lapi.Client{Resources: &m}}, log: logrus.WithField("test", t.Name())}
 
-		path, err := cl.Attach(context.Background(), ExampleResourceID, "node-3", false)
+		path, err := cl.Attach(context.Background(), volume.ID{ResourceName: ExampleResourceID}, "node-3", false)
 		assert.NoError(t, err)
 		assert.Equal(t, "/dev/vol1", path)
 		m.AssertExpectations(t)
@@ -216,7 +216,7 @@ func TestLinstor_Attach(t *testing.T) {
 		}
 		cl := Linstor{client: &lc.HighLevelClient{Client: &lapi.Client{Resources: &m}}, log: logrus.WithField("test", t.Name())}
 
-		path, err := cl.Attach(context.Background(), ExampleResourceID, "node-3", false)
+		path, err := cl.Attach(context.Background(), volume.ID{ResourceName: ExampleResourceID}, "node-3", false)
 		assert.NoError(t, err)
 		assert.Equal(t, "/dev/vol1", path)
 		m.AssertExpectations(t)
@@ -234,7 +234,7 @@ func TestLinstor_Attach(t *testing.T) {
 		}
 		cl := Linstor{client: &lc.HighLevelClient{Client: &lapi.Client{Resources: &m}}, log: logrus.WithField("test", t.Name())}
 
-		path, err := cl.Attach(context.Background(), ExampleResourceID, "node-2", false)
+		path, err := cl.Attach(context.Background(), volume.ID{ResourceName: ExampleResourceID}, "node-2", false)
 		assert.NoError(t, err)
 		assert.Equal(t, "/dev/vol1", path)
 		m.AssertExpectations(t)
@@ -470,7 +470,7 @@ func TestLinstor_Status(t *testing.T) {
 			r.On("GetResourceView", mock.Anything, &lapi.ListOpts{Resource: []string{tcase.name}}).Return(parsedResponse, nil)
 			cl := Linstor{client: &lc.HighLevelClient{Client: &lapi.Client{Resources: r}}, log: logrus.WithField("test", t.Name())}
 
-			actualCondition, err := cl.Status(context.Background(), tcase.name)
+			actualCondition, err := cl.Status(context.Background(), volume.ID{ResourceName: tcase.name, VolumeNumber: 0})
 			assert.NoError(t, err)
 			r.AssertExpectations(t)
 			assert.Equal(t, tcase.expectedCondition, actualCondition)

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -294,8 +294,13 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 		return nil, status.Errorf(codes.Internal, "NodePublishVolume failed for %s: invalid volume context: %v", req.GetVolumeId(), err)
 	}
 
+	volId, err := volume.ParseVolumeId(req.GetVolumeId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "failed to parse volume id: %v", err)
+	}
+
 	if volCtx == nil {
-		params, err := d.linstorClient.GetLegacyVolumeParameters(ctx, req.GetVolumeId())
+		params, err := d.linstorClient.GetLegacyVolumeParameters(ctx, volId)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "NodePublishVolume failed for %s: could not find volume parameters in context or legacy LINSTOR property", req.GetVolumeId())
 		}
@@ -311,7 +316,7 @@ func (d *Driver) NodePublishVolume(ctx context.Context, req *csi.NodePublishVolu
 
 	publishCtx := PublishContextFromMap(req.GetPublishContext())
 	if publishCtx == nil {
-		assignment, err := d.linstorClient.FindAssignmentOnNode(ctx, req.GetVolumeId(), d.nodeID)
+		assignment, err := d.linstorClient.FindAssignmentOnNode(ctx, volId, d.nodeID)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "NodePublishVolume failed for %s: %v", req.GetVolumeId(), err)
 		}
@@ -588,8 +593,8 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 
 		return &csi.CreateVolumeResponse{
 			Volume: &csi.Volume{
-				VolumeId:           existingVolume.ID,
-				CapacityBytes:      existingVolume.DeviceBytes[0],
+				VolumeId:           existingVolume.String(),
+				CapacityBytes:      existingVolume.Size(),
 				ContentSource:      req.GetVolumeContentSource(),
 				AccessibleTopology: topos,
 				VolumeContext:      volCtx,
@@ -618,7 +623,7 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 	return d.createNewVolume(
 		ctx,
 		&volume.Info{
-			ID:            volId,
+			ID:            volume.ID{ResourceName: volId, VolumeNumber: 0},
 			DeviceBytes:   volumeBytes,
 			ResourceGroup: params.ResourceGroup,
 			FsType:        fsType,
@@ -636,12 +641,17 @@ func (d *Driver) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest)
 		return nil, missingAttr("DeleteVolume", req.GetVolumeId(), "VolumeId")
 	}
 
-	err := d.nfsExporter.Unexport(ctx, req.GetVolumeId())
+	volId, err := volume.ParseVolumeId(req.GetVolumeId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "failed to parse volume id: %v", err)
+	}
+
+	err = d.nfsExporter.Unexport(ctx, volId)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to delete NFS export for %s: %v", req.GetVolumeId(), err)
 	}
 
-	err = d.linstorClient.Delete(ctx, req.GetVolumeId())
+	err = d.linstorClient.Delete(ctx, volId)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to delete volume: %v", err)
 	}
@@ -701,7 +711,12 @@ func (d *Driver) ControllerPublishVolume(ctx context.Context, req *csi.Controlle
 		}
 	}
 
-	devPath, err := d.linstorClient.Attach(ctx, req.GetVolumeId(), req.GetNodeId(), rwxBlock)
+	volId, err := volume.ParseVolumeId(req.GetVolumeId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "failed to parse volume id: %v", err)
+	}
+
+	devPath, err := d.linstorClient.Attach(ctx, volId, req.GetNodeId(), rwxBlock)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal,
 			"ControllerPublishVolume failed for %s: %v", req.GetVolumeId(), err)
@@ -752,7 +767,12 @@ func (d *Driver) ControllerUnpublishVolume(ctx context.Context, req *csi.Control
 		return nil, missingAttr("ControllerUnpublishVolume", req.GetNodeId(), "NodeId")
 	}
 
-	if err := d.linstorClient.Detach(ctx, req.GetVolumeId(), req.GetNodeId()); err != nil {
+	volId, err := volume.ParseVolumeId(req.GetVolumeId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "failed to parse volume id: %v", err)
+	}
+
+	if err := d.linstorClient.Detach(ctx, volId, req.GetNodeId()); err != nil {
 		return nil, status.Errorf(codes.Internal,
 			"ControllerUnpublishVolume failed for %s: %v", req.GetVolumeId(), err)
 	}
@@ -843,8 +863,8 @@ func (d *Driver) ListVolumes(ctx context.Context, req *csi.ListVolumesRequest) (
 	for i, vol := range volumes {
 		entries[i] = &csi.ListVolumesResponse_Entry{
 			Volume: &csi.Volume{
-				VolumeId:      vol.ID,
-				CapacityBytes: vol.DeviceBytes[0],
+				VolumeId:      vol.String(),
+				CapacityBytes: vol.Size(),
 				// NB: Topology is specifically excluded here. For topology we would need the volume context, which
 				// we don't have here. This might not be strictly to spec, but current consumers don't do anything with
 				// the information, so it should be fine.
@@ -1126,7 +1146,7 @@ func (d *Driver) ControllerExpandVolume(ctx context.Context, req *csi.Controller
 		return nil, status.Errorf(codes.Internal, "ControllerExpandVolume - expand volume failed for volume id %s: %v", req.GetVolumeId(), err)
 	}
 
-	existingVolume.DeviceBytes[0] = requiredBytes
+	existingVolume.DeviceBytes[existingVolume.VolumeNumber] = requiredBytes
 
 	d.log.WithFields(logrus.Fields{
 		"ControllerExpandVolume": fmt.Sprintf("%+v", req),
@@ -1144,7 +1164,7 @@ func (d *Driver) ControllerExpandVolume(ctx context.Context, req *csi.Controller
 		req.GetVolumeCapability().GetAccessMode().GetMode() == csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER
 
 	return &csi.ControllerExpandVolumeResponse{
-		CapacityBytes: existingVolume.DeviceBytes[0],
+		CapacityBytes: existingVolume.Size(),
 		// Skip node expansion for:
 		// * block volumes: normal LINSTOR resize is enough
 		// * NFS export, handled by the NFS exporter
@@ -1170,8 +1190,8 @@ func (d *Driver) ControllerGetVolume(ctx context.Context, req *csi.ControllerGet
 
 	return &csi.ControllerGetVolumeResponse{
 		Volume: &csi.Volume{
-			VolumeId:      vol.ID,
-			CapacityBytes: vol.DeviceBytes[0],
+			VolumeId:      vol.String(),
+			CapacityBytes: vol.Size(),
 		},
 		Status: &csi.ControllerGetVolumeResponse_VolumeStatus{
 			VolumeCondition: condition,
@@ -1290,7 +1310,18 @@ func (d *Driver) CreateVolumeGroupSnapshot(ctx context.Context, req *csi.CreateV
 		}
 	}
 
-	snaps, err := d.linstorClient.SnapCreate(ctx, id, params, req.GetSourceVolumeIds()...)
+	sources := make([]volume.ID, 0, len(req.GetSourceVolumeIds()))
+
+	for _, id := range req.GetSourceVolumeIds() {
+		volId, err := volume.ParseVolumeId(id)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "failed to parse volume id: %v", err)
+		}
+
+		sources = append(sources, volId)
+	}
+
+	snaps, err := d.linstorClient.SnapCreate(ctx, id, params, sources...)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to create snapshot: %v", err)
 	}
@@ -1465,7 +1496,7 @@ func (d *Driver) createNewVolume(ctx context.Context, info *volume.Info, params 
 	})
 
 	logger.WithFields(logrus.Fields{
-		"size": info.DeviceBytes[0],
+		"size": info.Size(),
 	}).Debug("creating new volume")
 
 	// We're cloning from a volume or snapshot.
@@ -1569,9 +1600,9 @@ func (d *Driver) createNewVolume(ctx context.Context, info *volume.Info, params 
 
 	return &csi.CreateVolumeResponse{
 		Volume: &csi.Volume{
-			VolumeId:           info.ID,
+			VolumeId:           info.String(),
 			ContentSource:      req.GetVolumeContentSource(),
-			CapacityBytes:      info.DeviceBytes[0],
+			CapacityBytes:      info.Size(),
 			AccessibleTopology: topos,
 			VolumeContext:      volCtx,
 		},
@@ -1679,7 +1710,7 @@ func parseAsInt(s string) (int, error) {
 // failpathDelete deletes volumes and logs if that fails. Mostly useful
 // in error paths where we need to report the original error and not the
 // possible error from trying to clean up from that original error.
-func (d *Driver) failpathDelete(ctx context.Context, volId string) {
+func (d *Driver) failpathDelete(ctx context.Context, volId volume.ID) {
 	if err := d.linstorClient.Delete(ctx, volId); err != nil {
 		d.log.WithFields(logrus.Fields{
 			"volume": volId,

--- a/pkg/driver/nfs_exporter.go
+++ b/pkg/driver/nfs_exporter.go
@@ -73,7 +73,7 @@ func (n *NfsExporter) Export(ctx context.Context, info *volume.Info, params *vol
 	var port uint16
 
 	if i := slices.IndexFunc(svc.Spec.Ports, func(p corev1.ServicePort) bool {
-		return p.Name == info.ID
+		return p.Name == info.ResourceName
 	}); i != -1 {
 		log.Debug("service port exists")
 
@@ -100,7 +100,7 @@ func (n *NfsExporter) Export(ctx context.Context, info *volume.Info, params *vol
 		}
 
 		svc.Spec.Ports = slices.Insert(svc.Spec.Ports, insertAt, corev1.ServicePort{
-			Name:        info.ID,
+			Name:        info.ResourceName,
 			Port:        previous + 1,
 			AppProtocol: ptr.To("nfs"),
 			Protocol:    corev1.ProtocolTCP,
@@ -118,7 +118,7 @@ func (n *NfsExporter) Export(ctx context.Context, info *volume.Info, params *vol
 
 	cfg := ReactorConfig{
 		Promoters: []PromoterConfig{{ResourceConfig: map[string]ResourceConfig{
-			info.ID: {
+			info.ResourceName: {
 				Metadata: NfsMetadata{
 					ServiceName:        params.NfsServiceName,
 					ConfigTemplatePath: params.NfsConfigTemplatePath,
@@ -131,14 +131,14 @@ func (n *NfsExporter) Export(ctx context.Context, info *volume.Info, params *vol
 				TargetAs:           "BindsTo",
 				DependenciesAs:     "BindsTo",
 				Start: []string{
-					fmt.Sprintf("prepare-device-links@%s.service", unit.UnitNameEscape(info.ID)),
-					fmt.Sprintf("clean-nfs-endpoint@%s.service", unit.UnitNameEscape(info.ID)),
-					fmt.Sprintf("mount-recovery@%s.service", unit.UnitNameEscape(info.ID)),
-					fmt.Sprintf("mount-export@%s.service", unit.UnitNameEscape(info.ID)),
+					fmt.Sprintf("prepare-device-links@%s.service", unit.UnitNameEscape(info.ResourceName)),
+					fmt.Sprintf("clean-nfs-endpoint@%s.service", unit.UnitNameEscape(info.ResourceName)),
+					fmt.Sprintf("mount-recovery@%s.service", unit.UnitNameEscape(info.ResourceName)),
+					fmt.Sprintf("mount-export@%s.service", unit.UnitNameEscape(info.ResourceName)),
 					fmt.Sprintf("growfs@%s.timer", unit.UnitNamePathEscape(fmt.Sprintf("/srv/exports/%s", info.ID))),
 					fmt.Sprintf("chmod@%s.service", unit.UnitNamePathEscape(fmt.Sprintf("/srv/exports/%s", info.ID))),
-					fmt.Sprintf("nfs-ganesha@%s.service", unit.UnitNameEscape(info.ID)),
-					fmt.Sprintf("advertise-nfs-endpoint@%s.service", unit.UnitNameEscape(info.ID)),
+					fmt.Sprintf("nfs-ganesha@%s.service", unit.UnitNameEscape(info.ResourceName)),
+					fmt.Sprintf("advertise-nfs-endpoint@%s.service", unit.UnitNameEscape(info.ResourceName)),
 				},
 			},
 		}}},
@@ -158,26 +158,26 @@ func (n *NfsExporter) Export(ctx context.Context, info *volume.Info, params *vol
 		configMap.Data = make(map[string]string)
 	}
 
-	if configMap.Data[info.ID+".toml"] != string(raw) {
-		log.WithField("config", info.ID+".toml").Debug("updating config map data")
-		configMap.Data[info.ID+".toml"] = string(raw)
+	if configMap.Data[info.ResourceName+".toml"] != string(raw) {
+		log.WithField("config", info.ResourceName+".toml").Debug("updating config map data")
+		configMap.Data[info.ResourceName+".toml"] = string(raw)
 
 		_, err = n.cl.CoreV1().ConfigMaps(n.namespace).Update(ctx, configMap, metav1.UpdateOptions{FieldManager: linstor.DriverName})
 		if err != nil {
 			return nil, fmt.Errorf("failed to update config map for export '%s': %w", info.ID, err)
 		}
 	} else {
-		log.WithField("config", info.ID+".toml").Debug("config exists")
+		log.WithField("config", info.ResourceName+".toml").Debug("config exists")
 	}
 
 	return &url.URL{
 		Scheme: "nfs",
 		Host:   fmt.Sprintf("%s.%s.svc:%d", params.NfsServiceName, n.namespace, port),
-		Path:   "/" + info.ID,
+		Path:   "/" + info.ResourceName,
 	}, nil
 }
 
-func (n *NfsExporter) Unexport(ctx context.Context, export string) error {
+func (n *NfsExporter) Unexport(ctx context.Context, export volume.ID) error {
 	if !n.Enabled() {
 		return nil
 	}
@@ -196,7 +196,7 @@ func (n *NfsExporter) Unexport(ctx context.Context, export string) error {
 		return fmt.Errorf("failed to get config map for export '%s': %w", export, err)
 	}
 
-	content, ok := configMap.Data[export+".toml"]
+	content, ok := configMap.Data[export.ResourceName+".toml"]
 	if !ok {
 		log.Debug("Config map has no matching entry, nothing to unexport")
 		return nil
@@ -213,7 +213,7 @@ func (n *NfsExporter) Unexport(ctx context.Context, export string) error {
 		return fmt.Errorf("unexpected number of promoter configuration, expected 1, got %d", len(reactorConfig.Promoters))
 	}
 
-	config, ok := reactorConfig.Promoters[0].ResourceConfig[export]
+	config, ok := reactorConfig.Promoters[0].ResourceConfig[export.ResourceName]
 	if !ok {
 		return fmt.Errorf("expected resource '%s' to exist in config, got [%s] instead", export, slices.Collect(maps.Keys(reactorConfig.Promoters[0].ResourceConfig)))
 	}
@@ -231,7 +231,7 @@ func (n *NfsExporter) Unexport(ctx context.Context, export string) error {
 
 		log.WithField("svc", svc).WithField("port", export).Info("removing export port")
 		svc.Spec.Ports = slices.DeleteFunc(svc.Spec.Ports, func(port corev1.ServicePort) bool {
-			return port.Name == export
+			return port.Name == export.ResourceName
 		})
 		log.WithField("svc", svc).Info("removed export port")
 
@@ -247,7 +247,7 @@ func (n *NfsExporter) Unexport(ctx context.Context, export string) error {
 
 	log.Debug("removing reactor config from config map")
 
-	delete(configMap.Data, export+".toml")
+	delete(configMap.Data, export.ResourceName+".toml")
 
 	_, err = n.cl.CoreV1().ConfigMaps(configMap.Namespace).Update(ctx, configMap, metav1.UpdateOptions{
 		FieldManager: linstor.DriverName,

--- a/pkg/topology/scheduler/scheduler.go
+++ b/pkg/topology/scheduler/scheduler.go
@@ -28,6 +28,6 @@ import (
 
 // Interface determines where to place volumes and where they are accessible from.
 type Interface interface {
-	Create(ctx context.Context, volId string, params *volume.Parameters, topologies *csi.TopologyRequirement) error
-	AccessibleTopologies(ctx context.Context, volId string, remoteAccessPolicy volume.RemoteAccessPolicy) ([]*csi.Topology, error)
+	Create(ctx context.Context, rdName string, params *volume.Parameters, topologies *csi.TopologyRequirement) error
+	AccessibleTopologies(ctx context.Context, rdName string, remoteAccessPolicy volume.RemoteAccessPolicy) ([]*csi.Topology, error)
 }

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -21,6 +21,7 @@ package volume
 import (
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -30,7 +31,7 @@ import (
 
 // Info provides everything needed to manipulate volumes.
 type Info struct {
-	ID string
+	ID
 	// The device sizes in bytes associated with this volume.
 	// A valid Info always has at least a 0th volume.
 	DeviceBytes   map[int]int64
@@ -40,12 +41,62 @@ type Info struct {
 	UseQuorum     bool
 }
 
+func (i *Info) Size() int64 {
+	return i.DeviceBytes[i.VolumeNumber]
+}
+
 // Assignment represents a volume situated on a particular node.
 type Assignment struct {
 	// Node is the node that the assignment is valid for.
 	Node string
 	// Path is a location on the Node's filesystem where the volume may be accessed.
 	Path string
+}
+
+// MaxVolumesPerResource is the maximum number of volumes a single resource can
+// hold. DRBD (and therefore LINSTOR) uses a 16-bit volume number, so valid
+// volume numbers fall in the range [0, MaxVolumesPerResource).
+const MaxVolumesPerResource = 1 << 16
+
+type ID struct {
+	ResourceName string
+	VolumeNumber int
+}
+
+func (i ID) String() string {
+	if i.VolumeNumber == 0 {
+		return i.ResourceName
+	}
+
+	return fmt.Sprintf("%s/%d", i.ResourceName, i.VolumeNumber)
+}
+
+func ParseVolumeId(id string) (ID, error) {
+	if id == "" {
+		return ID{}, fmt.Errorf("empty string is not a valid volume id")
+	}
+
+	volNr := 0
+
+	parts := strings.SplitN(id, "/", 2)
+	if parts[0] == "" {
+		return ID{}, fmt.Errorf("volume id is missing a resource name: '%s'", id)
+	}
+
+	if len(parts) == 2 {
+		v, err := strconv.Atoi(parts[1])
+		if err != nil {
+			return ID{}, fmt.Errorf("failed to parse volume id: %w", err)
+		}
+
+		if v < 0 || v >= MaxVolumesPerResource {
+			return ID{}, fmt.Errorf("volume number out of range [0, %d): '%s'", MaxVolumesPerResource, id)
+		}
+
+		volNr = v
+	}
+
+	return ID{ResourceName: parts[0], VolumeNumber: volNr}, nil
 }
 
 type SnapshotId struct {

--- a/pkg/volume/volume_test.go
+++ b/pkg/volume/volume_test.go
@@ -99,6 +99,327 @@ func TestDisklessFlag(t *testing.T) {
 	}
 }
 
+func TestParseVolumeId(t *testing.T) {
+	testcases := []struct {
+		name     string
+		id       string
+		expected volume.ID
+		isError  bool
+	}{
+		{
+			name:     "resource-only",
+			id:       "pvc-1234",
+			expected: volume.ID{ResourceName: "pvc-1234", VolumeNumber: 0},
+		},
+		{
+			name:     "explicit-volume-zero",
+			id:       "pvc-1234/0",
+			expected: volume.ID{ResourceName: "pvc-1234", VolumeNumber: 0},
+		},
+		{
+			name:     "explicit-volume-number",
+			id:       "pvc-1234/1",
+			expected: volume.ID{ResourceName: "pvc-1234", VolumeNumber: 1},
+		},
+		{
+			name:     "multi-digit-volume-number",
+			id:       "pvc-1234/42",
+			expected: volume.ID{ResourceName: "pvc-1234", VolumeNumber: 42},
+		},
+		{
+			name:     "max-volume-number",
+			id:       "pvc-1234/65535",
+			expected: volume.ID{ResourceName: "pvc-1234", VolumeNumber: 65535},
+		},
+		{
+			name:    "empty-string",
+			id:      "",
+			isError: true,
+		},
+		{
+			name:    "missing-resource-name",
+			id:      "/5",
+			isError: true,
+		},
+		{
+			name:    "only-separator",
+			id:      "/",
+			isError: true,
+		},
+		{
+			name:    "negative-volume-number",
+			id:      "pvc-1234/-1",
+			isError: true,
+		},
+		{
+			name:    "non-numeric-volume-number",
+			id:      "pvc-1234/abc",
+			isError: true,
+		},
+		{
+			name:    "missing-volume-number",
+			id:      "pvc-1234/",
+			isError: true,
+		},
+		{
+			name:    "extra-path-component",
+			id:      "pvc-1234/1/2",
+			isError: true,
+		},
+		{
+			name:    "volume-number-too-large",
+			id:      "pvc-1234/65536",
+			isError: true,
+		},
+		{
+			name:    "volume-number-overflows-int",
+			id:      "pvc-1234/99999999999999999999",
+			isError: true,
+		},
+	}
+
+	t.Parallel()
+
+	for i := range testcases {
+		tcase := testcases[i]
+		t.Run(tcase.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, err := volume.ParseVolumeId(tcase.id)
+			if tcase.isError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tcase.expected, actual)
+			}
+		})
+	}
+}
+
+func TestID_String(t *testing.T) {
+	testcases := []struct {
+		name     string
+		id       volume.ID
+		expected string
+	}{
+		{
+			name:     "volume-zero-omits-number",
+			id:       volume.ID{ResourceName: "pvc-1234", VolumeNumber: 0},
+			expected: "pvc-1234",
+		},
+		{
+			name:     "non-zero-volume-number",
+			id:       volume.ID{ResourceName: "pvc-1234", VolumeNumber: 1},
+			expected: "pvc-1234/1",
+		},
+		{
+			name:     "multi-digit-volume-number",
+			id:       volume.ID{ResourceName: "pvc-1234", VolumeNumber: 42},
+			expected: "pvc-1234/42",
+		},
+	}
+
+	t.Parallel()
+
+	for i := range testcases {
+		tcase := testcases[i]
+		t.Run(tcase.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tcase.expected, tcase.id.String())
+		})
+	}
+}
+
+func TestVolumeIdRoundTrip(t *testing.T) {
+	ids := []volume.ID{
+		{ResourceName: "pvc-1234", VolumeNumber: 0},
+		{ResourceName: "pvc-1234", VolumeNumber: 1},
+		{ResourceName: "pvc-1234", VolumeNumber: 42},
+	}
+
+	t.Parallel()
+
+	for i := range ids {
+		id := ids[i]
+		t.Run(id.String(), func(t *testing.T) {
+			t.Parallel()
+
+			parsed, err := volume.ParseVolumeId(id.String())
+			assert.NoError(t, err)
+			assert.Equal(t, id, parsed)
+		})
+	}
+}
+
+func TestParseSnapshotId(t *testing.T) {
+	testcases := []struct {
+		name     string
+		id       string
+		expected *volume.SnapshotId
+		isError  bool
+	}{
+		{
+			name: "s3-backup",
+			id:   "s3://remote-1/source-vol/snap-1",
+			expected: &volume.SnapshotId{
+				Type:         volume.SnapshotTypeS3,
+				Remote:       "remote-1",
+				SourceName:   "source-vol",
+				SnapshotName: "snap-1",
+			},
+		},
+		{
+			name: "linstor-l2l-backup",
+			id:   "linstor://remote-2/source-vol/snap-2",
+			expected: &volume.SnapshotId{
+				Type:         volume.SnapshotTypeLinstor,
+				Remote:       "remote-2",
+				SourceName:   "source-vol",
+				SnapshotName: "snap-2",
+			},
+		},
+		{
+			name: "in-cluster-without-remote",
+			id:   "incluster:///source-vol/snap-3",
+			expected: &volume.SnapshotId{
+				Type:         volume.SnapshotTypeInCluster,
+				Remote:       "",
+				SourceName:   "source-vol",
+				SnapshotName: "snap-3",
+			},
+		},
+		{
+			name: "scheme-is-case-insensitive",
+			id:   "S3://remote-1/source-vol/snap-1",
+			expected: &volume.SnapshotId{
+				Type:         volume.SnapshotTypeS3,
+				Remote:       "remote-1",
+				SourceName:   "source-vol",
+				SnapshotName: "snap-1",
+			},
+		},
+		{
+			name: "explicit-unknown-scheme",
+			id:   "unknown://remote-1/source-vol/snap-1",
+			expected: &volume.SnapshotId{
+				Type:         volume.SnapshotTypeUnknown,
+				Remote:       "remote-1",
+				SourceName:   "source-vol",
+				SnapshotName: "snap-1",
+			},
+		},
+		{
+			name: "legacy-snapshot-without-scheme",
+			id:   "snap-legacy",
+			expected: &volume.SnapshotId{
+				Type:         volume.SnapshotTypeUnknown,
+				SnapshotName: "snap-legacy",
+			},
+		},
+		{
+			name:    "unrecognized-scheme",
+			id:      "ftp://remote-1/source-vol/snap-1",
+			isError: true,
+		},
+		{
+			name:    "too-few-path-components",
+			id:      "s3://remote-1/only-one",
+			isError: true,
+		},
+		{
+			name:    "too-many-path-components",
+			id:      "s3://remote-1/source-vol/snap-1/extra",
+			isError: true,
+		},
+		{
+			name:    "missing-path",
+			id:      "s3://remote-1",
+			isError: true,
+		},
+		{
+			name:    "malformed-url",
+			id:      "s3://remote-1:notaport/source-vol/snap-1",
+			isError: true,
+		},
+	}
+
+	t.Parallel()
+
+	for i := range testcases {
+		tcase := testcases[i]
+		t.Run(tcase.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, err := volume.ParseSnapshotId(tcase.id)
+			if tcase.isError {
+				assert.Error(t, err)
+				assert.Nil(t, actual)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tcase.expected, actual)
+			}
+		})
+	}
+}
+
+func TestSnapshotId_String(t *testing.T) {
+	testcases := []struct {
+		name     string
+		snap     volume.SnapshotId
+		expected string
+	}{
+		{
+			name:     "s3-backup",
+			snap:     volume.SnapshotId{Type: volume.SnapshotTypeS3, Remote: "remote-1", SourceName: "source-vol", SnapshotName: "snap-1"},
+			expected: "S3://remote-1/source-vol/snap-1",
+		},
+		{
+			name:     "linstor-l2l-backup",
+			snap:     volume.SnapshotId{Type: volume.SnapshotTypeLinstor, Remote: "remote-2", SourceName: "source-vol", SnapshotName: "snap-2"},
+			expected: "Linstor://remote-2/source-vol/snap-2",
+		},
+		{
+			name:     "in-cluster",
+			snap:     volume.SnapshotId{Type: volume.SnapshotTypeInCluster, SourceName: "source-vol", SnapshotName: "snap-3"},
+			expected: "InCluster:///source-vol/snap-3",
+		},
+	}
+
+	t.Parallel()
+
+	for i := range testcases {
+		tcase := testcases[i]
+		t.Run(tcase.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tcase.expected, tcase.snap.String())
+		})
+	}
+}
+
+func TestSnapshotIdRoundTrip(t *testing.T) {
+	// Legacy snapshots (type Unknown, only a snapshot name) are intentionally
+	// excluded: they are a read-only compatibility path and do not round-trip
+	// through String().
+	ids := []volume.SnapshotId{
+		{Type: volume.SnapshotTypeS3, Remote: "remote-1", SourceName: "source-vol", SnapshotName: "snap-1"},
+		{Type: volume.SnapshotTypeLinstor, Remote: "remote-2", SourceName: "source-vol", SnapshotName: "snap-2"},
+		{Type: volume.SnapshotTypeInCluster, SourceName: "source-vol", SnapshotName: "snap-3"},
+	}
+
+	t.Parallel()
+
+	for i := range ids {
+		id := ids[i]
+		t.Run(id.String(), func(t *testing.T) {
+			t.Parallel()
+
+			parsed, err := volume.ParseSnapshotId(id.String())
+			assert.NoError(t, err)
+			assert.Equal(t, &id, parsed)
+		})
+	}
+}
+
 func TestParameters_ToResourceGroupModify(t *testing.T) {
 	testcases := []struct {
 		name            string

--- a/test/compat_test.go
+++ b/test/compat_test.go
@@ -142,12 +142,12 @@ func TestCompatFindSnapBySource(t *testing.T) {
 
 	compatClient := prepareFakeClient(t)
 
-	fakeVol := &volume.Info{ID: "fake"}
+	fakeVol := &volume.Info{ID: volume.ID{ResourceName: "fake", VolumeNumber: 0}}
 	empty, err := compatClient.FindSnapsBySource(ctx, fakeVol, 0, 0)
 	assert.NoError(t, err)
 	assert.Empty(t, empty)
 
-	volB := &volume.Info{ID: snapshotB.SourceName}
+	volB := &volume.Info{ID: volume.ID{ResourceName: snapshotB.SourceName, VolumeNumber: 0}}
 	actual, err := compatClient.FindSnapsBySource(ctx, volB, 0, 0)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, []*volume.Snapshot{snapshotB}, actual)


### PR DESCRIPTION
Replace the bare string Info.ID with an embedded volume.ID that carries both the resource name and the volume number, and add ParseVolumeId / String helpers along with an Info.Size() accessor.

Have the attach, detach, publish and expand paths operate on volume.ID and use its volume number instead of assuming the 0th volume.

Update the NFS exporter to address resources by ResourceName, rename the scheduler interface parameters to rdName for clarity, and add tests for the new ID and SnapshotId helpers.