### PR TITLE
feat: carry volume number in snapshot ID

### DIFF
--- a/pkg/client/linstor.go
+++ b/pkg/client/linstor.go
@@ -977,6 +977,13 @@ func (s *Linstor) SnapCreate(ctx context.Context, id string, params *volume.Snap
 
 		if s != nil {
 			s.Type = params.Type
+
+			for _, sourceVolId := range sourceVolIds {
+				if sourceVolId.ResourceName == s.SourceName {
+					s.VolumeNumber = sourceVolId.VolumeNumber
+					break
+				}
+			}
 		}
 
 		result = append(result, s)
@@ -1892,6 +1899,8 @@ func (s *Linstor) FindSnapsByID(ctx context.Context, id string) ([]*volume.Snaps
 		return s.findInProgressOrLegacySnaps(ctx, id)
 	}
 
+	var snaps []*volume.Snapshot
+
 	switch snapshotId.Type {
 	case volume.SnapshotTypeInCluster, volume.SnapshotTypeLinstor:
 		lsnap, err := s.client.Resources.GetSnapshot(ctx, snapshotId.SourceName, snapshotId.SnapshotName)
@@ -1907,14 +1916,22 @@ func (s *Linstor) FindSnapsByID(ctx context.Context, id string) ([]*volume.Snaps
 
 		snap.Type = snapshotId.Type
 
-		return []*volume.Snapshot{snap}, nil
+		snaps = []*volume.Snapshot{snap}
 	case volume.SnapshotTypeS3:
-		return s.findS3Backup(ctx, snapshotId)
+		snaps, err = s.findS3Backup(ctx, snapshotId)
+		if err != nil {
+			return nil, err
+		}
 	default:
 		// Either, snapshot is not ready yet, or it is a "legacy" snapshot where we did not have this logic yet.
 	}
 
-	return nil, nil
+	// Set the correct volume number based on the requested source ID.
+	for _, snap := range snaps {
+		snap.VolumeNumber = snapshotId.VolumeNumber
+	}
+
+	return snaps, nil
 }
 
 type BackupWithRemote struct {
@@ -2179,6 +2196,9 @@ func (s *Linstor) FindSnapsBySource(ctx context.Context, sourceVol *volume.Info,
 			log.WithError(err).Warn("failed to convert LINSTOR to CSI snapshot, skipping...")
 			continue
 		}
+
+		csiSnap.VolumeNumber = sourceVol.VolumeNumber
+
 		result = append(result, csiSnap)
 	}
 
@@ -2186,6 +2206,7 @@ func (s *Linstor) FindSnapsBySource(ctx context.Context, sourceVol *volume.Info,
 }
 
 // ListSnaps returns list of snapshots available in the cluster, including those available in remote (S3) locations
+// This currently assumes all snapshots have just one relevant volume number 0.
 func (s *Linstor) ListSnaps(ctx context.Context, start, limit int) ([]*volume.Snapshot, error) {
 	log := s.log.WithFields(logrus.Fields{"start": start, "limit": limit})
 

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -1086,7 +1086,7 @@ func (d *Driver) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsReques
 	for i, snap := range snapshots {
 		entries[i] = &csi.ListSnapshotsResponse_Entry{Snapshot: &csi.Snapshot{
 			SnapshotId:     snap.String(),
-			SourceVolumeId: snap.SourceName,
+			SourceVolumeId: snap.Source().String(),
 			CreationTime:   timestamppb.New(snap.CreationTime),
 			SizeBytes:      snap.SizeBytes,
 			ReadyToUse:     snap.ReadyToUse,
@@ -1400,7 +1400,7 @@ func AggregateGroupSnapshot(id string, snapshots ...*volume.Snapshot) *csi.Volum
 
 		csiSnapshots = append(csiSnapshots, &csi.Snapshot{
 			SnapshotId:     snap.String(),
-			SourceVolumeId: snap.SourceName,
+			SourceVolumeId: snap.Source().String(),
 			CreationTime:   timestamppb.New(snap.CreationTime),
 			ReadyToUse:     snap.ReadyToUse,
 			SizeBytes:      snap.SizeBytes,
@@ -1684,6 +1684,7 @@ func (d *Driver) maybeDeleteLocalSnapshot(ctx context.Context, snap *volume.Snap
 		Type:         volume.SnapshotTypeInCluster,
 		SnapshotName: snap.SnapshotName,
 		SourceName:   snap.SourceName,
+		VolumeNumber: snap.VolumeNumber,
 	})
 }
 

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -103,14 +103,20 @@ type SnapshotId struct {
 	Type         SnapshotType
 	Remote       string
 	SourceName   string
+	VolumeNumber int
 	SnapshotName string
 }
 
-func (s *SnapshotId) String() string {
+// Source returns the volume the snapshot was taken from.
+func (s SnapshotId) Source() ID {
+	return ID{ResourceName: s.SourceName, VolumeNumber: s.VolumeNumber}
+}
+
+func (s SnapshotId) String() string {
 	return (&url.URL{
 		Scheme: s.Type.String(),
 		Host:   s.Remote,
-		Path:   fmt.Sprintf("/%s/%s", s.SourceName, s.SnapshotName),
+		Path:   fmt.Sprintf("/%s/%s", s.Source().String(), s.SnapshotName),
 	}).String()
 }
 
@@ -134,15 +140,35 @@ func ParseSnapshotId(id string) (*SnapshotId, error) {
 	}
 
 	parts := strings.Split(u.Path, "/")
-	if len(parts) != 3 {
-		return nil, fmt.Errorf("expected SnapshotId to contain two path components, got '%s' instead", u.Path)
+
+	var (
+		source   ID
+		snapName string
+	)
+
+	switch len(parts) {
+	case 3:
+		// "/<source>/<snapshot>": the volume number falls back to 0.
+		source = ID{ResourceName: parts[1]}
+		snapName = parts[2]
+	case 4:
+		// "/<source>/<volume number>/<snapshot>".
+		source, err = ParseVolumeId(parts[1] + "/" + parts[2])
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse snapshot source volume: %w", err)
+		}
+
+		snapName = parts[3]
+	default:
+		return nil, fmt.Errorf("expected SnapshotId to contain a source and snapshot name, got '%s' instead", u.Path)
 	}
 
 	return &SnapshotId{
 		Type:         ty,
 		Remote:       u.Host,
-		SourceName:   parts[1],
-		SnapshotName: parts[2],
+		SourceName:   source.ResourceName,
+		VolumeNumber: source.VolumeNumber,
+		SnapshotName: snapName,
 	}, nil
 }
 

--- a/pkg/volume/volume_test.go
+++ b/pkg/volume/volume_test.go
@@ -289,6 +289,39 @@ func TestParseSnapshotId(t *testing.T) {
 			},
 		},
 		{
+			name: "explicit-volume-zero",
+			id:   "s3://remote-1/source-vol/0/snap-1",
+			expected: &volume.SnapshotId{
+				Type:         volume.SnapshotTypeS3,
+				Remote:       "remote-1",
+				SourceName:   "source-vol",
+				VolumeNumber: 0,
+				SnapshotName: "snap-1",
+			},
+		},
+		{
+			name: "non-zero-volume-number",
+			id:   "s3://remote-1/source-vol/2/snap-1",
+			expected: &volume.SnapshotId{
+				Type:         volume.SnapshotTypeS3,
+				Remote:       "remote-1",
+				SourceName:   "source-vol",
+				VolumeNumber: 2,
+				SnapshotName: "snap-1",
+			},
+		},
+		{
+			name: "in-cluster-with-volume-number",
+			id:   "incluster:///source-vol/3/snap-3",
+			expected: &volume.SnapshotId{
+				Type:         volume.SnapshotTypeInCluster,
+				Remote:       "",
+				SourceName:   "source-vol",
+				VolumeNumber: 3,
+				SnapshotName: "snap-3",
+			},
+		},
+		{
 			name: "scheme-is-case-insensitive",
 			id:   "S3://remote-1/source-vol/snap-1",
 			expected: &volume.SnapshotId{
@@ -328,7 +361,17 @@ func TestParseSnapshotId(t *testing.T) {
 		},
 		{
 			name:    "too-many-path-components",
-			id:      "s3://remote-1/source-vol/snap-1/extra",
+			id:      "s3://remote-1/source-vol/1/snap-1/extra",
+			isError: true,
+		},
+		{
+			name:    "non-numeric-volume-number",
+			id:      "s3://remote-1/source-vol/abc/snap-1",
+			isError: true,
+		},
+		{
+			name:    "volume-number-out-of-range",
+			id:      "s3://remote-1/source-vol/65536/snap-1",
 			isError: true,
 		},
 		{
@@ -383,6 +426,16 @@ func TestSnapshotId_String(t *testing.T) {
 			snap:     volume.SnapshotId{Type: volume.SnapshotTypeInCluster, SourceName: "source-vol", SnapshotName: "snap-3"},
 			expected: "InCluster:///source-vol/snap-3",
 		},
+		{
+			name:     "volume-zero-omits-number",
+			snap:     volume.SnapshotId{Type: volume.SnapshotTypeS3, Remote: "remote-1", SourceName: "source-vol", VolumeNumber: 0, SnapshotName: "snap-1"},
+			expected: "S3://remote-1/source-vol/snap-1",
+		},
+		{
+			name:     "non-zero-volume-number",
+			snap:     volume.SnapshotId{Type: volume.SnapshotTypeS3, Remote: "remote-1", SourceName: "source-vol", VolumeNumber: 2, SnapshotName: "snap-1"},
+			expected: "S3://remote-1/source-vol/2/snap-1",
+		},
 	}
 
 	t.Parallel()
@@ -404,6 +457,8 @@ func TestSnapshotIdRoundTrip(t *testing.T) {
 		{Type: volume.SnapshotTypeS3, Remote: "remote-1", SourceName: "source-vol", SnapshotName: "snap-1"},
 		{Type: volume.SnapshotTypeLinstor, Remote: "remote-2", SourceName: "source-vol", SnapshotName: "snap-2"},
 		{Type: volume.SnapshotTypeInCluster, SourceName: "source-vol", SnapshotName: "snap-3"},
+		{Type: volume.SnapshotTypeS3, Remote: "remote-1", SourceName: "source-vol", VolumeNumber: 2, SnapshotName: "snap-1"},
+		{Type: volume.SnapshotTypeInCluster, SourceName: "source-vol", VolumeNumber: 7, SnapshotName: "snap-3"},
 	}
 
 	t.Parallel()


### PR DESCRIPTION
Add a VolumeNumber to SnapshotId so the source volume of a snapshot is preserved, mirroring the typed volume ID. The number is encoded as an extra path component (`/<source>/<volume>/<snapshot>`) and falls back to 0, in which case the ID is byte-identical to the previous format.

Populate the number where the source is authoritative (snapshot creation, lookup by ID, lookup by source) and report it via Source().String() as the CSI SourceVolumeId. LINSTOR does not store the CSI-side volume number, so FindSnapsByID recovers it from the requested ID.