### PR TITLE
nfs: add option to keep running on unschedulable nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `snap.linstor.csi.linbit.com/full-snapshot-after` snapshot class parameters to
   bound the length / age of incremental S3 backup chains, forcing a fresh full
   backup so that older backups become reclaimable.
+- Add option to keep running NFS on unschedulable nodes.
 
 ### Fixed
 

--- a/cmd/nfs-helper/start-stop-reactor.go
+++ b/cmd/nfs-helper/start-stop-reactor.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/env"
 
 	"github.com/piraeusdatastore/linstor-csi/pkg/utils"
 )
@@ -40,12 +41,17 @@ func startStopReactor(ctx context.Context, _ []string) error {
 		options.FieldSelector = fields.OneTermEqualSelector("metadata.name", os.Getenv("NODE_NAME")).String()
 	})
 
+	tolerateUnschedulable, err := env.GetBool("LINSTOR_CSI_TOLERATE_UNSCHEDULABLE", false)
+	if err != nil {
+		return fmt.Errorf("failed to parse LINSTOR_CSI_TOLERATE_UNSCHEDULABLE: %w", err)
+	}
+
 	_, err = nodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			startOrStopReactor(ctx, obj)
+			startOrStopReactor(ctx, obj, tolerateUnschedulable)
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
-			startOrStopReactor(ctx, newObj)
+			startOrStopReactor(ctx, newObj, tolerateUnschedulable)
 		},
 	})
 	if err != nil {
@@ -84,14 +90,14 @@ func startStopReactor(ctx context.Context, _ []string) error {
 	return eg.Wait()
 }
 
-func startOrStopReactor(ctx context.Context, node any) {
+func startOrStopReactor(ctx context.Context, node any, tolerateUnschedulable bool) {
 	n, ok := node.(*corev1.Node)
 	if !ok {
 		log.Printf("node %v is not a Node\n", node)
 		return
 	}
 
-	if n.Spec.Unschedulable {
+	if !tolerateUnschedulable && n.Spec.Unschedulable {
 		if err := exec.CommandContext(ctx, "systemctl", "stop", "drbd-reactor.service").Run(); err != nil {
 			log.Printf("failed to stop drbd-reactor: %s\n", err)
 		}

--- a/nfs/service/start-stop-reactor.service
+++ b/nfs/service/start-stop-reactor.service
@@ -4,7 +4,7 @@ Description=Ensures the expected NFS Units are managed by DRBD Reactor
 [Service]
 Type=simple
 ExecStart=/usr/bin/nfs-helper start-stop-reactor
-PassEnvironment=NODE_NAME POD_NAMESPACE REACTOR_CONFIG_MAP KUBERNETES_SERVICE_HOST KUBERNETES_SERVICE_PORT
+PassEnvironment=LINSTOR_CSI_TOLERATE_UNSCHEDULABLE NODE_NAME POD_NAMESPACE REACTOR_CONFIG_MAP KUBERNETES_SERVICE_HOST KUBERNETES_SERVICE_PORT
 
 RestrictNamespaces=yes
 LockPersonality=yes

--- a/nfs/service/start-stop-reactor.service
+++ b/nfs/service/start-stop-reactor.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Ensures the expected NFS Units are managed by DRBD Reactor
+FailureAction=exit
 
 [Service]
 Type=simple


### PR DESCRIPTION
We had users that first try to cordon their set of "old" nodes before starting the migration. These users then had the issue that all their NFS exports stopped because the volumes remained on all the unschedulable nodes.

For these users, we want to enable them to keep running the NFS export even on these nodes.

Also fixes an issue where the start-stop-reactor.service could crash without the container getting notified.