### PR TITLE
CSI: implement new volume health RPCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - RWX block volumes no longer require a DRBD layer when all configured storage
   pools are backed by shared storage.
+- Volume health reporting via the new alpha `ControllerGetVolumeHealth` and
+  `ControllerListVolumeHealth` RPCs, replacing the `VOLUME_CONDITION`
+  mechanism removed in CSI spec 1.13.
 
 ### Changed
 

--- a/pkg/client/linstor.go
+++ b/pkg/client/linstor.go
@@ -177,9 +177,9 @@ func LogLevel(s string) func(*Linstor) error {
 	}
 }
 
-// ListAll returns a sorted list of volume and their status.
-func (s *Linstor) ListAll(ctx context.Context) ([]volume.Info, error) {
-	var vols []volume.Info
+// ListAll returns a sorted list of volumes and status.
+func (s *Linstor) ListAll(ctx context.Context) ([]volume.Status, error) {
+	var vols []volume.Status
 
 	resourcesByName := make(map[string][]lapi.ResourceWithVolumes)
 
@@ -200,6 +200,9 @@ func (s *Linstor) ListAll(ctx context.Context) ([]volume.Info, error) {
 	for i := range resDefs {
 		rd := resDefs[i]
 
+		// The volume health is resource-level and shared by every member of a consistency group.
+		healthIssue := HealthIssueFromResource(resourcesByName[rd.Name])
+
 		isConsistencyGroup := false
 
 		for vn := range util.ConsistencyGroupVolumes(rd.VolumeDefinitions...) {
@@ -207,14 +210,14 @@ func (s *Linstor) ListAll(ctx context.Context) ([]volume.Info, error) {
 
 			vol := s.volumeInfoFromResourceDefinition(volume.ID{ResourceName: rd.Name, VolumeNumber: vn}, rd)
 			if vol != nil {
-				vols = append(vols, *vol)
+				vols = append(vols, volume.Status{Info: *vol, HealthIssue: healthIssue})
 			}
 		}
 
 		if !isConsistencyGroup {
 			vol := s.volumeInfoFromResourceDefinition(volume.ID{ResourceName: rd.Name}, rd)
 			if vol != nil {
-				vols = append(vols, *vol)
+				vols = append(vols, volume.Status{Info: *vol, HealthIssue: healthIssue})
 			}
 		}
 	}
@@ -2530,6 +2533,20 @@ func (s *Linstor) FindAssignmentOnNode(ctx context.Context, id volume.ID, node s
 	return va, nil
 }
 
+// GetVolumeHealthIssue returns the health issue of the given volume, if any.
+func (s *Linstor) GetVolumeHealthIssue(ctx context.Context, id volume.ID) (*volume.HealthIssue, error) {
+	s.log.WithFields(logrus.Fields{
+		"volume": id,
+	}).Debug("getting resource health")
+
+	ress, err := s.client.Resources.GetResourceView(ctx, &lapi.ListOpts{Resource: []string{id.ResourceName}})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list resources for '%s': %w", id.ResourceName, err)
+	}
+
+	return HealthIssueFromResource(ress), nil
+}
+
 // SetSnapshotType tries to set the snapshot type based on the remote name.
 // If there is no remote name, it's a local snapshot, if the remote name is an S3 remote, it's an S3 snapshot, etc...
 // If the remote is unknown, we treat it as a local snapshot.
@@ -2606,6 +2623,51 @@ func GetSnapshotRemoteAndReadiness(snap *lapi.Snapshot) (string, bool, error) {
 
 	// Local only snapshot
 	return "", slices.Contains(snap.Flags, lapiconsts.FlagSuccessful), nil
+}
+
+// HealthIssueFromResource derives the health issues of a volume from its LINSTOR resources.
+//
+// A resource is abnormal if its state is unknown (satellite offline) or DRBD reports it as not
+// promotable. A nil result means the volume is healthy, abnormal resources degrade the
+// volume, and if no healthy resource is left the volume is inaccessible.
+func HealthIssueFromResource(ress []lapi.ResourceWithVolumes) *volume.HealthIssue {
+	if len(ress) == 0 {
+		return &volume.HealthIssue{
+			Status:  volume.HealthStatusInaccessible,
+			Reason:  "NoReplicas",
+			Message: "The volume has no deployed replica",
+		}
+	}
+
+	abnormalRes := slices.DeleteFunc(slices.Clone(ress), func(res lapi.ResourceWithVolumes) bool {
+		drbd := util.GetDrbdLayer(res.LayerObject)
+		return res.State != nil && (drbd == nil || drbd.PromotionScore != 0)
+	})
+
+	var abnormalNodes []string
+	for i := range abnormalRes {
+		abnormalNodes = append(abnormalNodes, abnormalRes[i].NodeName)
+	}
+
+	switch len(abnormalNodes) {
+	case 0:
+		// All good
+		return nil
+	case len(ress):
+		// All have issues
+		return &volume.HealthIssue{
+			Status:  volume.HealthStatusInaccessible,
+			Reason:  "NoHealthyReplicas",
+			Message: fmt.Sprintf("All deployed replicas have issues: %s", strings.Join(abnormalNodes, ", ")),
+		}
+	default:
+		// Some have issues
+		return &volume.HealthIssue{
+			Status:  volume.HealthStatusDegraded,
+			Reason:  "UnhealthyReplicas",
+			Message: fmt.Sprintf("Degraded replicas on: %s", strings.Join(abnormalNodes, ", ")),
+		}
+	}
 }
 
 // Mount makes volumes consumable from the source to the target.

--- a/pkg/client/linstor_test.go
+++ b/pkg/client/linstor_test.go
@@ -23,6 +23,7 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -424,6 +425,77 @@ func TestLinstor_SortByPreferred(t *testing.T) {
 			actual, err := cl.SortByPreferred(context.Background(), tcase.nodes, tcase.policy, tcase.preferredTopology)
 			assert.NoError(t, err)
 			tcase.assertion(t, actual)
+		})
+	}
+}
+
+func TestLinstor_GetVolumeHealth(t *testing.T) {
+	tcases := []struct {
+		name          string
+		response      []byte
+		expectedIssue *volume.HealthIssue
+	}{
+		{
+			// All resource connected and up to date - all diskful, none are published
+			name:          "pvc-080c4024-9f03-4d71-909f-be4aa58e64ff",
+			response:      []byte(`[{"name":"pvc-080c4024-9f03-4d71-909f-be4aa58e64ff","node_name":"node-0","props":{"StorPoolName":"worker-pool"},"layer_object":{"children":[{"type":"STORAGE","storage":{"storage_volumes":[{"volume_number":0,"device_path":"/dev/linstor-vg/pvc-080c4024-9f03-4d71-909f-be4aa58e64ff_00000","allocated_size_kib":507758,"usable_size_kib":8392704,"disk_state":"[]"}]}}],"type":"DRBD","drbd":{"drbd_resource_definition":{"peer_slots":7,"al_stripes":1,"al_stripe_size_kib":32,"port":7004,"transport_type":"IP","secret":"0iTx8wUc7WfRFZ9f5clx","down":false},"node_id":2,"peer_slots":7,"al_stripes":1,"al_size":32,"drbd_volumes":[{"drbd_volume_definition":{"volume_number":0,"minor_number":1004},"device_path":"/dev/drbd1004","backing_device":"/dev/linstor-vg/pvc-080c4024-9f03-4d71-909f-be4aa58e64ff_00000","allocated_size_kib":8390440,"usable_size_kib":8388608}],"connections":{"node-2":{"connected":true,"message":"Connected"},"node-1":{"connected":true,"message":"Connected"}},"promotion_score":10103,"may_promote":false}},"state":{"in_use":false},"uuid":"0c9c79f1-0c7d-44d6-9113-18f1f8da2f36","create_timestamp":1650958143619},{"name":"pvc-080c4024-9f03-4d71-909f-be4aa58e64ff","node_name":"node-1","props":{"StorPoolName":"worker-pool"},"layer_object":{"children":[{"type":"STORAGE","storage":{"storage_volumes":[{"volume_number":0,"device_path":"/dev/linstor-vg/pvc-080c4024-9f03-4d71-909f-be4aa58e64ff_00000","allocated_size_kib":507758,"usable_size_kib":8392704,"disk_state":"[]"}]}}],"type":"DRBD","drbd":{"drbd_resource_definition":{"peer_slots":7,"al_stripes":1,"al_stripe_size_kib":32,"port":7004,"transport_type":"IP","secret":"0iTx8wUc7WfRFZ9f5clx","down":false},"node_id":1,"peer_slots":7,"al_stripes":1,"al_size":32,"drbd_volumes":[{"drbd_volume_definition":{"volume_number":0,"minor_number":1004},"device_path":"/dev/drbd1004","backing_device":"/dev/linstor-vg/pvc-080c4024-9f03-4d71-909f-be4aa58e64ff_00000","allocated_size_kib":8390440,"usable_size_kib":8388608}],"connections":{"node-2":{"connected":true,"message":"Connected"},"node-0":{"connected":true,"message":"Connected"}},"promotion_score":10103,"may_promote":false}},"state":{"in_use":true},"uuid":"75a226de-172e-4464-ab1c-e1ad22ae8929","create_timestamp":1650958145216},{"name":"pvc-080c4024-9f03-4d71-909f-be4aa58e64ff","node_name":"node-2","props":{"StorPoolName":"worker-pool"},"layer_object":{"children":[{"type":"STORAGE","storage":{"storage_volumes":[{"volume_number":0,"device_path":"/dev/linstor-vg/pvc-080c4024-9f03-4d71-909f-be4aa58e64ff_00000","allocated_size_kib":507758,"usable_size_kib":8392704,"disk_state":"[]"}]}}],"type":"DRBD","drbd":{"drbd_resource_definition":{"peer_slots":7,"al_stripes":1,"al_stripe_size_kib":32,"port":7004,"transport_type":"IP","secret":"0iTx8wUc7WfRFZ9f5clx","down":false},"node_id":0,"peer_slots":7,"al_stripes":1,"al_size":32,"drbd_volumes":[{"drbd_volume_definition":{"volume_number":0,"minor_number":1004},"device_path":"/dev/drbd1004","backing_device":"/dev/linstor-vg/pvc-080c4024-9f03-4d71-909f-be4aa58e64ff_00000","allocated_size_kib":8390440,"usable_size_kib":8388608}],"connections":{"node-0":{"connected":true,"message":"Connected"},"node-1":{"connected":true,"message":"Connected"}},"promotion_score":10103,"may_promote":false}},"state":{"in_use":false},"uuid":"3939463f-2c72-4918-b485-53d44ca4337d","create_timestamp":1650958142041}]`),
+			expectedIssue: nil,
+		},
+		{
+			// No deployed resource - the volume is inaccessible
+			name:     "no-replica",
+			response: []byte(`[]`),
+			expectedIssue: &volume.HealthIssue{
+				Status:  volume.HealthStatusInaccessible,
+				Reason:  "NoReplicas",
+				Message: "The volume has no deployed replica",
+			},
+		},
+		{
+			// One resource disconnected, one tie-breaker diskless - none are published
+			name:     "res1",
+			response: []byte(`[{"name":"res1","node_name":"node-0","props":{"StorPoolName":"master-pool"},"layer_object":{"children":[{"type":"STORAGE","storage":{"storage_volumes":[{"volume_number":0,"device_path":"/dev/linstor-vg/res1_00000","allocated_size_kib":421,"usable_size_kib":1052672,"disk_state":"[]"}]}}],"type":"DRBD","drbd":{"drbd_resource_definition":{"peer_slots":7,"al_stripes":1,"al_stripe_size_kib":32,"port":7006,"transport_type":"IP","secret":"cADS/SmRP49riL4Ge+zf","down":false},"node_id":0,"peer_slots":7,"al_stripes":1,"al_size":32,"drbd_volumes":[{"drbd_volume_definition":{"volume_number":0,"minor_number":1006},"device_path":"/dev/drbd1006","backing_device":"/dev/linstor-vg/res1_00000","allocated_size_kib":1048840,"usable_size_kib":1048576}],"connections":{"node-1":{"connected":false,"message":"Connecting"},"node-2":{"connected":true,"message":"Connected"}},"promotion_score":10101,"may_promote":true}},"state":{"in_use":false},"uuid":"0b6003e6-c973-40ca-b1fd-46039f79c238","create_timestamp":1655106116603},{"name":"res1","node_name":"node-1","props":{"StorPoolName":"master-pool"},"layer_object":{"children":[{"type":"STORAGE","storage":{"storage_volumes":[{"volume_number":0,"device_path":"/dev/linstor-vg/res1_00000","allocated_size_kib":421,"usable_size_kib":1052672,"disk_state":"[]"}]}}],"type":"DRBD","drbd":{"drbd_resource_definition":{"peer_slots":7,"al_stripes":1,"al_stripe_size_kib":32,"port":7006,"transport_type":"IP","secret":"cADS/SmRP49riL4Ge+zf","down":false},"node_id":1,"peer_slots":7,"al_stripes":1,"al_size":32,"drbd_volumes":[{"drbd_volume_definition":{"volume_number":0,"minor_number":1006},"device_path":"/dev/drbd1006","backing_device":"/dev/linstor-vg/res1_00000","allocated_size_kib":1048840,"usable_size_kib":1048576}],"connections":{"node-2":{"connected":false,"message":"StandAlone"},"node-0":{"connected":false,"message":"StandAlone"}},"promotion_score":0,"may_promote":false}},"state":{"in_use":false},"uuid":"787cd251-0e6f-4135-8a41-3bf6292d4853","create_timestamp":1655106118277},{"name":"res1","node_name":"node-2","props":{"StorPoolName":"DfltDisklessStorPool"},"flags":["DISKLESS","DRBD_DISKLESS","TIE_BREAKER"],"layer_object":{"children":[{"type":"STORAGE","storage":{"storage_volumes":[{"volume_number":0,"allocated_size_kib":0,"usable_size_kib":1048576}]}}],"type":"DRBD","drbd":{"drbd_resource_definition":{"peer_slots":7,"al_stripes":1,"al_stripe_size_kib":32,"port":7006,"transport_type":"IP","secret":"cADS/SmRP49riL4Ge+zf","down":false},"node_id":2,"peer_slots":7,"al_stripes":1,"al_size":32,"flags":["DISKLESS","INITIALIZED"],"drbd_volumes":[{"drbd_volume_definition":{"volume_number":0,"minor_number":1006},"device_path":"/dev/drbd1006","allocated_size_kib":-1,"usable_size_kib":1048576}],"connections":{"node-1":{"connected":false,"message":"Connecting"},"node-0":{"connected":true,"message":"Connected"}},"promotion_score":1,"may_promote":true}},"state":{"in_use":false},"uuid":"b3aae5c4-64d9-4d24-a1ba-a306b21d53a8","create_timestamp":1655106114421}]`),
+			expectedIssue: &volume.HealthIssue{
+				Status:  volume.HealthStatusDegraded,
+				Reason:  "UnhealthyReplicas",
+				Message: "Degraded replicas on: node-1",
+			},
+		},
+		{
+			// Diskful storage backend + in-use diskless attachment - healthy
+			name:          "pvc-manual-diskless",
+			response:      []byte(`[{"name":"pvc-manual-diskless","node_name":"storage-0","props":{"StorPoolName":"data-pool"},"layer_object":{"children":[{"type":"STORAGE","storage":{"storage_volumes":[{"volume_number":0,"device_path":"/dev/data-vg/pvc-manual-diskless_00000","allocated_size_kib":421,"usable_size_kib":1052672,"disk_state":"[]"}]}}],"type":"DRBD","drbd":{"drbd_resource_definition":{"peer_slots":7,"al_stripes":1,"al_stripe_size_kib":32,"port":7011,"transport_type":"IP","secret":"secret","down":false},"node_id":0,"peer_slots":7,"al_stripes":1,"al_size":32,"drbd_volumes":[{"drbd_volume_definition":{"volume_number":0,"minor_number":1011},"device_path":"/dev/drbd1011","backing_device":"/dev/data-vg/pvc-manual-diskless_00000","allocated_size_kib":1048840,"usable_size_kib":1048576}],"connections":{"compute-0":{"connected":true,"message":"Connected"}},"promotion_score":10101,"may_promote":true}},"state":{"in_use":false},"uuid":"00000000-0000-0000-0000-000000000003","create_timestamp":1655106116603,"volumes":[{"volume_number":0}]},{"name":"pvc-manual-diskless","node_name":"compute-0","props":{"StorPoolName":"DfltDisklessStorPool"},"flags":["DISKLESS","DRBD_DISKLESS"],"layer_object":{"children":[{"type":"STORAGE","storage":{"storage_volumes":[{"volume_number":0,"allocated_size_kib":0,"usable_size_kib":1048576}]}}],"type":"DRBD","drbd":{"drbd_resource_definition":{"peer_slots":7,"al_stripes":1,"al_stripe_size_kib":32,"port":7011,"transport_type":"IP","secret":"secret","down":false},"node_id":1,"peer_slots":7,"al_stripes":1,"al_size":32,"flags":["DISKLESS","INITIALIZED"],"drbd_volumes":[{"drbd_volume_definition":{"volume_number":0,"minor_number":1011},"device_path":"/dev/drbd1011","allocated_size_kib":-1,"usable_size_kib":1048576}],"connections":{"storage-0":{"connected":true,"message":"Connected"}},"promotion_score":10101,"may_promote":true}},"state":{"in_use":true},"uuid":"00000000-0000-0000-0000-000000000004","create_timestamp":1655106118277,"volumes":[{"volume_number":0,"provider_kind":"DISKLESS"}]}]`),
+			expectedIssue: nil,
+		},
+		{
+			// No resource can be promoted - the volume is inaccessible
+			name:     "res-all-abnormal",
+			response: []byte(`[{"name":"res-all-abnormal","node_name":"node-a","layer_object":{"type":"DRBD","drbd":{"promotion_score":0,"may_promote":false}},"state":{"in_use":false}},{"name":"res-all-abnormal","node_name":"node-b","layer_object":{"type":"DRBD","drbd":{"promotion_score":0,"may_promote":false}},"state":{"in_use":false}}]`),
+			expectedIssue: &volume.HealthIssue{
+				Status:  volume.HealthStatusInaccessible,
+				Reason:  "NoHealthyReplicas",
+				Message: "All deployed replicas have issues: node-a, node-b",
+			},
+		},
+	}
+
+	for i := range tcases {
+		tcase := &tcases[i]
+
+		t.Run(tcase.name, func(t *testing.T) {
+			var parsedResponse []lapi.ResourceWithVolumes
+
+			err := json.Unmarshal(tcase.response, &parsedResponse)
+			assert.NoError(t, err)
+
+			r := &mocks.ResourceProvider{}
+			r.EXPECT().GetResourceView(mock.Anything, []*lapi.ListOpts{{Resource: []string{tcase.name}}}).Return(parsedResponse, nil)
+			cl := Linstor{client: &lc.HighLevelClient{Client: &lapi.Client{Resources: r}}, log: logrus.WithField("test", t.Name())}
+
+			actualIssue, err := cl.GetVolumeHealthIssue(context.Background(), volume.ID{ResourceName: tcase.name, VolumeNumber: 0})
+			assert.NoError(t, err)
+			r.AssertExpectations(t)
+			assert.Equal(t, tcase.expectedIssue, actualIssue)
 		})
 	}
 }

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -993,10 +993,10 @@ func (d *Driver) ValidateVolumeCapabilities(ctx context.Context, req *csi.Valida
 func (d *Driver) ListVolumes(ctx context.Context, req *csi.ListVolumesRequest) (*csi.ListVolumesResponse, error) {
 	volumes, err := d.linstorClient.ListAll(ctx)
 	if err != nil {
-		return &csi.ListVolumesResponse{}, status.Errorf(codes.Aborted, "ListVolumes failed: %v", err)
+		return &csi.ListVolumesResponse{}, status.Errorf(codes.Internal, "ListVolumes failed: %v", err)
 	}
 
-	start, err := parseAsInt(req.GetStartingToken())
+	start, err := parseStartingToken(req.GetStartingToken())
 	if err != nil {
 		return nil, status.Errorf(codes.Aborted, "ListVolumes failed for: %v", err)
 	}
@@ -1050,7 +1050,7 @@ func (d *Driver) ControllerListVolumeHealth(ctx context.Context, req *csi.Contro
 		return vol.HealthIssue == nil
 	})
 
-	start, err := parseAsInt(req.GetStartingToken())
+	start, err := parseStartingToken(req.GetStartingToken())
 	if err != nil {
 		return nil, status.Errorf(codes.Aborted, "ControllerListVolumeHealth failed: %v", err)
 	}
@@ -1306,7 +1306,8 @@ func (d *Driver) DeleteSnapshot(ctx context.Context, req *csi.DeleteSnapshotRequ
 // ListSnapshots https://github.com/container-storage-interface/spec/blob/v1.13.0/spec.md#listsnapshots
 func (d *Driver) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsRequest) (*csi.ListSnapshotsResponse, error) {
 	limit := int(req.GetMaxEntries())
-	start, err := parseAsInt(req.GetStartingToken())
+
+	start, err := parseStartingToken(req.GetStartingToken())
 	if err != nil {
 		return nil, status.Errorf(codes.Aborted, "Invalid starting token: %v", err)
 	}
@@ -1951,7 +1952,7 @@ func missingAttr(methodCall, volumeID, attr string) error {
 		"%s failed for %s: it requires a %s and none was provided", methodCall, volumeID, attr)
 }
 
-func parseAsInt(s string) (int, error) {
+func parseStartingToken(s string) (int, error) {
 	if s == "" {
 		return 0, nil
 	}
@@ -1960,6 +1961,11 @@ func parseAsInt(s string) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("failed to parse starting token: %v", err)
 	}
+
+	if i < 0 {
+		return 0, fmt.Errorf("starting token cannot be negative")
+	}
+
 	return int(i), nil
 }
 

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -1038,6 +1038,99 @@ func (d *Driver) ListVolumes(ctx context.Context, req *csi.ListVolumesRequest) (
 	return &csi.ListVolumesResponse{NextToken: nextToken, Entries: entries}, nil
 }
 
+// ControllerListVolumeHealth https://github.com/container-storage-interface/spec/blob/v1.13.0/spec.md#controllerlistvolumehealth
+func (d *Driver) ControllerListVolumeHealth(ctx context.Context, req *csi.ControllerListVolumeHealthRequest) (*csi.ControllerListVolumeHealthResponse, error) {
+	volumes, err := d.linstorClient.ListAll(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "ControllerListVolumeHealth failed: %v", err)
+	}
+
+	// Only abnormal volumes are reported.
+	volumes = slices.DeleteFunc(volumes, func(vol volume.Status) bool {
+		return vol.HealthIssue == nil
+	})
+
+	start, err := parseAsInt(req.GetStartingToken())
+	if err != nil {
+		return nil, status.Errorf(codes.Aborted, "ControllerListVolumeHealth failed: %v", err)
+	}
+
+	if start > len(volumes) {
+		return &csi.ControllerListVolumeHealthResponse{}, nil
+	}
+
+	end := len(volumes)
+
+	var nextToken string
+
+	if maxEntries := int(req.GetMaxEntries()); maxEntries > 0 && start+maxEntries < end {
+		end = start + maxEntries
+		nextToken = strconv.Itoa(end)
+	}
+
+	entries := make([]*csi.VolumeHealth, 0, end-start)
+
+	for i := range volumes[start:end] {
+		vol := &volumes[start+i]
+		entries = append(entries, &csi.VolumeHealth{
+			VolumeId:       vol.String(),
+			HealthStatuses: csiHealthStatus(vol.HealthIssue),
+		})
+	}
+
+	return &csi.ControllerListVolumeHealthResponse{NextToken: nextToken, Entries: entries}, nil
+}
+
+// csiHealthStatus converts the internal volume health representation to CSI health entries.
+func csiHealthStatus(health *volume.HealthIssue) []*csi.VolumeHealth_VolumeHealthEntry {
+	if health == nil {
+		return nil
+	}
+
+	s := csi.VolumeHealthErrorType_UNKNOWN_VOLUME_HEALTH_TYPE
+
+	switch health.Status {
+	case volume.HealthStatusDegraded:
+		s = csi.VolumeHealthErrorType_DEGRADED
+	case volume.HealthStatusInaccessible:
+		s = csi.VolumeHealthErrorType_INACCESSIBLE
+	}
+
+	return []*csi.VolumeHealth_VolumeHealthEntry{{
+		Status:  s,
+		Reason:  health.Reason,
+		Message: health.Message,
+	}}
+}
+
+// ControllerGetVolumeHealth https://github.com/container-storage-interface/spec/blob/v1.13.0/spec.md#controllergetvolumehealth
+func (d *Driver) ControllerGetVolumeHealth(ctx context.Context, req *csi.ControllerGetVolumeHealthRequest) (*csi.ControllerGetVolumeHealthResponse, error) {
+	if req.GetVolumeId() == "" {
+		return nil, missingAttr("ControllerGetVolumeHealth", req.GetVolumeId(), "VolumeId")
+	}
+
+	vol, err := d.linstorClient.FindByID(ctx, req.GetVolumeId())
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to find volume '%s': %v", req.GetVolumeId(), err)
+	}
+
+	if vol == nil {
+		return nil, status.Errorf(codes.NotFound, "no volume '%s' found", req.GetVolumeId())
+	}
+
+	healthIssue, err := d.linstorClient.GetVolumeHealthIssue(ctx, vol.ID)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to get health of volume '%s': %v", vol.ID, err)
+	}
+
+	return &csi.ControllerGetVolumeHealthResponse{
+		VolumeHealth: &csi.VolumeHealth{
+			VolumeId:       vol.String(),
+			HealthStatuses: csiHealthStatus(healthIssue),
+		},
+	}, nil
+}
+
 // GetCapacity https://github.com/container-storage-interface/spec/blob/v1.13.0/spec.md#getcapacity
 func (d *Driver) GetCapacity(ctx context.Context, req *csi.GetCapacityRequest) (*csi.GetCapacityResponse, error) {
 	params, err := volume.NewParameters(req.GetParameters(), d.topologyPrefix)
@@ -1137,6 +1230,17 @@ func (d *Driver) ControllerGetCapabilities(ctx context.Context, req *csi.Control
 			{Type: &csi.ControllerServiceCapability_Rpc{
 				Rpc: &csi.ControllerServiceCapability_RPC{
 					Type: csi.ControllerServiceCapability_RPC_GET_SNAPSHOT,
+				},
+			}},
+			// Tell the CO we can report volume health.
+			{Type: &csi.ControllerServiceCapability_Rpc{
+				Rpc: &csi.ControllerServiceCapability_RPC{
+					Type: csi.ControllerServiceCapability_RPC_GET_VOLUME_HEALTH,
+				},
+			}},
+			{Type: &csi.ControllerServiceCapability_Rpc{
+				Rpc: &csi.ControllerServiceCapability_RPC{
+					Type: csi.ControllerServiceCapability_RPC_LIST_VOLUME_HEALTH,
 				},
 			}},
 			// No PUBLISH_READONLY here: LINSTOR does not support enforcement of RO state at the make-avail/controller

--- a/pkg/linstor/util/util.go
+++ b/pkg/linstor/util/util.go
@@ -100,6 +100,10 @@ nextCandidate:
 }
 
 func GetDrbdLayer(layer *lapi.ResourceLayer) *lapi.DrbdResource {
+	if layer == nil {
+		return nil
+	}
+
 	if layer.Type == devicelayerkind.Drbd {
 		return layer.Drbd
 	}

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -200,6 +200,30 @@ type VolumeStats struct {
 	UsedInodes      int64
 }
 
+// HealthStatus classifies how a volume's health is impaired.
+type HealthStatus string
+
+const (
+	// HealthStatusDegraded means the volume works, but some replicas have issues.
+	HealthStatusDegraded HealthStatus = "Degraded"
+	// HealthStatusInaccessible means no healthy replica is left.
+	HealthStatusInaccessible HealthStatus = "Inaccessible"
+)
+
+// HealthIssue describes a single health issue of a volume.
+type HealthIssue struct {
+	Status  HealthStatus
+	Reason  string
+	Message string
+}
+
+// Status describes a volume, including the health state.
+type Status struct {
+	Info
+	// HealthIssue is nil if the volume is healthy, otherwise it contains details about the degraded volume.
+	HealthIssue *HealthIssue
+}
+
 // Add the given prefix to the property name.
 // If the property is already prefixed (with "Aux/"), no modification is made.
 func maybeAddTopologyPrefix(prefix string, props ...string) []string {


### PR DESCRIPTION
CSI spec 1.13 removed the `VOLUME_CONDITION` mechanism; this implements its replacement, the new alpha volume health APIs.

## Notes for review
- Node-side health (`NodeGetVolumeHealth`, `NodeGetStorageHealth`) is intentionally not implemented, matching the previous controller-only condition reporting.
