### PR TITLE
Rework Kubernetes client injection

### DIFF
--- a/cmd/linstor-csi/linstor-csi.go
+++ b/cmd/linstor-csi/linstor-csi.go
@@ -57,17 +57,21 @@ func main() {
 		labelBySP                 = flag.Bool("label-by-storage-pool", true, "Set to false to disable labeling of nodes based on their configured storage pools.")
 		nodeCacheTimeout          = flag.Duration("node-cache-timeout", 1*time.Minute, "Duration for which the results of node and storage pool related API responses should be cached.")
 		resourceCacheTimeout      = flag.Duration("resource-cache-timeout", 30*time.Second, "Duration for which the results of resource related API responses should be cached.")
-		resyncAfter               = flag.Duration("resync-after", 5*time.Minute, "Duration after which reconciliations (such as for VolumeSnapshotClasses) should be rerun. Set to 0 to disable.")
+		resyncAfter               = flag.Duration("resync-after", 5*time.Minute, "Duration after which reconciliations (such as for VolumeSnapshotClasses) should be rerun.")
 		enableRWX                 = flag.Bool("enable-rwx", false, "Enable RWX support via NFS (requires running in Kubernetes).")
 		namespace                 = flag.String("nfs-service-namespace", "", "The namespace the NFS service is running in.")
 		reactorConfigMapName      = flag.String("nfs-reactor-config-map-name", "linstor-csi-nfs-reactor-config", "Name of the config map used to store promoter configuration")
 		disableRWXBlockValidation = flag.Bool("disable-rwx-block-validation", false, "Disable KubeVirt VM ownership validation for RWX block volumes.")
 		enableConsistencyGroups   = flag.Bool("enable-consistency-groups", false, "Place PVCs sharing a linstor.csi.linbit.com/consistency-group label as separate volumes of one LINSTOR resource (requires running in Kubernetes).")
+		enableSnapshotClasses     = flag.Bool("enable-volume-snapshot-classes", true, "Enable VolumeSnapshotClass handling: reconcile VolumeSnapshotClasses and read snapshot-class parameters (requires running in Kubernetes).")
 	)
 
 	flag.Var(&volume.DefaultRemoteAccessPolicy, "default-remote-access-policy", "")
 
 	flag.Parse()
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
 
 	// TODO: Take log outputs and options from the command line.
 	logOut := os.Stderr
@@ -153,8 +157,18 @@ func main() {
 		driver.LogOut(logOut),
 		driver.NodeID(*node),
 		driver.TopologyPrefix(*propNs),
-		driver.KubeClient(kubeDynamic),
-		driver.ResyncAfter(*resyncAfter),
+	}
+
+	if *enableSnapshotClasses {
+		if kubeErr != nil {
+			log.Warnf("Failed to enable VolumeSnapshotClass handling, continuing without it: %s", kubeErr)
+		} else {
+			opts = append(opts, driver.SnapshotClient(kubeDynamic))
+
+			if err := driver.ReconcileVolumeSnapshotClass(ctx, kubeDynamic, linstorClient, logger, *resyncAfter); err != nil {
+				log.Fatalf("Failed to start VolumeSnapshotClass reconciler: %s", err)
+			}
+		}
 	}
 
 	if *enableRWX {
@@ -199,9 +213,6 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-	defer stop()
 
 	if err := drv.Serve(ctx, listener); err != nil {
 		log.Fatal(err)

--- a/cmd/linstor-csi/linstor-csi.go
+++ b/cmd/linstor-csi/linstor-csi.go
@@ -192,7 +192,12 @@ func main() {
 		if kubeErr != nil {
 			log.Warnf("Failed to enable RWX block validation support, continuing without it: %s", kubeErr)
 		} else {
-			opts = append(opts, driver.EnableRWXBlockValidation(kubeTyped))
+			validator, err := utils.NewRWXBlockValidator(ctx, kubeTyped, *resyncAfter, logger)
+			if err != nil {
+				log.Fatalf("Failed to enable block validation: %s", err)
+			}
+
+			opts = append(opts, driver.EnableRWXBlockValidation(validator))
 		}
 	}
 

--- a/cmd/linstor-csi/linstor-csi.go
+++ b/cmd/linstor-csi/linstor-csi.go
@@ -145,8 +145,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	// Build the Kubernetes clients once. They are nil when not running in Kubernetes; features that need
-	// them (RWX, snapshot-class syncing, RWX-block validation) handle their absence.
+	// Build the Kubernetes clients once. They are nil when not running in Kubernetes
 	kubeTyped, kubeDynamic, kubeErr := utils.KubernetesClient()
 
 	opts := []func(*driver.Driver) error{
@@ -160,31 +159,35 @@ func main() {
 
 	if *enableRWX {
 		if kubeErr != nil {
-			log.Fatalf("RWX support requires running in Kubernetes: %s", kubeErr)
-		}
+			log.Warnf("Failed to enable RWX support, continuing without it: %s", kubeErr)
+		} else {
+			if *namespace == "" {
+				content, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+				if err != nil {
+					log.Fatalf("RWX enabled but no valid service namespace could be found: %s", err)
+				}
 
-		if *namespace == "" {
-			content, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
-			if err != nil {
-				log.Fatalf("RWX enabled but no valid service namespace could be found: %s", err)
+				*namespace = strings.TrimSpace(string(content))
 			}
 
-			*namespace = strings.TrimSpace(string(content))
+			opts = append(opts, driver.ConfigureRWX(kubeTyped, *namespace, *reactorConfigMapName))
 		}
-
-		opts = append(opts, driver.ConfigureRWX(kubeTyped, *namespace, *reactorConfigMapName))
 	}
 
-	if *disableRWXBlockValidation {
-		opts = append(opts, driver.DisableRWXBlockValidation())
+	if !*disableRWXBlockValidation {
+		if kubeErr != nil {
+			log.Warnf("Failed to enable RWX block validation support, continuing without it: %s", kubeErr)
+		} else {
+			opts = append(opts, driver.EnableRWXBlockValidation(kubeTyped))
+		}
 	}
 
 	if *enableConsistencyGroups {
 		if kubeErr != nil {
-			log.Fatalf("consistency-group support requires running in Kubernetes: %s", kubeErr)
+			log.Warnf("Failed to enable consistency-group support, continuing without it: %s", kubeErr)
+		} else {
+			opts = append(opts, driver.ConfigureConsistencyGroups(kubeTyped))
 		}
-
-		opts = append(opts, driver.ConfigureConsistencyGroups())
 	}
 
 	drv, err := driver.NewDriver(linstorClient, opts...)

--- a/cmd/linstor-csi/linstor-csi.go
+++ b/cmd/linstor-csi/linstor-csi.go
@@ -150,7 +150,7 @@ func main() {
 	}
 
 	// Build the Kubernetes clients once. They are nil when not running in Kubernetes
-	kubeTyped, kubeDynamic, kubeErr := utils.KubernetesClient()
+	kubeTyped, kubeSnapshot, kubeErr := utils.KubernetesClient()
 
 	opts := []func(*driver.Driver) error{
 		driver.LogLevel(*logLevel),
@@ -163,9 +163,9 @@ func main() {
 		if kubeErr != nil {
 			log.Warnf("Failed to enable VolumeSnapshotClass handling, continuing without it: %s", kubeErr)
 		} else {
-			opts = append(opts, driver.SnapshotClient(kubeDynamic))
+			opts = append(opts, driver.SnapshotClient(kubeSnapshot))
 
-			if err := driver.ReconcileVolumeSnapshotClass(ctx, kubeDynamic, linstorClient, logger, *resyncAfter); err != nil {
+			if err := driver.ReconcileVolumeSnapshotClass(ctx, kubeSnapshot, kubeTyped, linstorClient, logger, *resyncAfter); err != nil {
 				log.Fatalf("Failed to start VolumeSnapshotClass reconciler: %s", err)
 			}
 		}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/LINBIT/golinstor v0.64.1
 	github.com/container-storage-interface/spec v1.12.0
 	github.com/coreos/go-systemd/v22 v22.7.0
+	github.com/kubernetes-csi/external-snapshotter/client/v8 v8.6.0
 	github.com/kubernetes-csi/external-snapshotter/v8 v8.6.0
 	github.com/pborman/uuid v1.2.1
 	github.com/piraeusdatastore/nri-volume-qos v0.1.3
@@ -54,7 +55,6 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kubernetes-csi/csi-test/v5 v5.5.0 // indirect
-	github.com/kubernetes-csi/external-snapshotter/client/v8 v8.6.0 // indirect
 	github.com/moby/sys/mountinfo v0.7.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -73,8 +73,8 @@ type Driver struct {
 	topologyPrefix string
 	// snapshotClient reads VolumeSnapshotClass/Content objects for snapshot-parameter lookups.
 	snapshotClient snapclientset.Interface
-	// rwxBlockValidationClient, when set, enables KubeVirt VM ownership validation for RWX block volumes.
-	rwxBlockValidationClient kubernetes.Interface
+	// rwxBlockValidator resolves volumes to their PV/PVC via a volume-handle index; built once in Serve.
+	rwxBlockValidator *utils.RWXBlockValidator
 	// consistencyGroupClient, when set, places PVCs sharing a consistency-group label as volume numbers of one resource.
 	consistencyGroupClient kubernetes.Interface
 
@@ -213,11 +213,10 @@ func ConfigureRWX(cl kubernetes.Interface, namespace, reactorConfigMap string) f
 
 // EnableRWXBlockValidation enables the KubeVirt VM ownership validation for RWX block volumes.
 // When enabled, the driver checks that multiple pods using the same RWX block volume belong to
-// the same VM, guarding against misuse of allow-two-primaries. The client is used to read the
-// PV/PVC objects.
-func EnableRWXBlockValidation(client kubernetes.Interface) func(*Driver) error {
+// the same VM, guarding against misuse of allow-two-primaries.
+func EnableRWXBlockValidation(validator *utils.RWXBlockValidator) func(*Driver) error {
 	return func(d *Driver) error {
-		d.rwxBlockValidationClient = client
+		d.rwxBlockValidator = validator
 		return nil
 	}
 }
@@ -854,8 +853,8 @@ func (d *Driver) ControllerPublishVolume(ctx context.Context, req *csi.Controlle
 	rwxBlock := req.VolumeCapability.AccessMode.GetMode() == csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER && req.VolumeCapability.GetBlock() != nil
 
 	// Validate RWX block attachment to prevent misuse of allow-two-primaries
-	if rwxBlock && d.rwxBlockValidationClient != nil {
-		if _, err := utils.ValidateRWXBlockAttachment(ctx, d.rwxBlockValidationClient, d.log, req.GetVolumeId()); err != nil {
+	if rwxBlock && d.rwxBlockValidator != nil {
+		if _, err := d.rwxBlockValidator.ValidateAttachment(ctx, req.GetVolumeId()); err != nil {
 			return nil, status.Errorf(codes.FailedPrecondition,
 				"ControllerPublishVolume failed for %s: %v", req.GetVolumeId(), err)
 		}

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -33,7 +33,6 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"time"
 
 	lc "github.com/LINBIT/golinstor"
 	"github.com/LINBIT/golinstor/devicelayerkind"
@@ -63,7 +62,6 @@ var Version = "UNKNOWN"
 // Driver fullfils CSI controller, node, and indentity server interfaces.
 type Driver struct {
 	linstorClient *client.Linstor
-	kubeClient    dynamic.Interface
 	nfsExporter   *NfsExporter
 	log           *logrus.Entry
 	version       string
@@ -74,8 +72,8 @@ type Driver struct {
 	nodeID string
 	// topologyPrefix is the name
 	topologyPrefix string
-	// resyncAfter is the interval after which reconciliations should be retried
-	resyncAfter time.Duration
+	// snapshotClient reads VolumeSnapshotClass/Content objects for snapshot-parameter lookups.
+	snapshotClient dynamic.Interface
 	// rwxBlockValidationClient, when set, enables KubeVirt VM ownership validation for RWX block volumes.
 	rwxBlockValidationClient kubernetes.Interface
 	// consistencyGroupClient, when set, places PVCs sharing a consistency-group label as volume numbers of one resource.
@@ -98,7 +96,6 @@ func NewDriver(linstorClient *client.Linstor, options ...func(*Driver) error) (*
 		nodeID:         "localhost",
 		log:            logrus.NewEntry(logrus.New()),
 		topologyPrefix: lc.NamespcAuxiliary,
-		resyncAfter:    5 * time.Minute,
 	}
 
 	d.log.Logger.SetOutput(ioutil.Discard)
@@ -182,11 +179,12 @@ func LogLevel(s string) func(*Driver) error {
 	}
 }
 
-// KubeClient sets the dynamic Kubernetes client used to read PVC/PV objects. It is built once in main
-// (nil when not running in Kubernetes); callers that need Kubernetes access guard on a nil client.
-func KubeClient(client dynamic.Interface) func(*Driver) error {
+// SnapshotClient sets the client used to read VolumeSnapshotClass/Content objects when resolving
+// snapshot parameters during snapshot operations.
+func SnapshotClient(client dynamic.Interface) func(*Driver) error {
 	return func(d *Driver) error {
-		d.kubeClient = client
+		d.snapshotClient = client
+
 		return nil
 	}
 }
@@ -210,17 +208,6 @@ func ConfigureRWX(cl kubernetes.Interface, namespace, reactorConfigMap string) f
 			log:              d.log.WithField("component", "nfsExporter"),
 		}
 
-		return nil
-	}
-}
-
-// ResyncAfter sets the interval in which certain resources should be synced.
-//
-// Currently, this only applies to VolumeSnapshotClassses.
-// Set to 0 to disable syncing.
-func ResyncAfter(resyncAfter time.Duration) func(*Driver) error {
-	return func(d *Driver) error {
-		d.resyncAfter = resyncAfter
 		return nil
 	}
 }
@@ -1624,13 +1611,6 @@ func (d *Driver) Serve(ctx context.Context, listener net.Listener) error {
 		return resp, err
 	}
 
-	if d.kubeClient != nil && d.resyncAfter > 0 {
-		err := ReconcileVolumeSnapshotClass(ctx, d.kubeClient, d.linstorClient, d.log, d.resyncAfter)
-		if err != nil {
-			return fmt.Errorf("failed to start volume snapshot class reconciler")
-		}
-	}
-
 	srv := grpc.NewServer(grpc.UnaryInterceptor(errHandler))
 	csi.RegisterIdentityServer(srv, d)
 	csi.RegisterControllerServer(srv, d)
@@ -1791,7 +1771,7 @@ func findMatchingSnapshotClassName(snapId string, contents ...unstructured.Unstr
 }
 
 func (d *Driver) maybeGetSnapshotParameters(ctx context.Context, snapshotID string) (*volume.SnapshotParameters, error) {
-	if d.kubeClient == nil {
+	if d.snapshotClient == nil {
 		return nil, nil
 	}
 
@@ -1799,7 +1779,7 @@ func (d *Driver) maybeGetSnapshotParameters(ctx context.Context, snapshotID stri
 	contentGvr := gv.WithResource("volumesnapshotcontents")
 	classGvr := gv.WithResource("volumesnapshotclasses")
 
-	result, err := d.kubeClient.Resource(contentGvr).List(ctx, metav1.ListOptions{})
+	result, err := d.snapshotClient.Resource(contentGvr).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch list of snapshot contents")
 	}
@@ -1809,7 +1789,7 @@ func (d *Driver) maybeGetSnapshotParameters(ctx context.Context, snapshotID stri
 		return nil, fmt.Errorf("failed to determine snapshot class name")
 	}
 
-	class, err := d.kubeClient.Resource(classGvr).Get(ctx, snapshotClassName, metav1.GetOptions{})
+	class, err := d.snapshotClient.Resource(classGvr).Get(ctx, snapshotClassName, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch snapshot class: %w", err)
 	}

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -37,6 +37,8 @@ import (
 	lc "github.com/LINBIT/golinstor"
 	"github.com/LINBIT/golinstor/devicelayerkind"
 	"github.com/container-storage-interface/spec/lib/go/csi"
+	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	snapclientset "github.com/kubernetes-csi/external-snapshotter/client/v8/clientset/versioned"
 	"github.com/piraeusdatastore/nri-volume-qos/pkg/meta"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
@@ -44,10 +46,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/piraeusdatastore/linstor-csi/pkg/client"
@@ -73,7 +72,7 @@ type Driver struct {
 	// topologyPrefix is the name
 	topologyPrefix string
 	// snapshotClient reads VolumeSnapshotClass/Content objects for snapshot-parameter lookups.
-	snapshotClient dynamic.Interface
+	snapshotClient snapclientset.Interface
 	// rwxBlockValidationClient, when set, enables KubeVirt VM ownership validation for RWX block volumes.
 	rwxBlockValidationClient kubernetes.Interface
 	// consistencyGroupClient, when set, places PVCs sharing a consistency-group label as volume numbers of one resource.
@@ -181,7 +180,7 @@ func LogLevel(s string) func(*Driver) error {
 
 // SnapshotClient sets the client used to read VolumeSnapshotClass/Content objects when resolving
 // snapshot parameters during snapshot operations.
-func SnapshotClient(client dynamic.Interface) func(*Driver) error {
+func SnapshotClient(client snapclientset.Interface) func(*Driver) error {
 	return func(d *Driver) error {
 		d.snapshotClient = client
 
@@ -190,7 +189,7 @@ func SnapshotClient(client dynamic.Interface) func(*Driver) error {
 }
 
 // ConfigureConsistencyGroups enables consistency-group support: CreateVolume reads each PVC's group label and
-// places grouped volumes in one shared resource. The client is used to read the PVCs.
+// places grouped volumes in one shared resource.
 func ConfigureConsistencyGroups(client kubernetes.Interface) func(*Driver) error {
 	return func(d *Driver) error {
 		d.consistencyGroupClient = client
@@ -1747,24 +1746,26 @@ func (d *Driver) createNewVolume(ctx context.Context, info *volume.Info, params 
 	}, nil
 }
 
-func findMatchingSnapshotClassName(snapId string, contents ...unstructured.Unstructured) string {
+func findMatchingSnapshotClassName(snapId string, contents ...snapv1.VolumeSnapshotContent) string {
 	for i := range contents {
-		content := contents[i].Object
-		if driver, _, _ := unstructured.NestedString(content, "spec", "driver"); driver != linstor.DriverName {
+		content := contents[i]
+		if content.Spec.Driver != linstor.DriverName {
 			continue
 		}
 
-		if handle, _, _ := unstructured.NestedString(content, "status", "snapshotHandle"); handle != snapId {
+		if content.Status == nil || content.Status.SnapshotHandle == nil || *content.Status.SnapshotHandle != snapId {
 			continue
 		}
 
-		if readyToUse, _, _ := unstructured.NestedBool(content, "status", "readyToUse"); !readyToUse {
+		if content.Status.ReadyToUse == nil || !*content.Status.ReadyToUse {
 			continue
 		}
 
-		snapshotClass, _, _ := unstructured.NestedString(content, "spec", "volumeSnapshotClassName")
+		if content.Spec.VolumeSnapshotClassName == nil {
+			continue
+		}
 
-		return snapshotClass
+		return *content.Spec.VolumeSnapshotClassName
 	}
 
 	return ""
@@ -1775,11 +1776,7 @@ func (d *Driver) maybeGetSnapshotParameters(ctx context.Context, snapshotID stri
 		return nil, nil
 	}
 
-	gv := schema.GroupVersion{Group: "snapshot.storage.k8s.io", Version: "v1"}
-	contentGvr := gv.WithResource("volumesnapshotcontents")
-	classGvr := gv.WithResource("volumesnapshotclasses")
-
-	result, err := d.snapshotClient.Resource(contentGvr).List(ctx, metav1.ListOptions{})
+	result, err := d.snapshotClient.SnapshotV1().VolumeSnapshotContents().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch list of snapshot contents")
 	}
@@ -1789,17 +1786,12 @@ func (d *Driver) maybeGetSnapshotParameters(ctx context.Context, snapshotID stri
 		return nil, fmt.Errorf("failed to determine snapshot class name")
 	}
 
-	class, err := d.snapshotClient.Resource(classGvr).Get(ctx, snapshotClassName, metav1.GetOptions{})
+	class, err := d.snapshotClient.SnapshotV1().VolumeSnapshotClasses().Get(ctx, snapshotClassName, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch snapshot class: %w", err)
 	}
 
-	rawParams, _, err := unstructured.NestedStringMap(class.Object, "parameters")
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse snapshot class: %w", err)
-	}
-
-	return volume.NewSnapshotParameters(rawParams, nil)
+	return volume.NewSnapshotParameters(class.Parameters, nil)
 }
 
 // maybeDeleteLocalSnapshot deletes the local portion of a snapshot according to their volume.SnapshotParameters.

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -60,9 +60,6 @@ import (
 // Version is set via ldflags configued in the Makefile.
 var Version = "UNKNOWN"
 
-// pvcGVR reads PersistentVolumeClaims via the dynamic client to resolve consistency-group membership.
-var pvcGVR = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}
-
 // Driver fullfils CSI controller, node, and indentity server interfaces.
 type Driver struct {
 	linstorClient *client.Linstor
@@ -79,10 +76,10 @@ type Driver struct {
 	topologyPrefix string
 	// resyncAfter is the interval after which reconciliations should be retried
 	resyncAfter time.Duration
-	// disableRWXBlockValidation disables KubeVirt VM ownership validation for RWX block volumes
-	disableRWXBlockValidation bool
-	// consistencyGroups places PVCs sharing a consistency-group label as volume numbers of one resource.
-	consistencyGroups bool
+	// rwxBlockValidationClient, when set, enables KubeVirt VM ownership validation for RWX block volumes.
+	rwxBlockValidationClient kubernetes.Interface
+	// consistencyGroupClient, when set, places PVCs sharing a consistency-group label as volume numbers of one resource.
+	consistencyGroupClient kubernetes.Interface
 
 	// Embed for forward compatibility.
 	csi.UnimplementedIdentityServer
@@ -195,19 +192,10 @@ func KubeClient(client dynamic.Interface) func(*Driver) error {
 }
 
 // ConfigureConsistencyGroups enables consistency-group support: CreateVolume reads each PVC's group label and
-// places grouped volumes in one shared resource. Needs a Kubernetes client (built from in-cluster config if none).
-func ConfigureConsistencyGroups() func(*Driver) error {
+// places grouped volumes in one shared resource. The client is used to read the PVCs.
+func ConfigureConsistencyGroups(client kubernetes.Interface) func(*Driver) error {
 	return func(d *Driver) error {
-		if d.kubeClient == nil {
-			_, dyn, err := utils.KubernetesClient()
-			if err != nil {
-				return fmt.Errorf("consistency-group support requires running in Kubernetes: %w", err)
-			}
-
-			d.kubeClient = dyn
-		}
-
-		d.consistencyGroups = true
+		d.consistencyGroupClient = client
 
 		return nil
 	}
@@ -237,13 +225,13 @@ func ResyncAfter(resyncAfter time.Duration) func(*Driver) error {
 	}
 }
 
-// DisableRWXBlockValidation disables the KubeVirt VM ownership validation for RWX block volumes.
-// When disabled, the driver will not check if multiple pods using the same RWX block volume
-// belong to the same VM. This may be needed in environments where the validation causes issues
-// or when using RWX block volumes outside of KubeVirt.
-func DisableRWXBlockValidation() func(*Driver) error {
+// EnableRWXBlockValidation enables the KubeVirt VM ownership validation for RWX block volumes.
+// When enabled, the driver checks that multiple pods using the same RWX block volume belong to
+// the same VM, guarding against misuse of allow-two-primaries. The client is used to read the
+// PV/PVC objects.
+func EnableRWXBlockValidation(client kubernetes.Interface) func(*Driver) error {
 	return func(d *Driver) error {
-		d.disableRWXBlockValidation = true
+		d.rwxBlockValidationClient = client
 		return nil
 	}
 }
@@ -502,7 +490,7 @@ func (d *Driver) NodeGetInfo(ctx context.Context, _ *csi.NodeGetInfoRequest) (*c
 // consistencyGroupForPVC returns the consistency group of a CreateVolume request from its PVC's label, or ""
 // (ordinary volume) when the feature is off, no Kubernetes client is set, or the label is absent.
 func (d *Driver) consistencyGroupForPVC(ctx context.Context, req *csi.CreateVolumeRequest) (string, error) {
-	if !d.consistencyGroups || d.kubeClient == nil {
+	if d.consistencyGroupClient == nil {
 		return "", nil
 	}
 
@@ -513,7 +501,7 @@ func (d *Driver) consistencyGroupForPVC(ctx context.Context, req *csi.CreateVolu
 		return "", nil
 	}
 
-	pvc, err := d.kubeClient.Resource(pvcGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	pvc, err := d.consistencyGroupClient.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return "", fmt.Errorf("could not read PVC %s/%s for consistency-group label: %w", namespace, name, err)
 	}
@@ -880,8 +868,8 @@ func (d *Driver) ControllerPublishVolume(ctx context.Context, req *csi.Controlle
 	rwxBlock := req.VolumeCapability.AccessMode.GetMode() == csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER && req.VolumeCapability.GetBlock() != nil
 
 	// Validate RWX block attachment to prevent misuse of allow-two-primaries
-	if rwxBlock && !d.disableRWXBlockValidation {
-		if _, err := utils.ValidateRWXBlockAttachment(ctx, d.kubeClient, d.log, req.GetVolumeId()); err != nil {
+	if rwxBlock && d.rwxBlockValidationClient != nil {
+		if _, err := utils.ValidateRWXBlockAttachment(ctx, d.rwxBlockValidationClient, d.log, req.GetVolumeId()); err != nil {
 			return nil, status.Errorf(codes.FailedPrecondition,
 				"ControllerPublishVolume failed for %s: %v", req.GetVolumeId(), err)
 		}

--- a/pkg/driver/volumesnapshotclass_watcher.go
+++ b/pkg/driver/volumesnapshotclass_watcher.go
@@ -2,18 +2,17 @@ package driver
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 	"time"
 
-	"github.com/kubernetes-csi/external-snapshotter/v8/pkg/utils"
+	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	snapclientset "github.com/kubernetes-csi/external-snapshotter/client/v8/clientset/versioned"
+	snapinformers "github.com/kubernetes-csi/external-snapshotter/client/v8/informers/externalversions"
+	snaputils "github.com/kubernetes-csi/external-snapshotter/v8/pkg/utils"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/piraeusdatastore/linstor-csi/pkg/client"
@@ -21,15 +20,11 @@ import (
 	"github.com/piraeusdatastore/linstor-csi/pkg/volume"
 )
 
-func ReconcileVolumeSnapshotClass(ctx context.Context, kubeClient dynamic.Interface, snapshotter *client.Linstor, log *logrus.Entry, resyncAfter time.Duration) error {
-	factory := dynamicinformer.NewDynamicSharedInformerFactory(kubeClient, resyncAfter)
-	volumeSnapshotClassIndexer := factory.ForResource(schema.GroupVersionResource{
-		Group:    "snapshot.storage.k8s.io",
-		Version:  "v1",
-		Resource: "volumesnapshotclasses",
-	}).Informer()
+func ReconcileVolumeSnapshotClass(ctx context.Context, snapClient snapclientset.Interface, secretClient kubernetes.Interface, snapshotter *client.Linstor, log *logrus.Entry, resyncAfter time.Duration) error {
+	factory := snapinformers.NewSharedInformerFactory(snapClient, resyncAfter)
+	volumeSnapshotClassInformer := factory.Snapshot().V1().VolumeSnapshotClasses().Informer()
 
-	err := volumeSnapshotClassIndexer.SetWatchErrorHandlerWithContext(func(ctx context.Context, r *cache.Reflector, err error) {
+	err := volumeSnapshotClassInformer.SetWatchErrorHandlerWithContext(func(ctx context.Context, r *cache.Reflector, err error) {
 		if errors.IsNotFound(err) {
 			log.WithError(err).Debug("volumesnapshotclasses.snapshot.storage.k8s.io not deployed in cluster, ignoring")
 		} else {
@@ -40,37 +35,31 @@ func ReconcileVolumeSnapshotClass(ctx context.Context, kubeClient dynamic.Interf
 		return fmt.Errorf("failed to set error handler: %w", err)
 	}
 
-	_, err = volumeSnapshotClassIndexer.AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj any) {
-			params, err := snapshotParamsFromUnstructured(ctx, kubeClient, obj.(*unstructured.Unstructured))
-			if err != nil {
-				log.WithError(err).Warn("failed to parse unstructured object")
-				return
-			}
+	reconcile := func(obj any) {
+		class, ok := obj.(*snapv1.VolumeSnapshotClass)
+		if !ok {
+			log.Warnf("expected *VolumeSnapshotClass, got %T", obj)
+			return
+		}
 
-			if params != nil {
-				err := snapshotter.ReconcileRemote(ctx, params)
-				if err != nil {
-					log.WithError(err).Warnf("failed to reconcile remote for volumesnapshotclass '%s'", obj.(*unstructured.Unstructured).GetName())
-					return
-				}
-			}
-		},
-		UpdateFunc: func(_, newObj any) {
-			newParams, err := snapshotParamsFromUnstructured(ctx, kubeClient, newObj.(*unstructured.Unstructured))
-			if err != nil {
-				log.WithError(err).Warn("failed to parse unstructured (new) object")
-				return
-			}
+		params, err := snapshotParamsFromClass(ctx, secretClient, class)
+		if err != nil {
+			log.WithError(err).Warn("failed to parse volume snapshot class")
+			return
+		}
 
-			if newParams != nil {
-				err := snapshotter.ReconcileRemote(ctx, newParams)
-				if err != nil {
-					log.WithError(err).Warnf("failed to reconcile remote for volumesnapshotclass '%s'", newObj.(*unstructured.Unstructured).GetName())
-					return
-				}
-			}
-		},
+		if params == nil {
+			return
+		}
+
+		if err := snapshotter.ReconcileRemote(ctx, params); err != nil {
+			log.WithError(err).Warnf("failed to reconcile remote for volumesnapshotclass '%s'", class.GetName())
+		}
+	}
+
+	_, err = volumeSnapshotClassInformer.AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
+		AddFunc:    reconcile,
+		UpdateFunc: func(_, newObj any) { reconcile(newObj) },
 	}, resyncAfter)
 	if err != nil {
 		return err
@@ -81,53 +70,27 @@ func ReconcileVolumeSnapshotClass(ctx context.Context, kubeClient dynamic.Interf
 	return nil
 }
 
-func snapshotParamsFromUnstructured(ctx context.Context, client dynamic.Interface, obj *unstructured.Unstructured) (*volume.SnapshotParameters, error) {
-	driver, _, err := unstructured.NestedString(obj.Object, "driver")
-	if err != nil {
-		return nil, fmt.Errorf("failed to get driver name: %w", err)
-	}
-
-	if driver != linstor.DriverName {
+func snapshotParamsFromClass(ctx context.Context, secretClient kubernetes.Interface, class *snapv1.VolumeSnapshotClass) (*volume.SnapshotParameters, error) {
+	if class.Driver != linstor.DriverName {
 		return nil, nil
 	}
 
-	params, _, err := unstructured.NestedStringMap(obj.Object, "parameters")
-	if err != nil {
-		return nil, fmt.Errorf("failed to get driver parameters: %w", err)
-	}
-
-	secretName, _, err := unstructured.NestedString(obj.Object, "parameters", utils.PrefixedSnapshotterSecretNameKey)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get driver secret name: %w", err)
-	}
-
-	secretNamespace, _, err := unstructured.NestedString(obj.Object, "parameters", utils.PrefixedSnapshotterSecretNamespaceKey)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get driver secret namespace: %w", err)
-	}
+	secretName := class.Parameters[snaputils.PrefixedSnapshotterSecretNameKey]
+	secretNamespace := class.Parameters[snaputils.PrefixedSnapshotterSecretNamespaceKey]
 
 	var secretMap map[string]string
 
 	if secretName != "" {
-		secret, err := client.Resource(schema.GroupVersionResource{Version: "v1", Resource: "secrets"}).Namespace(secretNamespace).Get(ctx, secretName, metav1.GetOptions{})
+		secret, err := secretClient.CoreV1().Secrets(secretNamespace).Get(ctx, secretName, metav1.GetOptions{})
 		if err != nil {
 			return nil, fmt.Errorf("failed to get secret '%s': %w", secretName, err)
 		}
 
-		secretMap, _, err = unstructured.NestedStringMap(secret.Object, "data")
-		if err != nil {
-			return nil, fmt.Errorf("failed to access secret '%s': %w", secretName, err)
-		}
-
-		for k, v := range secretMap {
-			b, err := base64.StdEncoding.DecodeString(v)
-			if err != nil {
-				return nil, fmt.Errorf("failed to decode secret value '%s/data/%s': %w", secretName, k, err)
-			}
-
-			secretMap[k] = string(b)
+		secretMap = make(map[string]string, len(secret.Data))
+		for k, v := range secret.Data {
+			secretMap[k] = string(v)
 		}
 	}
 
-	return volume.NewSnapshotParameters(params, secretMap)
+	return volume.NewSnapshotParameters(class.Parameters, secretMap)
 }

--- a/pkg/utils/kubernetes.go
+++ b/pkg/utils/kubernetes.go
@@ -3,12 +3,12 @@ package utils
 import (
 	"fmt"
 
-	"k8s.io/client-go/dynamic"
+	snapclientset "github.com/kubernetes-csi/external-snapshotter/client/v8/clientset/versioned"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
 
-func KubernetesClient() (kubernetes.Interface, dynamic.Interface, error) {
+func KubernetesClient() (kubernetes.Interface, snapclientset.Interface, error) {
 	cfg, err := rest.InClusterConfig()
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to read cluster config: %w", err)
@@ -19,10 +19,10 @@ func KubernetesClient() (kubernetes.Interface, dynamic.Interface, error) {
 		return nil, nil, fmt.Errorf("failed to create typed cluster client: %w", err)
 	}
 
-	d, err := dynamic.NewForConfig(cfg)
+	s, err := snapclientset.NewForConfig(cfg)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create dynamic cluster client: %w", err)
+		return nil, nil, fmt.Errorf("failed to create snapshot cluster client: %w", err)
 	}
 
-	return c, d, nil
+	return c, s, nil
 }

--- a/pkg/utils/rwx_validation.go
+++ b/pkg/utils/rwx_validation.go
@@ -21,12 +21,14 @@ package utils
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
 )
 
 // KubeVirtVMLabel is the label that KubeVirt adds to pods to identify the VM they belong to.
@@ -35,41 +37,85 @@ const KubeVirtVMLabel = "vm.kubevirt.io/name"
 // KubeVirtHotplugDiskLabel is the label that KubeVirt adds to hotplug disk pods.
 const KubeVirtHotplugDiskLabel = "kubevirt.io"
 
-// PodGVR is the GroupVersionResource for pods.
-var PodGVR = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+// volumeHandleIndex indexes PersistentVolumes by their CSI volume handle.
+const volumeHandleIndex = "byVolumeHandle"
 
-// PVGVR is the GroupVersionResource for persistent volumes.
-var PVGVR = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}
+// RWXBlockValidator checks that RWX block volumes are only used by pods belonging to the same KubeVirt VM.
+// It resolves the PersistentVolume for a CSI volume handle through an informer-backed index, so the volume
+// handle does not need to match the PV object name.
+type RWXBlockValidator struct {
+	pvIndexer cache.Indexer
+	client    kubernetes.Interface
+	log       *logrus.Entry
+}
 
-// ValidateRWXBlockAttachment checks that RWX block volumes are only used by pods belonging to the same VM.
+// NewRWXBlockValidator builds a PersistentVolume informer indexed by CSI volume handle, starts it, and
+// blocks until its cache has synced. The informer keeps the index current for the lifetime of ctx.
+func NewRWXBlockValidator(ctx context.Context, client kubernetes.Interface, resyncAfter time.Duration, log *logrus.Entry) (*RWXBlockValidator, error) {
+	factory := informers.NewSharedInformerFactory(client, resyncAfter)
+	informer := factory.Core().V1().PersistentVolumes().Informer()
+
+	if err := informer.AddIndexers(cache.Indexers{volumeHandleIndex: indexPersistentVolumeByVolumeHandle}); err != nil {
+		return nil, fmt.Errorf("failed to add volume handle index: %w", err)
+	}
+
+	factory.StartWithContext(ctx)
+
+	if !cache.WaitForNamedCacheSyncWithContext(ctx, informer.HasSynced) {
+		return nil, fmt.Errorf("failed to sync persistent volume informer cache")
+	}
+
+	return &RWXBlockValidator{
+		pvIndexer: informer.GetIndexer(),
+		client:    client,
+		log:       log.WithField("component", "RWXBlockValidator"),
+	}, nil
+}
+
+// indexPersistentVolumeByVolumeHandle keys CSI-backed PersistentVolumes by their volume handle.
+func indexPersistentVolumeByVolumeHandle(obj interface{}) ([]string, error) {
+	pv, ok := obj.(*corev1.PersistentVolume)
+	if !ok || pv.Spec.CSI == nil {
+		return nil, nil
+	}
+
+	return []string{pv.Spec.CSI.VolumeHandle}, nil
+}
+
+// persistentVolumeForVolumeHandle returns the PersistentVolume whose CSI volume handle matches volumeID.
+func (v *RWXBlockValidator) persistentVolumeForVolumeHandle(volumeID string) (*corev1.PersistentVolume, error) {
+	objs, err := v.pvIndexer.ByIndex(volumeHandleIndex, volumeID)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(objs) != 1 {
+		return nil, fmt.Errorf("unexpected number of PVs found with matching volume handle: %d != 1", len(objs))
+	}
+
+	pv, ok := objs[0].(*corev1.PersistentVolume)
+	if !ok {
+		return nil, fmt.Errorf("unexpected PV type: %T", pv)
+	}
+
+	// An informer may change this, so create a deep copy
+	return pv.DeepCopy(), nil
+}
+
+// ValidateAttachment checks that an RWX block volume is only used by pods belonging to the same VM.
 // This prevents misuse of allow-two-primaries while still permitting live migration.
 // Returns the VM name if validation passes, or an error if:
 // - Multiple pods from different VMs are trying to use the same volume
 // - A pod without the KubeVirt VM label is trying to use a volume already attached elsewhere (strict mode)
 // Returns empty string for VM name when no pods are using the volume or validation is skipped.
-func ValidateRWXBlockAttachment(ctx context.Context, kubeClient kubernetes.Interface, log *logrus.Entry, volumeID string) (string, error) {
-	log.WithField("volumeID", volumeID).Info("validateRWXBlockAttachment called")
+func (v *RWXBlockValidator) ValidateAttachment(ctx context.Context, volumeID string) (string, error) {
+	log := v.log.WithField("volumeID", volumeID)
+	log.Info("validateRWXBlockAttachment called")
 
-	// Get PV to find PVC reference
-	pv, err := kubeClient.CoreV1().PersistentVolumes().Get(ctx, volumeID, metav1.GetOptions{})
+	// Resolve the PV by its CSI volume handle; the handle need not match the PV object name.
+	pv, err := v.persistentVolumeForVolumeHandle(volumeID)
 	if err != nil {
-		log.WithError(err).Warn("cannot validate RWX attachment: failed to get PV")
-		return "", nil
-	}
-
-	// Verify that PV's volumeHandle matches the volumeID
-	if pv.Spec.CSI == nil {
-		log.Warnf("cannot validate RWX attachment: volumeHandle not found for PV %s", volumeID)
-
-		return "", nil
-	}
-
-	if pv.Spec.CSI.VolumeHandle != volumeID {
-		log.WithFields(logrus.Fields{
-			"volumeID":     volumeID,
-			"volumeHandle": pv.Spec.CSI.VolumeHandle,
-		}).Warn("cannot validate RWX attachment: PV volumeHandle does not match volumeID")
-
+		log.WithError(err).Warn("cannot validate RWX attachment: failed to look up PV by volume handle")
 		return "", nil
 	}
 
@@ -82,7 +128,7 @@ func ValidateRWXBlockAttachment(ctx context.Context, kubeClient kubernetes.Inter
 	pvcNamespace := pv.Spec.ClaimRef.Namespace
 
 	// List all pods in the namespace
-	podList, err := kubeClient.CoreV1().Pods(pvcNamespace).List(ctx, metav1.ListOptions{})
+	podList, err := v.client.CoreV1().Pods(pvcNamespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return "", fmt.Errorf("failed to list pods in namespace %s: %w", pvcNamespace, err)
 	}
@@ -115,7 +161,7 @@ func ValidateRWXBlockAttachment(ctx context.Context, kubeClient kubernetes.Inter
 			}
 
 			// Extract VM name, handling both regular and hotplug disk pods
-			vmName, err := GetVMNameFromPod(ctx, kubeClient, log, pod)
+			vmName, err := GetVMNameFromPod(ctx, v.client, log, pod)
 			if err != nil {
 				log.WithError(err).WithField("pod", pod.Name).Warn("failed to get VM name from pod")
 				// Continue with empty vmName - will be caught by strict mode check
@@ -136,7 +182,6 @@ func ValidateRWXBlockAttachment(ctx context.Context, kubeClient kubernetes.Inter
 		// Return VM name if there's exactly one pod
 		if len(podsUsingPVC) == 1 {
 			log.WithFields(logrus.Fields{
-				"volumeID":     volumeID,
 				"vmName":       podsUsingPVC[0].vmName,
 				"podCount":     1,
 				"pvcNamespace": pvcNamespace,
@@ -147,7 +192,6 @@ func ValidateRWXBlockAttachment(ctx context.Context, kubeClient kubernetes.Inter
 		}
 
 		log.WithFields(logrus.Fields{
-			"volumeID":     volumeID,
 			"pvcNamespace": pvcNamespace,
 			"pvcName":      pvcName,
 		}).Info("validateRWXBlockAttachment: no pods found using PVC")

--- a/pkg/utils/rwx_validation.go
+++ b/pkg/utils/rwx_validation.go
@@ -23,10 +23,10 @@ import (
 	"fmt"
 
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 )
 
 // KubeVirtVMLabel is the label that KubeVirt adds to pods to identify the VM they belong to.
@@ -47,62 +47,42 @@ var PVGVR = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "per
 // - Multiple pods from different VMs are trying to use the same volume
 // - A pod without the KubeVirt VM label is trying to use a volume already attached elsewhere (strict mode)
 // Returns empty string for VM name when no pods are using the volume or validation is skipped.
-func ValidateRWXBlockAttachment(ctx context.Context, kubeClient dynamic.Interface, log *logrus.Entry, volumeID string) (string, error) {
+func ValidateRWXBlockAttachment(ctx context.Context, kubeClient kubernetes.Interface, log *logrus.Entry, volumeID string) (string, error) {
 	log.WithField("volumeID", volumeID).Info("validateRWXBlockAttachment called")
 
-	if kubeClient == nil {
-		// Not running in Kubernetes, skip validation
-		log.Warn("validateRWXBlockAttachment: kubeClient is nil, skipping validation")
-		return "", nil
-	}
-
 	// Get PV to find PVC reference
-	pv, err := kubeClient.Resource(PVGVR).Get(ctx, volumeID, metav1.GetOptions{})
+	pv, err := kubeClient.CoreV1().PersistentVolumes().Get(ctx, volumeID, metav1.GetOptions{})
 	if err != nil {
 		log.WithError(err).Warn("cannot validate RWX attachment: failed to get PV")
 		return "", nil
 	}
 
 	// Verify that PV's volumeHandle matches the volumeID
-	volumeHandle, found, err := unstructured.NestedString(pv.Object, "spec", "csi", "volumeHandle")
-	if err != nil {
-		log.WithError(err).Warnf("cannot validate RWX attachment: failed to read volumeHandle for PV %s", volumeID)
-
-		return "", nil
-	}
-
-	if !found {
+	if pv.Spec.CSI == nil {
 		log.Warnf("cannot validate RWX attachment: volumeHandle not found for PV %s", volumeID)
 
 		return "", nil
 	}
 
-	if volumeHandle != volumeID {
+	if pv.Spec.CSI.VolumeHandle != volumeID {
 		log.WithFields(logrus.Fields{
 			"volumeID":     volumeID,
-			"volumeHandle": volumeHandle,
+			"volumeHandle": pv.Spec.CSI.VolumeHandle,
 		}).Warn("cannot validate RWX attachment: PV volumeHandle does not match volumeID")
 
 		return "", nil
 	}
 
-	// Extract claimRef from PV
-	claimRef, found, _ := unstructured.NestedMap(pv.Object, "spec", "claimRef")
-	if !found {
+	if pv.Spec.ClaimRef == nil {
 		log.Warn("cannot validate RWX attachment: PV has no claimRef")
 		return "", nil
 	}
 
-	pvcName, _, _ := unstructured.NestedString(claimRef, "name")
-	pvcNamespace, _, _ := unstructured.NestedString(claimRef, "namespace")
-
-	if pvcNamespace == "" || pvcName == "" {
-		log.Warn("cannot validate RWX attachment: PVC name or namespace is empty in claimRef")
-		return "", nil
-	}
+	pvcName := pv.Spec.ClaimRef.Name
+	pvcNamespace := pv.Spec.ClaimRef.Namespace
 
 	// List all pods in the namespace
-	podList, err := kubeClient.Resource(PodGVR).Namespace(pvcNamespace).List(ctx, metav1.ListOptions{})
+	podList, err := kubeClient.CoreV1().Pods(pvcNamespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return "", fmt.Errorf("failed to list pods in namespace %s: %w", pvcNamespace, err)
 	}
@@ -115,40 +95,35 @@ func ValidateRWXBlockAttachment(ctx context.Context, kubeClient dynamic.Interfac
 
 	var podsUsingPVC []podInfo
 
-	for _, item := range podList.Items {
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+
 		// Get pod phase from status
-		phase, _, _ := unstructured.NestedString(item.Object, "status", "phase")
-		if phase == "Succeeded" || phase == "Failed" {
+		if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
 			continue
 		}
 
-		// Check if pod uses the PVC
-		volumes, found, _ := unstructured.NestedSlice(item.Object, "spec", "volumes")
-		if !found {
-			continue
-		}
+		for j := range pod.Spec.Volumes {
+			vol := &pod.Spec.Volumes[j]
 
-		for _, vol := range volumes {
-			volMap, ok := vol.(map[string]interface{})
-			if !ok {
+			if vol.PersistentVolumeClaim == nil {
 				continue
 			}
 
-			claimName, found, _ := unstructured.NestedString(volMap, "persistentVolumeClaim", "claimName")
-			if !found || claimName != pvcName {
+			if vol.PersistentVolumeClaim.ClaimName != pvcName {
 				continue
 			}
 
 			// Extract VM name, handling both regular and hotplug disk pods
-			vmName, err := GetVMNameFromPod(ctx, kubeClient, log, &item)
+			vmName, err := GetVMNameFromPod(ctx, kubeClient, log, pod)
 			if err != nil {
-				log.WithError(err).WithField("pod", item.GetName()).Warn("failed to get VM name from pod")
+				log.WithError(err).WithField("pod", pod.Name).Warn("failed to get VM name from pod")
 				// Continue with empty vmName - will be caught by strict mode check
 				vmName = ""
 			}
 
 			podsUsingPVC = append(podsUsingPVC, podInfo{
-				name:   item.GetName(),
+				name:   pod.Name,
 				vmName: vmName,
 			})
 
@@ -213,7 +188,7 @@ func ValidateRWXBlockAttachment(ctx context.Context, kubeClient dynamic.Interfac
 
 // GetVMNameFromPod extracts the VM name from a pod, handling both regular virt-launcher pods
 // and hotplug disk pods (which reference the virt-launcher pod via ownerReferences).
-func GetVMNameFromPod(ctx context.Context, kubeClient dynamic.Interface, log *logrus.Entry, pod *unstructured.Unstructured) (string, error) {
+func GetVMNameFromPod(ctx context.Context, kubeClient kubernetes.Interface, log *logrus.Entry, pod *corev1.Pod) (string, error) {
 	labels := pod.GetLabels()
 	if labels == nil {
 		return "", nil
@@ -234,23 +209,20 @@ func GetVMNameFromPod(ctx context.Context, kubeClient dynamic.Interface, log *lo
 			}
 
 			// Get the owner pod (virt-launcher)
-			ownerPod, err := kubeClient.Resource(PodGVR).Namespace(pod.GetNamespace()).Get(ctx, owner.Name, metav1.GetOptions{})
+			ownerPod, err := kubeClient.CoreV1().Pods(pod.GetNamespace()).Get(ctx, owner.Name, metav1.GetOptions{})
 			if err != nil {
 				return "", fmt.Errorf("failed to get owner pod %s: %w", owner.Name, err)
 			}
 
 			// Extract VM name from owner pod
-			ownerLabels := ownerPod.GetLabels()
-			if ownerLabels != nil {
-				if vmName, ok := ownerLabels[KubeVirtVMLabel]; ok && vmName != "" {
-					log.WithFields(logrus.Fields{
-						"hotplugPod":   pod.GetName(),
-						"virtLauncher": owner.Name,
-						"vmName":       vmName,
-					}).Debug("resolved VM name from hotplug disk pod via owner reference")
+			if vmName, ok := ownerPod.GetLabels()[KubeVirtVMLabel]; ok {
+				log.WithFields(logrus.Fields{
+					"hotplugPod":   pod.GetName(),
+					"virtLauncher": owner.Name,
+					"vmName":       vmName,
+				}).Debug("resolved VM name from hotplug disk pod via owner reference")
 
-					return vmName, nil
-				}
+				return vmName, nil
 			}
 
 			return "", fmt.Errorf("owner pod %s does not have %s label", owner.Name, KubeVirtVMLabel)

--- a/pkg/utils/rwx_validation_test.go
+++ b/pkg/utils/rwx_validation_test.go
@@ -19,11 +19,11 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 package utils
 
 import (
-	"context"
 	"testing"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -168,7 +168,7 @@ func TestValidateRWXBlockAttachment(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Create PV object that references the PVC
-			pv := createPV("test-volume-id", tc.namespace, tc.pvcName)
+			pv := createPV("test-volume-id", "test-volume-id", tc.namespace, tc.pvcName)
 
 			objects := make([]runtime.Object, 0, len(tc.pods)+1)
 			objects = append(objects, pv)
@@ -177,14 +177,10 @@ func TestValidateRWXBlockAttachment(t *testing.T) {
 				objects = append(objects, pod)
 			}
 
-			client := fake.NewClientset(objects...)
-
-			// Create logger
-			logger := logrus.NewEntry(logrus.New())
-			logger.Logger.SetLevel(logrus.DebugLevel)
+			validator := newValidator(t, objects...)
 
 			// Run validation
-			vmName, err := ValidateRWXBlockAttachment(context.Background(), client, logger, "test-volume-id")
+			vmName, err := validator.ValidateAttachment(t.Context(), "test-volume-id")
 
 			if tc.expectError {
 				assert.Error(t, err)
@@ -204,15 +200,42 @@ func TestValidateRWXBlockAttachment(t *testing.T) {
 }
 
 func TestValidateRWXBlockAttachmentPVNotFound(t *testing.T) {
-	// When PV is not found, validation should be skipped with warning
-	client := fake.NewClientset()
+	// When no PV matches the volume handle, validation should be skipped without error.
+	validator := newValidator(t)
+
+	vmName, err := validator.ValidateAttachment(t.Context(), "non-existent-pv")
+	assert.NoError(t, err)
+	assert.Empty(t, vmName)
+}
+
+func TestValidateRWXBlockAttachmentFindsPVByVolumeHandle(t *testing.T) {
+	// The PV object name differs from the CSI volume handle; the validator must still resolve it
+	// through the volume-handle index rather than assuming the handle is the PV name.
+	validator := newValidator(t,
+		createPV("different-pv-name", "test-volume-id", "default", "test-pvc"),
+		createPod("virt-launcher-vm1-abc", "default", "test-pvc", map[string]string{KubeVirtVMLabel: "vm1"}, "Running"),
+		createPod("virt-launcher-vm2-xyz", "default", "test-pvc", map[string]string{KubeVirtVMLabel: "vm2"}, "Running"),
+	)
+
+	vmName, err := validator.ValidateAttachment(t.Context(), "test-volume-id")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "different VMs")
+	assert.Empty(t, vmName)
+}
+
+// newValidator builds an RWXBlockValidator backed by a fake client seeded with the given objects.
+func newValidator(t *testing.T, objects ...runtime.Object) *RWXBlockValidator {
+	t.Helper()
+
+	client := fake.NewClientset(objects...)
 
 	logger := logrus.NewEntry(logrus.New())
 	logger.Logger.SetLevel(logrus.DebugLevel)
 
-	vmName, err := ValidateRWXBlockAttachment(context.Background(), client, logger, "non-existent-pv")
-	assert.NoError(t, err)
-	assert.Empty(t, vmName)
+	validator, err := NewRWXBlockValidator(t.Context(), client, 0, logger)
+	require.NoError(t, err)
+
+	return validator
 }
 
 // createPod creates a pod object for testing.
@@ -241,8 +264,9 @@ func createPod(name, namespace, pvcName string, labels map[string]string, phase 
 	return pod
 }
 
-// createPV creates a PersistentVolume object for testing.
-func createPV(name, pvcNamespace, pvcName string) *corev1.PersistentVolume {
+// createPV creates a PersistentVolume object for testing. The object name and CSI volume handle are
+// separate so tests can exercise the case where they differ.
+func createPV(name, volumeHandle, pvcNamespace, pvcName string) *corev1.PersistentVolume {
 	pv := &corev1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -255,7 +279,7 @@ func createPV(name, pvcNamespace, pvcName string) *corev1.PersistentVolume {
 			PersistentVolumeSource: corev1.PersistentVolumeSource{
 				CSI: &corev1.CSIPersistentVolumeSource{
 					Driver:       linstor.DriverName,
-					VolumeHandle: name,
+					VolumeHandle: volumeHandle,
 				},
 			},
 		},

--- a/pkg/utils/rwx_validation_test.go
+++ b/pkg/utils/rwx_validation_test.go
@@ -24,16 +24,18 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/piraeusdatastore/linstor-csi/pkg/linstor"
 )
 
 func TestValidateRWXBlockAttachment(t *testing.T) {
 	testCases := []struct {
 		name        string
-		pods        []*unstructured.Unstructured
+		pods        []*corev1.Pod
 		pvcName     string
 		namespace   string
 		expectError bool
@@ -41,15 +43,15 @@ func TestValidateRWXBlockAttachment(t *testing.T) {
 	}{
 		{
 			name:        "no pods using PVC",
-			pods:        []*unstructured.Unstructured{},
+			pods:        []*corev1.Pod{},
 			pvcName:     "test-pvc",
 			namespace:   "default",
 			expectError: false,
 		},
 		{
 			name: "single pod using PVC",
-			pods: []*unstructured.Unstructured{
-				createUnstructuredPod("pod1", "default", "test-pvc", map[string]string{KubeVirtVMLabel: "vm1"}, "Running"),
+			pods: []*corev1.Pod{
+				createPod("pod1", "default", "test-pvc", map[string]string{KubeVirtVMLabel: "vm1"}, "Running"),
 			},
 			pvcName:     "test-pvc",
 			namespace:   "default",
@@ -57,9 +59,9 @@ func TestValidateRWXBlockAttachment(t *testing.T) {
 		},
 		{
 			name: "two pods same VM (live migration)",
-			pods: []*unstructured.Unstructured{
-				createUnstructuredPod("virt-launcher-vm1-abc", "default", "test-pvc", map[string]string{KubeVirtVMLabel: "vm1"}, "Running"),
-				createUnstructuredPod("virt-launcher-vm1-xyz", "default", "test-pvc", map[string]string{KubeVirtVMLabel: "vm1"}, "Running"),
+			pods: []*corev1.Pod{
+				createPod("virt-launcher-vm1-abc", "default", "test-pvc", map[string]string{KubeVirtVMLabel: "vm1"}, "Running"),
+				createPod("virt-launcher-vm1-xyz", "default", "test-pvc", map[string]string{KubeVirtVMLabel: "vm1"}, "Running"),
 			},
 			pvcName:     "test-pvc",
 			namespace:   "default",
@@ -67,9 +69,9 @@ func TestValidateRWXBlockAttachment(t *testing.T) {
 		},
 		{
 			name: "two pods different VMs (should fail)",
-			pods: []*unstructured.Unstructured{
-				createUnstructuredPod("virt-launcher-vm1-abc", "default", "test-pvc", map[string]string{KubeVirtVMLabel: "vm1"}, "Running"),
-				createUnstructuredPod("virt-launcher-vm2-xyz", "default", "test-pvc", map[string]string{KubeVirtVMLabel: "vm2"}, "Running"),
+			pods: []*corev1.Pod{
+				createPod("virt-launcher-vm1-abc", "default", "test-pvc", map[string]string{KubeVirtVMLabel: "vm1"}, "Running"),
+				createPod("virt-launcher-vm2-xyz", "default", "test-pvc", map[string]string{KubeVirtVMLabel: "vm2"}, "Running"),
 			},
 			pvcName:     "test-pvc",
 			namespace:   "default",
@@ -78,9 +80,9 @@ func TestValidateRWXBlockAttachment(t *testing.T) {
 		},
 		{
 			name: "pod without KubeVirt label when multiple pods exist (strict mode)",
-			pods: []*unstructured.Unstructured{
-				createUnstructuredPod("pod1", "default", "test-pvc", map[string]string{KubeVirtVMLabel: "vm1"}, "Running"),
-				createUnstructuredPod("pod2", "default", "test-pvc", map[string]string{}, "Running"),
+			pods: []*corev1.Pod{
+				createPod("pod1", "default", "test-pvc", map[string]string{KubeVirtVMLabel: "vm1"}, "Running"),
+				createPod("pod2", "default", "test-pvc", map[string]string{}, "Running"),
 			},
 			pvcName:     "test-pvc",
 			namespace:   "default",
@@ -89,9 +91,9 @@ func TestValidateRWXBlockAttachment(t *testing.T) {
 		},
 		{
 			name: "completed pods should be ignored",
-			pods: []*unstructured.Unstructured{
-				createUnstructuredPod("pod1", "default", "test-pvc", map[string]string{KubeVirtVMLabel: "vm1"}, "Running"),
-				createUnstructuredPod("pod2", "default", "test-pvc", map[string]string{KubeVirtVMLabel: "vm2"}, "Succeeded"),
+			pods: []*corev1.Pod{
+				createPod("pod1", "default", "test-pvc", map[string]string{KubeVirtVMLabel: "vm1"}, "Running"),
+				createPod("pod2", "default", "test-pvc", map[string]string{KubeVirtVMLabel: "vm2"}, "Succeeded"),
 			},
 			pvcName:     "test-pvc",
 			namespace:   "default",
@@ -99,9 +101,9 @@ func TestValidateRWXBlockAttachment(t *testing.T) {
 		},
 		{
 			name: "failed pods should be ignored",
-			pods: []*unstructured.Unstructured{
-				createUnstructuredPod("pod1", "default", "test-pvc", map[string]string{KubeVirtVMLabel: "vm1"}, "Running"),
-				createUnstructuredPod("pod2", "default", "test-pvc", map[string]string{KubeVirtVMLabel: "vm2"}, "Failed"),
+			pods: []*corev1.Pod{
+				createPod("pod1", "default", "test-pvc", map[string]string{KubeVirtVMLabel: "vm1"}, "Running"),
+				createPod("pod2", "default", "test-pvc", map[string]string{KubeVirtVMLabel: "vm2"}, "Failed"),
 			},
 			pvcName:     "test-pvc",
 			namespace:   "default",
@@ -109,9 +111,9 @@ func TestValidateRWXBlockAttachment(t *testing.T) {
 		},
 		{
 			name: "pods in different namespace should not conflict",
-			pods: []*unstructured.Unstructured{
-				createUnstructuredPod("pod1", "default", "test-pvc", map[string]string{KubeVirtVMLabel: "vm1"}, "Running"),
-				createUnstructuredPod("pod2", "other", "test-pvc", map[string]string{KubeVirtVMLabel: "vm2"}, "Running"),
+			pods: []*corev1.Pod{
+				createPod("pod1", "default", "test-pvc", map[string]string{KubeVirtVMLabel: "vm1"}, "Running"),
+				createPod("pod2", "other", "test-pvc", map[string]string{KubeVirtVMLabel: "vm2"}, "Running"),
 			},
 			pvcName:     "test-pvc",
 			namespace:   "default",
@@ -119,9 +121,9 @@ func TestValidateRWXBlockAttachment(t *testing.T) {
 		},
 		{
 			name: "pods using different PVCs should not conflict",
-			pods: []*unstructured.Unstructured{
-				createUnstructuredPod("pod1", "default", "test-pvc", map[string]string{KubeVirtVMLabel: "vm1"}, "Running"),
-				createUnstructuredPod("pod2", "default", "other-pvc", map[string]string{KubeVirtVMLabel: "vm2"}, "Running"),
+			pods: []*corev1.Pod{
+				createPod("pod1", "default", "test-pvc", map[string]string{KubeVirtVMLabel: "vm1"}, "Running"),
+				createPod("pod2", "default", "other-pvc", map[string]string{KubeVirtVMLabel: "vm2"}, "Running"),
 			},
 			pvcName:     "test-pvc",
 			namespace:   "default",
@@ -129,10 +131,10 @@ func TestValidateRWXBlockAttachment(t *testing.T) {
 		},
 		{
 			name: "three pods from same VM (multi-node live migration scenario)",
-			pods: []*unstructured.Unstructured{
-				createUnstructuredPod("virt-launcher-vm1-a", "default", "test-pvc", map[string]string{KubeVirtVMLabel: "vm1"}, "Running"),
-				createUnstructuredPod("virt-launcher-vm1-b", "default", "test-pvc", map[string]string{KubeVirtVMLabel: "vm1"}, "Running"),
-				createUnstructuredPod("virt-launcher-vm1-c", "default", "test-pvc", map[string]string{KubeVirtVMLabel: "vm1"}, "Pending"),
+			pods: []*corev1.Pod{
+				createPod("virt-launcher-vm1-a", "default", "test-pvc", map[string]string{KubeVirtVMLabel: "vm1"}, "Running"),
+				createPod("virt-launcher-vm1-b", "default", "test-pvc", map[string]string{KubeVirtVMLabel: "vm1"}, "Running"),
+				createPod("virt-launcher-vm1-c", "default", "test-pvc", map[string]string{KubeVirtVMLabel: "vm1"}, "Pending"),
 			},
 			pvcName:     "test-pvc",
 			namespace:   "default",
@@ -140,8 +142,8 @@ func TestValidateRWXBlockAttachment(t *testing.T) {
 		},
 		{
 			name: "hotplug disk pod with virt-launcher (should succeed)",
-			pods: []*unstructured.Unstructured{
-				createUnstructuredPod("virt-launcher-vm1-abc", "default", "test-pvc", map[string]string{KubeVirtVMLabel: "vm1"}, "Running"),
+			pods: []*corev1.Pod{
+				createPod("virt-launcher-vm1-abc", "default", "test-pvc", map[string]string{KubeVirtVMLabel: "vm1"}, "Running"),
 				createHotplugDiskPod("hp-volume-xyz", "default", "test-pvc", "virt-launcher-vm1-abc", "Running"),
 			},
 			pvcName:     "test-pvc",
@@ -150,10 +152,10 @@ func TestValidateRWXBlockAttachment(t *testing.T) {
 		},
 		{
 			name: "hotplug disks from different VMs (should fail)",
-			pods: []*unstructured.Unstructured{
-				createUnstructuredPod("virt-launcher-vm1-abc", "default", "test-pvc", map[string]string{KubeVirtVMLabel: "vm1"}, "Running"),
+			pods: []*corev1.Pod{
+				createPod("virt-launcher-vm1-abc", "default", "test-pvc", map[string]string{KubeVirtVMLabel: "vm1"}, "Running"),
 				createHotplugDiskPod("hp-volume-vm1", "default", "test-pvc", "virt-launcher-vm1-abc", "Running"),
-				createUnstructuredPod("virt-launcher-vm2-xyz", "default", "test-pvc", map[string]string{KubeVirtVMLabel: "vm2"}, "Running"),
+				createPod("virt-launcher-vm2-xyz", "default", "test-pvc", map[string]string{KubeVirtVMLabel: "vm2"}, "Running"),
 				createHotplugDiskPod("hp-volume-vm2", "default", "test-pvc", "virt-launcher-vm2-xyz", "Running"),
 			},
 			pvcName:     "test-pvc",
@@ -165,11 +167,8 @@ func TestValidateRWXBlockAttachment(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Create fake dynamic client with test pods and PV
-			scheme := runtime.NewScheme()
-
 			// Create PV object that references the PVC
-			pv := createUnstructuredPV("test-volume-id", tc.namespace, tc.pvcName)
+			pv := createPV("test-volume-id", tc.namespace, tc.pvcName)
 
 			objects := make([]runtime.Object, 0, len(tc.pods)+1)
 			objects = append(objects, pv)
@@ -178,11 +177,7 @@ func TestValidateRWXBlockAttachment(t *testing.T) {
 				objects = append(objects, pod)
 			}
 
-			gvrToListKind := map[schema.GroupVersionResource]string{
-				PodGVR: "PodList",
-				PVGVR:  "PersistentVolumeList",
-			}
-			client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind, objects...)
+			client := fake.NewClientset(objects...)
 
 			// Create logger
 			logger := logrus.NewEntry(logrus.New())
@@ -208,24 +203,9 @@ func TestValidateRWXBlockAttachment(t *testing.T) {
 	}
 }
 
-func TestValidateRWXBlockAttachmentNoKubeClient(t *testing.T) {
-	// When not running in Kubernetes (no client), validation should be skipped
-	logger := logrus.NewEntry(logrus.New())
-
-	vmName, err := ValidateRWXBlockAttachment(context.Background(), nil, logger, "test-volume-id")
-	assert.NoError(t, err)
-	assert.Empty(t, vmName)
-}
-
 func TestValidateRWXBlockAttachmentPVNotFound(t *testing.T) {
 	// When PV is not found, validation should be skipped with warning
-	scheme := runtime.NewScheme()
-
-	gvrToListKind := map[schema.GroupVersionResource]string{
-		PodGVR: "PodList",
-		PVGVR:  "PersistentVolumeList",
-	}
-	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind)
+	client := fake.NewClientset()
 
 	logger := logrus.NewEntry(logrus.New())
 	logger.Logger.SetLevel(logrus.DebugLevel)
@@ -235,52 +215,47 @@ func TestValidateRWXBlockAttachmentPVNotFound(t *testing.T) {
 	assert.Empty(t, vmName)
 }
 
-// createUnstructuredPod creates an unstructured pod object for testing.
-func createUnstructuredPod(name, namespace, pvcName string, labels map[string]string, phase string) *unstructured.Unstructured {
-	pod := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "v1",
-			"kind":       "Pod",
-			"metadata": map[string]interface{}{
-				"name":      name,
-				"namespace": namespace,
-				"labels":    toStringInterfaceMap(labels),
-			},
-			"spec": map[string]interface{}{
-				"volumes": []interface{}{
-					map[string]interface{}{
-						"name": "data",
-						"persistentVolumeClaim": map[string]interface{}{
-							"claimName": pvcName,
-						},
+// createPod creates a pod object for testing.
+func createPod(name, namespace, pvcName string, labels map[string]string, phase corev1.PodPhase) *corev1.Pod {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec: corev1.PodSpec{
+			Volumes: []corev1.Volume{{
+				Name: "data",
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: pvcName,
 					},
 				},
-			},
-			"status": map[string]interface{}{
-				"phase": phase,
-			},
+			}},
+		},
+		Status: corev1.PodStatus{
+			Phase: phase,
 		},
 	}
 
 	return pod
 }
 
-// createUnstructuredPV creates an unstructured PersistentVolume object for testing.
-func createUnstructuredPV(name, pvcNamespace, pvcName string) *unstructured.Unstructured {
-	pv := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "v1",
-			"kind":       "PersistentVolume",
-			"metadata": map[string]interface{}{
-				"name": name,
+// createPV creates a PersistentVolume object for testing.
+func createPV(name, pvcNamespace, pvcName string) *corev1.PersistentVolume {
+	pv := &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: corev1.PersistentVolumeSpec{
+			ClaimRef: &corev1.ObjectReference{
+				Name:      pvcName,
+				Namespace: pvcNamespace,
 			},
-			"spec": map[string]interface{}{
-				"claimRef": map[string]interface{}{
-					"name":      pvcName,
-					"namespace": pvcNamespace,
-				},
-				"csi": map[string]interface{}{
-					"volumeHandle": name,
+			PersistentVolumeSource: corev1.PersistentVolumeSource{
+				CSI: &corev1.CSIPersistentVolumeSource{
+					Driver:       linstor.DriverName,
+					VolumeHandle: name,
 				},
 			},
 		},
@@ -289,52 +264,35 @@ func createUnstructuredPV(name, pvcNamespace, pvcName string) *unstructured.Unst
 	return pv
 }
 
-// toStringInterfaceMap converts map[string]string to map[string]interface{}.
-func toStringInterfaceMap(m map[string]string) map[string]interface{} {
-	result := make(map[string]interface{})
-
-	for k, v := range m {
-		result[k] = v
-	}
-
-	return result
-}
-
 // createHotplugDiskPod creates a hotplug disk pod that references a virt-launcher pod via ownerReferences.
-func createHotplugDiskPod(name, namespace, pvcName, ownerPodName, phase string) *unstructured.Unstructured {
-	pod := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "v1",
-			"kind":       "Pod",
-			"metadata": map[string]interface{}{
-				"name":      name,
-				"namespace": namespace,
-				"labels": map[string]interface{}{
-					"kubevirt.io": "hotplug-disk",
-				},
-				"ownerReferences": []interface{}{
-					map[string]interface{}{
-						"apiVersion":         "v1",
-						"kind":               "Pod",
-						"name":               ownerPodName,
-						"controller":         true,
-						"blockOwnerDeletion": true,
+func createHotplugDiskPod(name, namespace, pvcName, ownerPodName string, phase corev1.PodPhase) *corev1.Pod {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"kubevirt.io": "hotplug-disk",
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion:         "v1",
+				Kind:               "Pod",
+				Name:               ownerPodName,
+				Controller:         new(true),
+				BlockOwnerDeletion: new(true),
+			}},
+		},
+		Spec: corev1.PodSpec{
+			Volumes: []corev1.Volume{{
+				Name: "data",
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: pvcName,
 					},
 				},
-			},
-			"spec": map[string]interface{}{
-				"volumes": []interface{}{
-					map[string]interface{}{
-						"name": "data",
-						"persistentVolumeClaim": map[string]interface{}{
-							"claimName": pvcName,
-						},
-					},
-				},
-			},
-			"status": map[string]interface{}{
-				"phase": phase,
-			},
+			}},
+		},
+		Status: corev1.PodStatus{
+			Phase: phase,
 		},
 	}
 

--- a/test/consistency_group_test.go
+++ b/test/consistency_group_test.go
@@ -19,11 +19,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/dynamic"
-	dynfake "k8s.io/client-go/dynamic/fake"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 
 	"github.com/piraeusdatastore/linstor-csi/pkg/client"
@@ -81,46 +79,32 @@ func realLinstor(t *testing.T) (*client.Linstor, *hlc.HighLevelClient) {
 	return cl, hl
 }
 
-// pvc builds an unstructured PVC; a non-empty group stamps the consistency-group label.
-func pvc(namespace, name, group string) *unstructured.Unstructured {
-	meta := map[string]interface{}{
-		"name":      name,
-		"namespace": namespace,
-	}
+// pvc builds an PVC; a non-empty group stamps the consistency-group label.
+func pvc(namespace, name, group string) *corev1.PersistentVolumeClaim {
+	var labels map[string]string
 	if group != "" {
-		meta["labels"] = map[string]interface{}{
+		labels = map[string]string{
 			"linstor.csi.linbit.com/consistency-group": group,
 		}
 	}
 
-	return &unstructured.Unstructured{Object: map[string]interface{}{
-		"apiVersion": "v1",
-		"kind":       "PersistentVolumeClaim",
-		"metadata":   meta,
-	}}
-}
-
-func fakeKube(objs ...runtime.Object) dynamic.Interface {
-	// The fake dynamic client must know the list kind for every resource the driver LISTs; register them.
-	gvrToListKind := map[schema.GroupVersionResource]string{
-		{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}:                        "PersistentVolumeClaimList",
-		{Group: "snapshot.storage.k8s.io", Version: "v1", Resource: "volumesnapshotcontents"}: "VolumeSnapshotContentList",
-		{Group: "snapshot.storage.k8s.io", Version: "v1", Resource: "volumesnapshotclasses"}:  "VolumeSnapshotClassList",
-		{Group: "snapshot.storage.k8s.io", Version: "v1", Resource: "volumesnapshots"}:        "VolumeSnapshotList",
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
 	}
-
-	return dynfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind, objs...)
 }
 
 // newDriver builds an in-process driver with consistency groups enabled and the fake Kubernetes client injected.
-func newDriver(t *testing.T, cl *client.Linstor, kube dynamic.Interface, extra ...func(*driver.Driver) error) *driver.Driver {
+func newDriver(t *testing.T, cl *client.Linstor, kube kubernetes.Interface, extra ...func(*driver.Driver) error) *driver.Driver {
 	t.Helper()
 
 	opts := append([]func(*driver.Driver) error{
 		driver.NodeID(testNode()),
 		driver.LogLevel("debug"),
-		driver.KubeClient(kube),
-		driver.ConfigureConsistencyGroups(),
+		driver.ConfigureConsistencyGroups(kube),
 	}, extra...)
 
 	drv, err := driver.NewDriver(cl, opts...)
@@ -226,7 +210,7 @@ func TestCGAllocation(t *testing.T) {
 	const ns = "cgtest"
 
 	group := uniqueGroup("alloc")
-	drv := newDriver(t, cl, fakeKube(pvc(ns, "pvc-a", group), pvc(ns, "pvc-b", group)))
+	drv := newDriver(t, cl, kubefake.NewClientset(pvc(ns, "pvc-a", group), pvc(ns, "pvc-b", group)))
 
 	resps := runInParallel(t,
 		func() (*csi.CreateVolumeResponse, error) {
@@ -282,7 +266,7 @@ func TestCGMemberDeleteGC(t *testing.T) {
 	const ns = "cgtest"
 
 	group := uniqueGroup("gc")
-	drv := newDriver(t, cl, fakeKube(pvc(ns, "gc-a", group), pvc(ns, "gc-b", group), pvc(ns, "gc-c", group)))
+	drv := newDriver(t, cl, kubefake.NewClientset(pvc(ns, "gc-a", group), pvc(ns, "gc-b", group), pvc(ns, "gc-c", group)))
 
 	resps := runInParallel(t,
 		func() (*csi.CreateVolumeResponse, error) {
@@ -322,7 +306,7 @@ func TestCGNamespaceIsolation(t *testing.T) {
 	cl, _ := realLinstor(t)
 
 	group := uniqueGroup("iso")
-	drv := newDriver(t, cl, fakeKube(pvc("ns-one", "pvc-x", group), pvc("ns-two", "pvc-x", group)))
+	drv := newDriver(t, cl, kubefake.NewClientset(pvc("ns-one", "pvc-x", group), pvc("ns-two", "pvc-x", group)))
 
 	resps := runInParallel(t,
 		func() (*csi.CreateVolumeResponse, error) {
@@ -359,7 +343,7 @@ func TestCGPerMemberFsType(t *testing.T) {
 	const ns = "cgtest"
 
 	group := uniqueGroup("fstype")
-	drv := newDriver(t, cl, fakeKube(pvc(ns, "fs-ext4", group), pvc(ns, "fs-xfs", group)))
+	drv := newDriver(t, cl, kubefake.NewClientset(pvc(ns, "fs-ext4", group), pvc(ns, "fs-xfs", group)))
 
 	resps := runInParallel(t,
 		func() (*csi.CreateVolumeResponse, error) {
@@ -406,7 +390,7 @@ func TestCGGroupSnapshotDedup(t *testing.T) {
 	const ns = "cgtest"
 
 	group := uniqueGroup("gsnap")
-	drv := newDriver(t, cl, fakeKube(pvc(ns, "gs-a", group), pvc(ns, "gs-b", group)))
+	drv := newDriver(t, cl, kubefake.NewClientset(pvc(ns, "gs-a", group), pvc(ns, "gs-b", group)))
 
 	resps := runInParallel(t,
 		func() (*csi.CreateVolumeResponse, error) {
@@ -474,7 +458,7 @@ func TestCGDeleteSnapshotRejectsGroupMember(t *testing.T) {
 	const ns = "cgtest"
 
 	group := uniqueGroup("delsnap")
-	drv := newDriver(t, cl, fakeKube(pvc(ns, "ds-a", group), pvc(ns, "ds-b", group)))
+	drv := newDriver(t, cl, kubefake.NewClientset(pvc(ns, "ds-a", group), pvc(ns, "ds-b", group)))
 
 	resps := runInParallel(t,
 		func() (*csi.CreateVolumeResponse, error) {
@@ -555,7 +539,7 @@ func TestCGGroupRestore(t *testing.T) {
 	const ns = "cgtest"
 
 	srcGroup := uniqueGroup("restore-src")
-	srcDrv := newDriver(t, cl, fakeKube(pvc(ns, "src-a", srcGroup), pvc(ns, "src-b", srcGroup)))
+	srcDrv := newDriver(t, cl, kubefake.NewClientset(pvc(ns, "src-a", srcGroup), pvc(ns, "src-b", srcGroup)))
 
 	resps := runInParallel(t,
 		func() (*csi.CreateVolumeResponse, error) {
@@ -600,7 +584,7 @@ func TestCGGroupRestore(t *testing.T) {
 
 	// Restore into a NEW, all-fresh group. The first member to arrive triggers the whole-resource restore.
 	restoreGroup := uniqueGroup("restore-dst")
-	dstDrv := newDriver(t, cl, fakeKube(pvc(ns, "dst-a", restoreGroup), pvc(ns, "dst-b", restoreGroup)))
+	dstDrv := newDriver(t, cl, kubefake.NewClientset(pvc(ns, "dst-a", restoreGroup), pvc(ns, "dst-b", restoreGroup)))
 
 	reqA := createReq("dst-a", ns, "dst-a", "ext4", 128*miB, false)
 	reqA.VolumeContentSource = snapshotSource(snapForSource[idA])
@@ -644,7 +628,7 @@ func TestCGListVolumes(t *testing.T) {
 	const ns = "cgtest"
 
 	group := uniqueGroup("list")
-	drv := newDriver(t, cl, fakeKube(pvc(ns, "ls-a", group), pvc(ns, "ls-b", group), pvc(ns, "ls-plain", "")))
+	drv := newDriver(t, cl, kubefake.NewClientset(pvc(ns, "ls-a", group), pvc(ns, "ls-b", group), pvc(ns, "ls-plain", "")))
 
 	resps := runInParallel(t,
 		func() (*csi.CreateVolumeResponse, error) {
@@ -701,7 +685,7 @@ func TestCGNodePublish(t *testing.T) {
 	const ns = "cgtest"
 
 	group := uniqueGroup("publish")
-	drv := newDriver(t, cl, fakeKube(pvc(ns, "pub-a", group), pvc(ns, "pub-b", group)))
+	drv := newDriver(t, cl, kubefake.NewClientset(pvc(ns, "pub-a", group), pvc(ns, "pub-b", group)))
 
 	resps := runInParallel(t,
 		func() (*csi.CreateVolumeResponse, error) {
@@ -779,7 +763,7 @@ func TestCGRejectRWXOverNFS(t *testing.T) {
 	const ns = "cgtest"
 
 	group := uniqueGroup("rwxnfs")
-	drv := newDriver(t, cl, fakeKube(pvc(ns, "nfs-a", group)),
+	drv := newDriver(t, cl, kubefake.NewClientset(pvc(ns, "nfs-a", group)),
 		driver.ConfigureRWX(kubefake.NewSimpleClientset(), ns, "reactor-config"))
 
 	req := createReq("nfs-a", ns, "nfs-a", "ext4", 128*miB, false)
@@ -816,7 +800,7 @@ func TestCGRejectConflictingPlacement(t *testing.T) {
 	const ns = "cgtest"
 
 	group := uniqueGroup("conflict")
-	drv := newDriver(t, cl, fakeKube(pvc(ns, "cf-a", group), pvc(ns, "cf-b", group)))
+	drv := newDriver(t, cl, kubefake.NewClientset(pvc(ns, "cf-a", group), pvc(ns, "cf-b", group)))
 
 	respA, err := drv.CreateVolume(ctx, createReq("cf-a", ns, "cf-a", "ext4", 128*miB, false))
 	require.NoError(t, err)


### PR DESCRIPTION
Use typed Kubernetes clients instead of the "dynamic" client.

While at it, make it so that all extras that require kubeclients (VolumeSnapshot handling, Consistency Groups, RWX + validation), directly take the clients they depend on as arguments, and are "opt-in" on the code side.

In the case of RWX validation, we keep it opt-out on the CLI side for compatibility. We now also always log a warning if an option is enabled but no kubernetes client could be build.