### PR TITLE
fix: converge parallel CreateVolume requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Concurrent `CreateVolume` requests that share a resource group, resource
+  definition, or volume definition no longer fail spuriously with "already
+  exists" errors. The reconcilers now treat these as success, so parallel
+  provisioning converges instead of relying on the external-provisioner retry.
 - Deletion of incremental S3 backups no longer fails permanently when a backup
   is still the base of a newer increment. The delete is deferred and retried so
   the chain drains newest-first instead of leaking backups forever.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/BurntSushi/toml v1.6.0
-	github.com/LINBIT/golinstor v0.63.0
+	github.com/LINBIT/golinstor v0.64.0
 	github.com/container-storage-interface/spec v1.12.0
 	github.com/coreos/go-systemd/v22 v22.7.0
 	github.com/kubernetes-csi/external-snapshotter/v8 v8.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
-github.com/LINBIT/golinstor v0.63.0 h1:UyMWCg45p8bk/uBAaN+Oki6jkmzEnLh7TA5KhevAkj0=
-github.com/LINBIT/golinstor v0.63.0/go.mod h1:XrBZ/is88K8Bw3QDZaxlwJDSgeMkiiATpv81dlZEOIk=
+github.com/LINBIT/golinstor v0.64.0 h1:WFrpnlGru56gsvLVrJOXmeC2DiVlyUbBemycWcrAr/I=
+github.com/LINBIT/golinstor v0.64.0/go.mod h1:XrBZ/is88K8Bw3QDZaxlwJDSgeMkiiATpv81dlZEOIk=
 github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=
 github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/pkg/client/linstor.go
+++ b/pkg/client/linstor.go
@@ -1080,7 +1080,7 @@ func (s *Linstor) reconcileBackup(ctx context.Context, id string, params *volume
 func (s *Linstor) backupChainExhausted(ctx context.Context, params *volume.SnapshotParameters, rscName string) (bool, error) {
 	backups, err := s.client.Backup.GetAll(ctx, params.RemoteName, rscName, "")
 	if err != nil {
-		if lapi.IsApiCallError(err, lapiconsts.FailInvldRemoteName) {
+		if errors.Is(err, lapi.ApiCallRcErr(lapiconsts.FailInvldRemoteName)) {
 			// No remote yet -> nothing to base an incremental on.
 			return false, nil
 		}
@@ -1273,7 +1273,7 @@ func (s *Linstor) SnapDelete(ctx context.Context, snap *volume.SnapshotId) error
 		// incremental is "based on" an earlier backup, and LINSTOR refuses to
 		// delete one another increment still depends on, so we need the full set.
 		backups, err := s.client.Backup.GetAll(ctx, snap.Remote, snap.SourceName, "")
-		if err != nil && !lapi.IsApiCallError(err, lapiconsts.FailInvldRemoteName) {
+		if err != nil && !errors.Is(err, lapi.ApiCallRcErr(lapiconsts.FailInvldRemoteName)) {
 			// Ignore errors caused by missing remotes: no remote -> no snapshots to delete.
 			return fmt.Errorf("failed to list backups for snapshot %s: %w", snap.String(), err)
 		}
@@ -1574,6 +1574,11 @@ func (s *Linstor) reconcileSnapshotVolumeDefinitions(ctx context.Context, snapsh
 		restoreConf := lapi.SnapshotRestore{ToResource: targetRD}
 
 		err := s.client.Resources.RestoreVolumeDefinitionSnapshot(ctx, snapshot.SourceName, snapshot.SnapshotName, restoreConf)
+		if errors.Is(err, lapi.ApiCallRcErr(lapiconsts.FailExistsVlmDfn)) {
+			// A concurrent restore already created them; nothing left to do.
+			return nil
+		}
+
 		if err != nil {
 			return fmt.Errorf("could not restore volume definitions: %w", err)
 		}
@@ -1635,6 +1640,11 @@ func (s *Linstor) reconcileSnapshotResources(ctx context.Context, snapshot *volu
 	restoreConf := lapi.SnapshotRestore{ToResource: targetRD, Nodes: []string{selectedNode}}
 
 	err = s.client.Resources.RestoreSnapshot(ctx, snapshot.SourceName, snapshot.SnapshotName, restoreConf)
+	if errors.Is(err, lapi.ApiCallRcErr(lapiconsts.FailExistsRsc)) {
+		// A concurrent restore already created the resource; nothing left to do.
+		return nil
+	}
+
 	if err != nil {
 		return fmt.Errorf("could not restore resources: %w", err)
 	}
@@ -1661,19 +1671,18 @@ func (s *Linstor) reconcileResourceGroup(ctx context.Context, params *volume.Par
 	// does the RG already exist?
 	rg, err := s.client.ResourceGroups.Get(ctx, rgName)
 	if errors.Is(err, lapi.NotFoundError) {
-		// just create the minimal RG/VG, we sync all the props then anyways.
+		// just create the minimal RG, we sync all the props then anyways.
 		resourceGroup := lapi.ResourceGroup{
 			Name:         rgName,
 			Props:        make(map[string]string),
 			SelectFilter: lapi.AutoSelectFilter{},
 		}
-		volumeGroup := lapi.VolumeGroup{}
-		if err := s.client.ResourceGroups.Create(ctx, resourceGroup); err != nil {
+
+		// A concurrent CreateVolume may have created it first.
+		if err := s.client.ResourceGroups.Create(ctx, resourceGroup); err != nil && !errors.Is(err, lapi.ApiCallRcErr(lapiconsts.FailExistsRscGrp)) {
 			return nil, err
 		}
-		if err := s.client.ResourceGroups.CreateVolumeGroup(ctx, rgName, volumeGroup); err != nil {
-			return nil, err
-		}
+
 		rg, err = s.client.ResourceGroups.Get(ctx, rgName)
 		if err != nil {
 			return nil, err
@@ -1719,8 +1728,9 @@ func (s *Linstor) reconcileResourceDefinition(ctx context.Context, rdName, rgNam
 			},
 		}
 
+		// A concurrent CreateVolume may have created it first.
 		err = s.client.ResourceDefinitions.Create(ctx, rdCreate)
-		if err != nil {
+		if err != nil && !errors.Is(err, lapi.ApiCallRcErr(lapiconsts.FailExistsRscDfn)) {
 			return nil, err
 		}
 
@@ -1773,8 +1783,9 @@ func (s *Linstor) reconcileVolumeDefinition(ctx context.Context, info *volume.In
 				},
 			}
 
+			// A concurrent CreateVolume may have created it first.
 			err = s.client.ResourceDefinitions.CreateVolumeDefinition(ctx, info.ResourceName, vdCreate)
-			if err != nil {
+			if err != nil && !errors.Is(err, lapi.ApiCallRcErr(lapiconsts.FailExistsVlmDfn)) {
 				return err
 			}
 
@@ -2851,7 +2862,7 @@ func (s *Linstor) deleteResourceDefinitionAndGroupIfUnused(ctx context.Context, 
 
 	err = s.client.ResourceGroups.Delete(ctx, rDef.ResourceGroupName)
 	if err != nil {
-		if lapi.IsApiCallError(err, lapiconsts.FailExistsRscDfn) {
+		if errors.Is(err, lapi.ApiCallRcErr(lapiconsts.FailExistsRscDfn)) {
 			return nil
 		}
 

--- a/pkg/topology/scheduler/autoplacetopology/autoplacetopology.go
+++ b/pkg/topology/scheduler/autoplacetopology/autoplacetopology.go
@@ -2,6 +2,7 @@ package autoplacetopology
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"sort"
@@ -135,7 +136,7 @@ func (s *Scheduler) Create(ctx context.Context, volId string, params *volume.Par
 
 		err := s.Resources.Autoplace(ctx, volId, req)
 		if err != nil {
-			if lapi.IsApiCallError(err, linstor.FailNotEnoughNodes) {
+			if errors.Is(err, lapi.ApiCallRcErr(linstor.FailNotEnoughNodes)) {
 				// We need a special return code when the requisite could not be fulfilled
 				return status.Errorf(codes.ResourceExhausted, "failed to enough replicas on requisite nodes: %v", err)
 			}


### PR DESCRIPTION
Concurrent CreateVolume calls that share a resource group, resource definition, or volume definition raced on the "get, then create" reconcilers: the loser got an "already exists" error that failed the whole request. Treat the matching FailExists* return code as success so parallel provisioning converges instead of relying on the external-provisioner retry.

Drop the empty volume group creation in reconcileResourceGroup. The driver creates volume definitions directly and their count varies (one for a normal volume, two for an NFS volume), so a fixed volume-group template is never used; creating it only added another create race.

Use the idiomatic errors.Is(err, lapi.ApiCallRcErr(mask)) throughout instead of the lapi.IsApiCallError helper. ApiCallRcErr is new in golinstor v0.64.0, so bump the dependency.