### PR TITLE
clean up attach/detach path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deletion of incremental S3 backups no longer fails permanently when a backup
   is still the base of a newer increment. The delete is deferred and retried so
   the chain drains newest-first instead of leaking backups forever.
+- Deletion of diskless resource on detach now always preserves the tiebreaker.
 
 ## [1.11.2] - 2026-05-12
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/BurntSushi/toml v1.6.0
-	github.com/LINBIT/golinstor v0.61.1
+	github.com/LINBIT/golinstor v0.63.0
 	github.com/container-storage-interface/spec v1.12.0
 	github.com/coreos/go-systemd/v22 v22.7.0
 	github.com/kubernetes-csi/external-snapshotter/v8 v8.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
-github.com/LINBIT/golinstor v0.61.1 h1:3MAdGovwODRugWb0H90mSoVcoVnsS19lqXkW2R36B+A=
-github.com/LINBIT/golinstor v0.61.1/go.mod h1:XrBZ/is88K8Bw3QDZaxlwJDSgeMkiiATpv81dlZEOIk=
+github.com/LINBIT/golinstor v0.63.0 h1:UyMWCg45p8bk/uBAaN+Oki6jkmzEnLh7TA5KhevAkj0=
+github.com/LINBIT/golinstor v0.63.0/go.mod h1:XrBZ/is88K8Bw3QDZaxlwJDSgeMkiiATpv81dlZEOIk=
 github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=
 github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/pkg/client/linstor.go
+++ b/pkg/client/linstor.go
@@ -531,7 +531,7 @@ func (s *Linstor) Delete(ctx context.Context, id volume.ID) error {
 	})
 
 	for _, res := range resources {
-		err := s.client.Resources.Delete(ctx, id.ResourceName, res.NodeName)
+		err := s.client.Resources.Delete(ctx, id.ResourceName, res.NodeName, &lapi.ResourceDeleteOpts{KeepTiebreaker: false})
 		if err != nil {
 			// If two deletions run in parallel, one could get a 404 message, which we treat as "everything finished"
 			return nil404(err)
@@ -678,8 +678,6 @@ func (s *Linstor) Attach(ctx context.Context, id volume.ID, node string, rwxBloc
 		}
 	}
 
-	overrideProps := map[string]string{}
-
 	// If the resource is already on the node, don't worry about attaching, unless we also need to activate it.
 	if existingRes == nil || slices.Contains(existingRes.Flags, lapiconsts.FlagRscInactive) {
 		err := s.client.Resources.MakeAvailable(ctx, id.ResourceName, node, lapi.ResourceMakeAvailable{Diskful: false})
@@ -706,25 +704,12 @@ func (s *Linstor) Attach(ctx context.Context, id volume.ID, node string, rwxBloc
 			return "", err
 		}
 
-		if existingRes == nil {
-			overrideProps[linstor.PropertyCreatedFor] = linstor.CreatedForTemporaryDisklessAttach
-		}
-
 		newRsc, err := s.client.Resources.Get(ctx, id.ResourceName, node)
 		if err != nil {
 			return "", err
 		}
 
 		existingRes = &newRsc
-	}
-
-	if len(overrideProps) > 0 {
-		err = s.client.Resources.ModifyVolume(ctx, id.ResourceName, node, id.VolumeNumber, lapi.GenericPropsModify{
-			OverrideProps: overrideProps,
-		})
-		if err != nil {
-			return "", err
-		}
 	}
 
 	if slices.Contains(existingRes.Flags, lapiconsts.FlagDelete) {
@@ -804,20 +789,14 @@ func (s *Linstor) Detach(ctx context.Context, id volume.ID, node string) error {
 		return nil404(err)
 	}
 
-	createdFor, ok := vol.Props[linstor.PropertyCreatedFor]
-	if !ok || createdFor != linstor.CreatedForTemporaryDisklessAttach {
-		log.Info("resource not temporary (not created by Attach) not deleting")
-		return nil
-	}
-
 	if vol.ProviderKind != lapi.DISKLESS {
-		log.Info("temporary resource created by Attach is now diskfull, not deleting")
+		log.Info("resource not a diskless, not deleting")
 		return nil
 	}
 
 	log.Info("removing temporary resource")
 
-	return nil404(s.client.Resources.Delete(ctx, id.ResourceName, node))
+	return nil404(s.client.Resources.Delete(ctx, id.ResourceName, node, &lapi.ResourceDeleteOpts{KeepTiebreaker: true}))
 }
 
 // CapacityBytes returns the amount of free space in the storage pool specified by the params and topology.

--- a/pkg/client/linstor.go
+++ b/pkg/client/linstor.go
@@ -645,20 +645,10 @@ func (s *Linstor) Attach(ctx context.Context, id volume.ID, node string, rwxBloc
 		return "", fmt.Errorf("failed to attach resource with no deployed replica")
 	}
 
-	var existingRes *lapi.Resource
-
-	disklessFlag := ""
 	otherResInUse := 0
 
 	for i := range ress {
-		flag := getDisklessFlag(&ress[i])
-		if flag != "" && disklessFlag == "" {
-			disklessFlag = flag
-		}
-
-		if ress[i].NodeName == node {
-			existingRes = &ress[i]
-		} else if ress[i].State != nil && ress[i].State.InUse != nil && *ress[i].State.InUse {
+		if ress[i].NodeName != node && ress[i].State != nil && ress[i].State.InUse != nil && *ress[i].State.InUse {
 			otherResInUse++
 		}
 	}
@@ -678,46 +668,9 @@ func (s *Linstor) Attach(ctx context.Context, id volume.ID, node string, rwxBloc
 		}
 	}
 
-	// If the resource is already on the node, don't worry about attaching, unless we also need to activate it.
-	if existingRes == nil || slices.Contains(existingRes.Flags, lapiconsts.FlagRscInactive) {
-		err := s.client.Resources.MakeAvailable(ctx, id.ResourceName, node, lapi.ResourceMakeAvailable{Diskful: false})
-
-		if errors.Is(err, lapi.NotFoundError) {
-			// Make-available honors replica-on-same and replicas-on-different. We do not, as the import parts of that
-			// are already covered in the allowed topology bits.
-			s.log.WithError(err).Info("fall back to manual diskless creation after make-available refused")
-
-			if disklessFlag == "" {
-				return "", fmt.Errorf("resource does not support diskless attachment")
-			}
-
-			rCreate := lapi.ResourceCreate{Resource: lapi.Resource{
-				Name:     id.ResourceName,
-				NodeName: node,
-				Flags:    []string{disklessFlag},
-			}}
-
-			err = s.client.Resources.Create(ctx, rCreate)
-		}
-
-		if err != nil {
-			return "", err
-		}
-
-		newRsc, err := s.client.Resources.Get(ctx, id.ResourceName, node)
-		if err != nil {
-			return "", err
-		}
-
-		existingRes = &newRsc
-	}
-
-	if slices.Contains(existingRes.Flags, lapiconsts.FlagDelete) {
-		return "", &DeleteInProgressError{
-			Operation: "attach volume",
-			Kind:      "resource",
-			Name:      id.ResourceName,
-		}
+	err = s.client.Resources.MakeAvailable(ctx, id.ResourceName, node, lapi.ResourceMakeAvailable{Diskful: false})
+	if err != nil {
+		return "", err
 	}
 
 	vol, err := s.client.Resources.GetVolume(ctx, id.ResourceName, node, id.VolumeNumber)

--- a/pkg/client/linstor_test.go
+++ b/pkg/client/linstor_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/piraeusdatastore/linstor-csi/pkg/client/mocks"
-	"github.com/piraeusdatastore/linstor-csi/pkg/linstor"
 	lc "github.com/piraeusdatastore/linstor-csi/pkg/linstor/highlevelclient"
 	"github.com/piraeusdatastore/linstor-csi/pkg/topology"
 	"github.com/piraeusdatastore/linstor-csi/pkg/volume"
@@ -154,8 +153,6 @@ const (
 )
 
 func TestLinstor_Attach(t *testing.T) {
-	ResourceModifyReadWriteWithTemporaryAttach := lapi.GenericPropsModify{OverrideProps: map[string]string{linstor.PropertyCreatedFor: linstor.CreatedForTemporaryDisklessAttach}}
-
 	fromJson := func(s string) ([]lapi.Resource, error) {
 		var result []lapi.Resource
 
@@ -191,7 +188,6 @@ func TestLinstor_Attach(t *testing.T) {
 			{Method: "GetAll", Arguments: mock.Arguments{mock.Anything, ExampleResourceID}, ReturnArguments: mock.Arguments{rv, rvErr}},
 			{Method: "Get", Arguments: mock.Arguments{mock.Anything, ExampleResourceID, "node-3"}, ReturnArguments: mock.Arguments{lapi.Resource{}, nil}},
 			{Method: "MakeAvailable", Arguments: mock.Arguments{mock.Anything, ExampleResourceID, "node-3", lapi.ResourceMakeAvailable{Diskful: false}}, ReturnArguments: mock.Arguments{nil}},
-			{Method: "ModifyVolume", Arguments: mock.Arguments{mock.Anything, ExampleResourceID, "node-3", 0, ResourceModifyReadWriteWithTemporaryAttach}, ReturnArguments: mock.Arguments{nil}},
 			{Method: "GetVolume", Arguments: mock.Arguments{mock.Anything, ExampleResourceID, "node-3", 0}, ReturnArguments: mock.Arguments{lapi.Volume{DevicePath: "/dev/vol1"}, nil}},
 		}
 		cl := Linstor{client: &lc.HighLevelClient{Client: &lapi.Client{Resources: &m}}, log: logrus.WithField("test", t.Name())}
@@ -211,7 +207,6 @@ func TestLinstor_Attach(t *testing.T) {
 			{Method: "Get", Arguments: mock.Arguments{mock.Anything, ExampleResourceID, "node-3"}, ReturnArguments: mock.Arguments{lapi.Resource{}, nil}},
 			{Method: "MakeAvailable", Arguments: mock.Arguments{mock.Anything, ExampleResourceID, "node-3", lapi.ResourceMakeAvailable{Diskful: false}}, ReturnArguments: mock.Arguments{lapi.NotFoundError}},
 			{Method: "Create", Arguments: mock.Arguments{mock.Anything, lapi.ResourceCreate{Resource: lapi.Resource{Name: ExampleResourceID, NodeName: "node-3", Flags: []string{lapiconsts.FlagDrbdDiskless}}}}, ReturnArguments: mock.Arguments{nil}},
-			{Method: "ModifyVolume", Arguments: mock.Arguments{mock.Anything, ExampleResourceID, "node-3", 0, ResourceModifyReadWriteWithTemporaryAttach}, ReturnArguments: mock.Arguments{nil}},
 			{Method: "GetVolume", Arguments: mock.Arguments{mock.Anything, ExampleResourceID, "node-3", 0}, ReturnArguments: mock.Arguments{lapi.Volume{DevicePath: "/dev/vol1"}, nil}},
 		}
 		cl := Linstor{client: &lc.HighLevelClient{Client: &lapi.Client{Resources: &m}}, log: logrus.WithField("test", t.Name())}

--- a/pkg/client/linstor_test.go
+++ b/pkg/client/linstor_test.go
@@ -170,6 +170,7 @@ func TestLinstor_Attach(t *testing.T) {
 
 		m.ExpectedCalls = []*mock.Call{
 			{Method: "GetAll", Arguments: mock.Arguments{mock.Anything, ExampleResourceID}, ReturnArguments: mock.Arguments{rv, rvErr}},
+			{Method: "MakeAvailable", Arguments: mock.Arguments{mock.Anything, ExampleResourceID, "node-2", lapi.ResourceMakeAvailable{Diskful: false}}, ReturnArguments: mock.Arguments{nil}},
 			{Method: "GetVolume", Arguments: mock.Arguments{mock.Anything, ExampleResourceID, "node-2", 0}, ReturnArguments: mock.Arguments{lapi.Volume{DevicePath: "/dev/vol1"}, nil}},
 		}
 		cl := Linstor{client: &lc.HighLevelClient{Client: &lapi.Client{Resources: &m}}, log: logrus.WithField("test", t.Name())}
@@ -186,50 +187,12 @@ func TestLinstor_Attach(t *testing.T) {
 
 		m.ExpectedCalls = []*mock.Call{
 			{Method: "GetAll", Arguments: mock.Arguments{mock.Anything, ExampleResourceID}, ReturnArguments: mock.Arguments{rv, rvErr}},
-			{Method: "Get", Arguments: mock.Arguments{mock.Anything, ExampleResourceID, "node-3"}, ReturnArguments: mock.Arguments{lapi.Resource{}, nil}},
 			{Method: "MakeAvailable", Arguments: mock.Arguments{mock.Anything, ExampleResourceID, "node-3", lapi.ResourceMakeAvailable{Diskful: false}}, ReturnArguments: mock.Arguments{nil}},
 			{Method: "GetVolume", Arguments: mock.Arguments{mock.Anything, ExampleResourceID, "node-3", 0}, ReturnArguments: mock.Arguments{lapi.Volume{DevicePath: "/dev/vol1"}, nil}},
 		}
 		cl := Linstor{client: &lc.HighLevelClient{Client: &lapi.Client{Resources: &m}}, log: logrus.WithField("test", t.Name())}
 
 		path, err := cl.Attach(context.Background(), volume.ID{ResourceName: ExampleResourceID}, "node-3", false)
-		assert.NoError(t, err)
-		assert.Equal(t, "/dev/vol1", path)
-		m.AssertExpectations(t)
-	})
-
-	t.Run("no resource with expected diskfull resources - make-available conflict", func(t *testing.T) {
-		m := mocks.ResourceProvider{}
-		rv, rvErr := fromJson(ResourceOneOfflineQuorum)
-
-		m.ExpectedCalls = []*mock.Call{
-			{Method: "GetAll", Arguments: mock.Arguments{mock.Anything, ExampleResourceID}, ReturnArguments: mock.Arguments{rv, rvErr}},
-			{Method: "Get", Arguments: mock.Arguments{mock.Anything, ExampleResourceID, "node-3"}, ReturnArguments: mock.Arguments{lapi.Resource{}, nil}},
-			{Method: "MakeAvailable", Arguments: mock.Arguments{mock.Anything, ExampleResourceID, "node-3", lapi.ResourceMakeAvailable{Diskful: false}}, ReturnArguments: mock.Arguments{lapi.NotFoundError}},
-			{Method: "Create", Arguments: mock.Arguments{mock.Anything, lapi.ResourceCreate{Resource: lapi.Resource{Name: ExampleResourceID, NodeName: "node-3", Flags: []string{lapiconsts.FlagDrbdDiskless}}}}, ReturnArguments: mock.Arguments{nil}},
-			{Method: "GetVolume", Arguments: mock.Arguments{mock.Anything, ExampleResourceID, "node-3", 0}, ReturnArguments: mock.Arguments{lapi.Volume{DevicePath: "/dev/vol1"}, nil}},
-		}
-		cl := Linstor{client: &lc.HighLevelClient{Client: &lapi.Client{Resources: &m}}, log: logrus.WithField("test", t.Name())}
-
-		path, err := cl.Attach(context.Background(), volume.ID{ResourceName: ExampleResourceID}, "node-3", false)
-		assert.NoError(t, err)
-		assert.Equal(t, "/dev/vol1", path)
-		m.AssertExpectations(t)
-	})
-
-	t.Run("existing resource shared storage pool and read only", func(t *testing.T) {
-		m := mocks.ResourceProvider{}
-		rv, rvErr := fromJson(ResourceSharedStoragePool)
-
-		m.ExpectedCalls = []*mock.Call{
-			{Method: "GetAll", Arguments: mock.Arguments{mock.Anything, ExampleResourceID}, ReturnArguments: mock.Arguments{rv, rvErr}},
-			{Method: "Get", Arguments: mock.Arguments{mock.Anything, ExampleResourceID, "node-2"}, ReturnArguments: mock.Arguments{lapi.Resource{}, nil}},
-			{Method: "MakeAvailable", Arguments: mock.Arguments{mock.Anything, ExampleResourceID, "node-2", lapi.ResourceMakeAvailable{Diskful: false}}, ReturnArguments: mock.Arguments{nil}},
-			{Method: "GetVolume", Arguments: mock.Arguments{mock.Anything, ExampleResourceID, "node-2", 0}, ReturnArguments: mock.Arguments{lapi.Volume{DevicePath: "/dev/vol1"}, nil}},
-		}
-		cl := Linstor{client: &lc.HighLevelClient{Client: &lapi.Client{Resources: &m}}, log: logrus.WithField("test", t.Name())}
-
-		path, err := cl.Attach(context.Background(), volume.ID{ResourceName: ExampleResourceID}, "node-2", false)
 		assert.NoError(t, err)
 		assert.Equal(t, "/dev/vol1", path)
 		m.AssertExpectations(t)

--- a/pkg/client/mocks/ResourceProvider.go
+++ b/pkg/client/mocks/ResourceProvider.go
@@ -129,17 +129,24 @@ func (_m *ResourceProvider) Deactivate(ctx context.Context, resName string, node
 	return r0
 }
 
-// Delete provides a mock function with given fields: ctx, resName, nodeName
-func (_m *ResourceProvider) Delete(ctx context.Context, resName string, nodeName string) error {
-	ret := _m.Called(ctx, resName, nodeName)
+// Delete provides a mock function with given fields: ctx, resName, nodeName, opts
+func (_m *ResourceProvider) Delete(ctx context.Context, resName string, nodeName string, opts ...*client.ResourceDeleteOpts) error {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, resName, nodeName)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Delete")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
-		r0 = rf(ctx, resName, nodeName)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, ...*client.ResourceDeleteOpts) error); ok {
+		r0 = rf(ctx, resName, nodeName, opts...)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/pkg/linstor/const.go
+++ b/pkg/linstor/const.go
@@ -37,10 +37,6 @@ const (
 	// fully provisioned by this plugin.
 	PropertyProvisioningCompletedBy = lc.NamespcAuxiliary + "/csi-provisioning-completed-by"
 
-	// PropertyCreatedFor is the Aux props key in linstor used to identify why a specific object (for example, a
-	// resource) exists.
-	PropertyCreatedFor = lc.NamespcAuxiliary + "/csi-created-for"
-
 	// PropertyAllowTwoPrimaries is DRBD option to allow second primary. Mainly used for live-migration.
 	PropertyAllowTwoPrimaries = lc.NamespcDrbdNetOptions + "/allow-two-primaries"
 


### PR DESCRIPTION
We want to clean up any diskless resource we created while attaching. We only want to delete "extra" resources however, and not the tie breaker.

With an update to golinstor, we can pass the "KeepTiebreaker" flag to LINSTOR, so when we delete the diskless, we can be sure it will be taken over as tie breaker, if that is needed.