### PR TITLE
use new LINSTOR 1.35 APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- RWX block volumes no longer require a DRBD layer when all configured storage
+  pools are backed by shared storage.
+
 ### Changed
 
 - Update CSI spec to 1.13.0.
+- The driver now requires LINSTOR 1.35 or newer and refuses to start against
+  older controllers.
 
 ## [1.12.0] - 2026-07-24
 

--- a/cmd/linstor-csi/linstor-csi.go
+++ b/cmd/linstor-csi/linstor-csi.go
@@ -137,6 +137,10 @@ func main() {
 		log.Fatal(err)
 	}
 
+	if err := c.EnsureMinimumApiVersion(ctx); err != nil {
+		log.Fatal(err)
+	}
+
 	linstorClient, err := client.NewLinstor(
 		client.APIClient(c),
 		client.LogFmt(logFmt),

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/BurntSushi/toml v1.6.0
-	github.com/LINBIT/golinstor v0.65.0
+	github.com/LINBIT/golinstor v0.65.1
 	github.com/container-storage-interface/spec v1.13.0
 	github.com/coreos/go-systemd/v22 v22.7.0
 	github.com/kubernetes-csi/external-snapshotter/client/v8 v8.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
-github.com/LINBIT/golinstor v0.65.0 h1:KJtF1na90/5v4gTpTuk3TsmUQj61tRlJe6PA0r3X8co=
-github.com/LINBIT/golinstor v0.65.0/go.mod h1:LrjAIoiOeyrfkQpWNHuAvwMSGPD9ISDZMUekSQ4i/V0=
+github.com/LINBIT/golinstor v0.65.1 h1:JIdEcPRhiISms6ANLeSLzIpV0YNJpwDP1/LcI1k7I/4=
+github.com/LINBIT/golinstor v0.65.1/go.mod h1:LrjAIoiOeyrfkQpWNHuAvwMSGPD9ISDZMUekSQ4i/V0=
 github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=
 github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/pkg/client/linstor.go
+++ b/pkg/client/linstor.go
@@ -41,7 +41,6 @@ import (
 	lapiconsts "github.com/LINBIT/golinstor"
 	lapi "github.com/LINBIT/golinstor/client"
 	"github.com/LINBIT/golinstor/clonestatus"
-	"github.com/LINBIT/golinstor/devicelayerkind"
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/pborman/uuid"
 	"github.com/sirupsen/logrus"
@@ -704,18 +703,14 @@ func (s *Linstor) Delete(ctx context.Context, id volume.ID) error {
 
 // deleteResource tears down a whole resource; used for standalone volumes and a group's last member.
 func (s *Linstor) deleteResource(ctx context.Context, rdName string) error {
-	// Disable the BalanceResourceTask for this resource during deletion.
-	err := s.client.ResourceDefinitions.Modify(ctx, rdName, lapi.GenericPropsModify{
-		OverrideProps: map[string]string{lapiconsts.KeyBalanceResourcesEnabled: lapiconsts.ValFalse},
-	})
+	// Remember the resource group: the resource definition may be gone after the truncate.
+	rDef, err := s.client.ResourceDefinitions.Get(ctx, rdName)
 	if err != nil {
 		return nil404(err)
 	}
 
-	var resources []lapi.Resource
-
 	for {
-		resources, err = s.client.Resources.GetAll(ctx, rdName)
+		resources, err := s.client.Resources.GetAll(ctx, rdName)
 		if err != nil {
 			return nil404(err)
 		}
@@ -730,23 +725,22 @@ func (s *Linstor) deleteResource(ctx context.Context, rdName string) error {
 		time.Sleep(5 * time.Second)
 	}
 
-	// Need to ensure that diskless resources are always deleted first, otherwise the last diskfull resource won't be
-	// deleted
-	sort.Slice(resources, func(i, j int) bool {
-		return !util.DeployedDiskfully(resources[i]) && util.DeployedDiskfully(resources[j])
+	// Truncating removes all resources in one server-side operation, so there is no window in
+	// which the balancer could re-create replicas, nor a need to delete diskless resources first.
+	err = s.client.ResourceDefinitions.Truncate(ctx, rdName, &lapi.ResourceDefinitionTruncateOpts{
+		// Delete the resource definition unless snapshots keep it alive; the emptiness check
+		// happens server-side, atomically after the truncate completed.
+		DeleteEmptyResourceDefinition: true,
 	})
-
-	for _, res := range resources {
-		err := s.client.Resources.Delete(ctx, rdName, res.NodeName, &lapi.ResourceDeleteOpts{KeepTiebreaker: false})
-		if err != nil {
-			// If two deletions run in parallel, one could get a 404 message, which we treat as "everything finished"
-			return nil404(err)
-		}
+	if nil404(err) != nil {
+		return err
 	}
 
+	// If snapshots kept the resource definition alive, delete the volume definitions: this marks
+	// the normal deletion as complete, hiding the volume while the snapshots live on.
 	vds, err := s.client.ResourceDefinitions.GetVolumeDefinitions(ctx, rdName)
-	if err != nil {
-		return nil404(err)
+	if nil404(err) != nil {
+		return err
 	}
 
 	// Sort descending, volume 0 should be the last to be removed
@@ -755,28 +749,13 @@ func (s *Linstor) deleteResource(ctx context.Context, rdName string) error {
 	})
 
 	for _, vd := range vds {
-		// Delete the volume definition. This indicates the normal deletion is complete.
 		err = s.client.ResourceDefinitions.DeleteVolumeDefinition(ctx, rdName, int(*vd.VolumeNumber))
 		if nil404(err) != nil {
-			// We continue with the cleanup on 404, maybe the previous cleanup was interrupted
 			return err
 		}
 	}
 
-	// Reset BalanceResourceTask for the case the resource definition is in use by a snapshot.
-	err = s.client.ResourceDefinitions.Modify(ctx, rdName, lapi.GenericPropsModify{
-		DeleteProps: []string{lapiconsts.KeyBalanceResourcesEnabled},
-	})
-	if err != nil {
-		return nil404(err)
-	}
-
-	err = s.deleteResourceDefinitionAndGroupIfUnused(ctx, rdName)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return s.deleteResourceGroupIfUnused(ctx, rDef.ResourceGroupName)
 }
 
 // AccessibleTopologies returns a list of pointers to csi.Topology from where the
@@ -842,39 +821,11 @@ func (s *Linstor) Attach(ctx context.Context, id volume.ID, node string, rwxBloc
 		"targetNode": node,
 	}).Info("attaching volume")
 
-	ress, err := s.client.Resources.GetAll(ctx, id.ResourceName)
-	if err != nil {
-		return "", err
-	}
-
-	if len(ress) == 0 {
-		return "", fmt.Errorf("failed to attach resource with no deployed replica")
-	}
-
-	otherResInUse := 0
-
-	for i := range ress {
-		if ress[i].NodeName != node && ress[i].State != nil && ress[i].State.InUse != nil && *ress[i].State.InUse {
-			otherResInUse++
-		}
-	}
-
-	if otherResInUse >= 2 {
-		return "", fmt.Errorf("two other resources already InUse")
-	}
-
-	if otherResInUse > 0 && rwxBlock {
-		rdPropsModify := lapi.GenericPropsModify{OverrideProps: map[string]string{
-			linstor.PropertyAllowTwoPrimaries: "yes",
-		}}
-
-		err = s.client.ResourceDefinitions.Modify(ctx, id.ResourceName, rdPropsModify)
-		if err != nil {
-			return "", err
-		}
-	}
-
-	err = s.client.Resources.MakeAvailable(ctx, id.ResourceName, node, lapi.ResourceMakeAvailable{Diskful: false})
+	// For RWX volumes LINSTOR manages allow-two-primaries (or activation on both nodes for
+	// shared storage pools) itself, keeping it set only while a live migration needs it.
+	err := s.client.Resources.MakeAvailable(ctx, id.ResourceName, node, lapi.ResourceMakeAvailable{
+		AutoManageDualPrimary: rwxBlock,
+	})
 	if err != nil {
 		return "", err
 	}
@@ -887,79 +838,20 @@ func (s *Linstor) Attach(ctx context.Context, id volume.ID, node string, rwxBloc
 	return vol.DevicePath, nil
 }
 
-// getDisklessFlag inspects a resource to determine the right diskless flag to use.
-func getDisklessFlag(resource *lapi.Resource) string {
-	layer := resource.LayerObject
-
-	for layer != nil {
-		switch layer.Type {
-		case devicelayerkind.Drbd:
-			return lapiconsts.FlagDrbdDiskless
-		case devicelayerkind.Nvme:
-			return lapiconsts.FlagNvmeInitiator
-		default:
-			// recurse deeper
-		}
-
-		if len(layer.Children) != 1 {
-			// No idea how to deal with layer depending on children anyways, so we just ignore those
-			break
-		}
-
-		layer = &layer.Children[0]
-	}
-
-	return ""
-}
-
-// Detach removes a volume from the node.
+// Detach reverts a previous Attach, removing temporary resources from the node.
 func (s *Linstor) Detach(ctx context.Context, id volume.ID, node string) error {
 	log := s.log.WithFields(logrus.Fields{
 		"volume":     id,
 		"targetNode": node,
 	})
 
-	ress, err := s.client.Resources.GetAll(ctx, id.ResourceName)
-	if err != nil {
-		return nil404(err)
-	}
+	log.Info("detaching volume")
 
-	resInUse := 0
-
-	for i := range ress {
-		if ress[i].State != nil && ress[i].State.InUse != nil && *ress[i].State.InUse {
-			resInUse++
-		}
-	}
-
-	if resInUse == 1 {
-		rdPropsModify := lapi.GenericPropsModify{DeleteProps: []string{
-			linstor.PropertyAllowTwoPrimaries,
-		}}
-
-		err = s.client.ResourceDefinitions.Modify(ctx, id.ResourceName, rdPropsModify)
-		if err != nil {
-			return nil404(err)
-		}
-	}
-
-	vol, err := s.client.Resources.GetVolume(ctx, id.ResourceName, node, id.VolumeNumber)
-	if err != nil {
-		return nil404(err)
-	}
-
-	if vol.ProviderKind != lapi.DISKLESS {
-		log.Info("resource not a diskless, not deleting")
-		return nil
-	}
-
-	log.Info("removing temporary resource")
-
-	// The shared diskless attachment must outlive all but the last member: delete it, but treat LINSTOR's
-	// FailInUse rejection as "a sibling still needs it" (race-free, no separate in-use check).
-	err = s.client.Resources.Delete(ctx, id.ResourceName, node, &lapi.ResourceDeleteOpts{KeepTiebreaker: true})
+	// A consistency-group sibling may still be mounted on the node: treat LINSTOR's FailInUse
+	// rejection as "a sibling still needs it" (race-free, no separate in-use check).
+	err := s.client.Resources.UnmakeAvailable(ctx, id.ResourceName, node)
 	if errors.Is(err, lapi.ApiCallRcErr(lapiconsts.FailInUse)) {
-		log.Info("resource still in use, keeping shared diskless attachment")
+		log.Info("resource still in use, keeping attachment")
 		return nil
 	}
 
@@ -1084,6 +976,47 @@ func (s *Linstor) CapacityBytes(ctx context.Context, storagePools []string, over
 	}
 
 	return totalKiB * KiB, nil
+}
+
+// OnlySharedStoragePools reports whether the given storage pools are all backed by a shared
+// space, i.e. the volume data is accessible from multiple nodes without replication.
+// A configured pool that exists on no node is an error rather than being silently ignored.
+func (s *Linstor) OnlySharedStoragePools(ctx context.Context, pools []string) (bool, error) {
+	if len(pools) == 0 {
+		// Without an explicit storage pool selection we cannot tell where the volume ends up.
+		return false, nil
+	}
+
+	cached := true
+
+	// The cached view can lag briefly after pool reconfiguration; acceptable for a
+	// create-time validation.
+	sps, err := s.client.Nodes.GetStoragePoolView(ctx, &lapi.ListOpts{Cached: &cached})
+	if err != nil {
+		return false, fmt.Errorf("failed to check storage pools for shared spaces: %w", err)
+	}
+
+	notFound := sets.New(pools...)
+
+	for i := range sps {
+		if !slices.Contains(pools, sps[i].StoragePoolName) {
+			continue
+		}
+
+		notFound.Delete(sps[i].StoragePoolName)
+
+		// LINSTOR names the free space manager of non-shared pools "<node>;<pool>"; actual
+		// shared spaces never contain the reserved ";".
+		if sps[i].FreeSpaceMgrName == "" || strings.Contains(sps[i].FreeSpaceMgrName, ";") {
+			return false, nil
+		}
+	}
+
+	if notFound.Len() > 0 {
+		return false, fmt.Errorf("storage pool(s) %s not found on any node", strings.Join(sets.List(notFound), ", "))
+	}
+
+	return true, nil
 }
 
 func (s *Linstor) CompatibleSnapshotId(name string) string {
@@ -1535,14 +1468,30 @@ func (s *Linstor) SnapDelete(ctx context.Context, snap *volume.SnapshotId) error
 
 	log.Debug("deleting local snapshot")
 
-	err := s.client.Resources.DeleteSnapshot(ctx, snap.SourceName, snap.SnapshotName)
+	// Remember the resource group: when LINSTOR deletes the empty resource definition together
+	// with the snapshot, it can no longer be looked up afterwards.
+	rDef, err := s.client.ResourceDefinitions.Get(ctx, snap.SourceName)
+	if err != nil {
+		// A missing resource definition means the snapshot is already gone.
+		if nil404(err) == nil {
+			return nil
+		}
+
+		return fmt.Errorf("failed to remove snapshot: %w", err)
+	}
+
+	err = s.client.Resources.DeleteSnapshot(ctx, snap.SourceName, snap.SnapshotName, &lapi.SnapshotDeleteOpts{
+		// Delete the resource definition along with its last snapshot, without a client-side
+		// check-then-delete race.
+		DeleteEmptyResourceDefinition: true,
+	})
 	if nil404(err) != nil {
 		return fmt.Errorf("failed to remove snapshot: %w", err)
 	}
 
-	err = s.deleteResourceDefinitionAndGroupIfUnused(ctx, snap.SourceName)
-	if nil404(err) != nil {
-		return fmt.Errorf("failed to remove resource definition: %w", err)
+	err = s.deleteResourceGroupIfUnused(ctx, rDef.ResourceGroupName)
+	if err != nil {
+		return fmt.Errorf("failed to remove resource group: %w", err)
 	}
 
 	return nil
@@ -1641,14 +1590,23 @@ func (s *Linstor) VolFromSnap(ctx context.Context, snap *volume.Snapshot, vol *v
 	if snap.Remote != "" && snapParams != nil && snapParams.DeleteLocal {
 		logger.Info("deleting local copy of backup")
 
-		err := s.client.Resources.DeleteSnapshot(ctx, snap.SourceName, snap.SnapshotName)
+		// Remember the resource group: the snapshot delete may remove the empty resource
+		// definition along with the snapshot.
+		srcDef, err := s.client.ResourceDefinitions.Get(ctx, snap.SourceName)
 		if err != nil {
-			logger.WithError(err).Warn("deleting local copy of backup failed")
-		}
+			logger.WithError(err).Warn("looking up local RD of backup failed")
+		} else {
+			err = s.client.Resources.DeleteSnapshot(ctx, snap.SourceName, snap.SnapshotName, &lapi.SnapshotDeleteOpts{
+				DeleteEmptyResourceDefinition: true,
+			})
+			if err != nil {
+				logger.WithError(err).Warn("deleting local copy of backup failed")
+			}
 
-		err = s.deleteResourceDefinitionAndGroupIfUnused(ctx, snap.SourceName)
-		if err != nil {
-			logger.WithError(err).Warn("deleting local RD of backup failed")
+			err = s.deleteResourceGroupIfUnused(ctx, srcDef.ResourceGroupName)
+			if err != nil {
+				logger.WithError(err).Warn("deleting local RG of backup failed")
+			}
 		}
 	}
 
@@ -2998,73 +2956,19 @@ func (s *Linstor) GetNodeTopologies(ctx context.Context, nodename string) (*csi.
 	return topo, nil
 }
 
-// Delete the given resource definition and linked resource group, but only if:
-// * No resources are placed
-// * No snapshots of the resource exist
-func (s *Linstor) deleteResourceDefinitionAndGroupIfUnused(ctx context.Context, rdName string) error {
-	log := s.log.WithField("rd", rdName)
-	log.Debug("checking for undeleted resources")
-
-	resources, err := s.client.Resources.GetAll(ctx, rdName)
-	if err != nil {
-		// Returns nil if api call returned 404, i.e. someone else already deleted the RD
-		return nil404(err)
-	}
-
-	for _, res := range resources {
-		if !slices.Contains(res.Flags, lapiconsts.FlagDelete) {
-			log.WithField("resource", res).Debug("not deleting resource definition, found undeleted resource")
-			return nil
-		}
-	}
-
-	log.Debug("checking for undeleted snapshots")
-
-	snapshots, err := s.client.Resources.GetSnapshots(ctx, rdName)
-	if err != nil {
-		// Returns nil if api call returned 404, i.e. someone else already deleted the RD
-		return nil404(err)
-	}
-
-	for _, snap := range snapshots {
-		if !slices.Contains(snap.Flags, lapiconsts.FlagDelete) {
-			log.WithField("snapshot", snap).Debug("not deleting resource definition, found undeleted snapshot")
-			return nil
-		}
-	}
-
-	log.Debug("fetching resource definition, then deleting it")
-
-	// Our last chance to get the resource group from the RD
-	rDef, err := s.client.ResourceDefinitions.Get(ctx, rdName)
-	if err != nil {
-		// if no RD was found, returns nil
-		return nil404(err)
-	}
-
-	err = s.client.ResourceDefinitions.Delete(ctx, rdName)
-	if err != nil {
-		// Returns nil if api call returned 404, i.e. someone else already deleted the RD
-		return nil404(err)
-	}
-
-	log.Info("checking RG for removal")
-
-	if rDef.ResourceGroupName == "DfltRscGrp" {
+// deleteResourceGroupIfUnused removes a resource group unless other resource definitions still use it.
+func (s *Linstor) deleteResourceGroupIfUnused(ctx context.Context, rgName string) error {
+	if rgName == "DfltRscGrp" {
 		// Don't try to delete the default resource group
 		return nil
 	}
 
-	err = s.client.ResourceGroups.Delete(ctx, rDef.ResourceGroupName)
-	if err != nil {
-		if errors.Is(err, lapi.ApiCallRcErr(lapiconsts.FailExistsRscDfn)) {
-			return nil
-		}
-
-		return nil404(err)
+	err := s.client.ResourceGroups.Delete(ctx, rgName)
+	if errors.Is(err, lapi.ApiCallRcErr(lapiconsts.FailExistsRscDfn)) {
+		return nil
 	}
 
-	return nil
+	return nil404(err)
 }
 
 // SortByPreferred sorts nodes based on the given topology preferences.

--- a/pkg/client/linstor_test.go
+++ b/pkg/client/linstor_test.go
@@ -22,7 +22,6 @@ package client
 
 import (
 	"context"
-	"encoding/json"
 	"testing"
 	"time"
 
@@ -146,31 +145,13 @@ func TestLinstorifyResourceName(t *testing.T) {
 	}
 }
 
-const (
-	ExampleResourceID         = "rsc1"
-	ResourceAllOnline         = `[{"name":"rsc1","node_name":"node-0","props":{"StorPoolName":"thinpool"},"layer_object":{"children":[{"type":"STORAGE","storage":{"storage_volumes":[{"volume_number":0,"device_path":"/dev/linstor_vg/rsc1_00000","allocated_size_kib":1052672,"usable_size_kib":1052672,"disk_state":"[]"}]}}],"type":"DRBD","drbd":{"drbd_resource_definition":{"peer_slots":7,"al_stripes":1,"al_stripe_size_kib":32,"port":7000,"transport_type":"IP","secret":"6uwedER7tGEifV9WzGMf","down":false},"node_id":0,"peer_slots":7,"al_stripes":1,"al_size":32,"drbd_volumes":[{"drbd_volume_definition":{"volume_number":0,"minor_number":1000},"device_path":"/dev/drbd1000","backing_device":"/dev/linstor_vg/rsc1_00000","allocated_size_kib":1048840,"usable_size_kib":1048576}],"connections":{"node-2":{"connected":true,"message":"Connected"},"node-1":{"connected":true,"message":"Connected"}},"promotion_score":10103,"may_promote":true}},"state":{"in_use":false},"uuid":"88e64cd1-bac2-4ef7-9abc-5f994c49bada","create_timestamp":1623230527247,"volumes":[{"volume_number":0,"storage_pool_name":"thinpool","provider_kind":"LVM_THIN","device_path":"/dev/drbd1000","allocated_size_kib":315,"props":{"Satellite/Device/Symlinks/0":"/dev/drbd/by-disk/linstor_vg/rsc1_00000","Satellite/Device/Symlinks/1":"/dev/drbd/by-res/rsc1/0"},"state":{"disk_state":"UpToDate"},"layer_data_list":[{"type":"DRBD","data":{"drbd_volume_definition":{"volume_number":0,"minor_number":1000},"device_path":"/dev/drbd1000","backing_device":"/dev/linstor_vg/rsc1_00000","allocated_size_kib":1048840,"usable_size_kib":1048576}},{"type":"STORAGE","data":{"volume_number":0,"device_path":"/dev/linstor_vg/rsc1_00000","allocated_size_kib":1052672,"usable_size_kib":1052672,"disk_state":"[]"}}],"uuid":"96069b58-f483-4897-b443-c89cdf7a0e73"}]},{"name":"rsc1","node_name":"node-1","props":{"StorPoolName":"thinpool"},"layer_object":{"children":[{"type":"STORAGE","storage":{"storage_volumes":[{"volume_number":0,"device_path":"/dev/linstor_vg/rsc1_00000","allocated_size_kib":1052672,"usable_size_kib":1052672,"disk_state":"[]"}]}}],"type":"DRBD","drbd":{"drbd_resource_definition":{"peer_slots":7,"al_stripes":1,"al_stripe_size_kib":32,"port":7000,"transport_type":"IP","secret":"6uwedER7tGEifV9WzGMf","down":false},"node_id":1,"peer_slots":7,"al_stripes":1,"al_size":32,"drbd_volumes":[{"drbd_volume_definition":{"volume_number":0,"minor_number":1000},"device_path":"/dev/drbd1000","backing_device":"/dev/linstor_vg/rsc1_00000","allocated_size_kib":1048840,"usable_size_kib":1048576}],"connections":{"node-2":{"connected":true,"message":"Connected"},"node-0":{"connected":true,"message":"Connected"}},"promotion_score":10103,"may_promote":true}},"state":{"in_use":false},"uuid":"f8f3bac3-bb9c-4334-a9d7-c9e24f31feba","create_timestamp":1623230527453,"volumes":[{"volume_number":0,"storage_pool_name":"thinpool","provider_kind":"LVM_THIN","device_path":"/dev/drbd1000","allocated_size_kib":315,"props":{"Satellite/Device/Symlinks/0":"/dev/drbd/by-disk/linstor_vg/rsc1_00000","Satellite/Device/Symlinks/1":"/dev/drbd/by-res/rsc1/0"},"state":{"disk_state":"UpToDate"},"layer_data_list":[{"type":"DRBD","data":{"drbd_volume_definition":{"volume_number":0,"minor_number":1000},"device_path":"/dev/drbd1000","backing_device":"/dev/linstor_vg/rsc1_00000","allocated_size_kib":1048840,"usable_size_kib":1048576}},{"type":"STORAGE","data":{"volume_number":0,"device_path":"/dev/linstor_vg/rsc1_00000","allocated_size_kib":1052672,"usable_size_kib":1052672,"disk_state":"[]"}}],"uuid":"83aeff7b-ee69-4457-82b6-daa677265045"}]},{"name":"rsc1","node_name":"node-2","props":{"StorPoolName":"thinpool"},"layer_object":{"children":[{"type":"STORAGE","storage":{"storage_volumes":[{"volume_number":0,"device_path":"/dev/linstor_vg/rsc1_00000","allocated_size_kib":1052672,"usable_size_kib":1052672,"disk_state":"[]"}]}}],"type":"DRBD","drbd":{"drbd_resource_definition":{"peer_slots":7,"al_stripes":1,"al_stripe_size_kib":32,"port":7000,"transport_type":"IP","secret":"6uwedER7tGEifV9WzGMf","down":false},"node_id":2,"peer_slots":7,"al_stripes":1,"al_size":32,"drbd_volumes":[{"drbd_volume_definition":{"volume_number":0,"minor_number":1000},"device_path":"/dev/drbd1000","backing_device":"/dev/linstor_vg/rsc1_00000","allocated_size_kib":1048840,"usable_size_kib":1048576}],"connections":{"node-1":{"connected":true,"message":"Connected"},"node-0":{"connected":true,"message":"Connected"}},"promotion_score":10103,"may_promote":true}},"state":{"in_use":false},"uuid":"9ef08b80-3152-46a6-b53d-705395414fbe","create_timestamp":1623230527299,"volumes":[{"volume_number":0,"storage_pool_name":"thinpool","provider_kind":"LVM_THIN","device_path":"/dev/drbd1000","allocated_size_kib":315,"props":{"Satellite/Device/Symlinks/0":"/dev/drbd/by-disk/linstor_vg/rsc1_00000","Satellite/Device/Symlinks/1":"/dev/drbd/by-res/rsc1/0"},"state":{"disk_state":"UpToDate"},"layer_data_list":[{"type":"DRBD","data":{"drbd_volume_definition":{"volume_number":0,"minor_number":1000},"device_path":"/dev/drbd1000","backing_device":"/dev/linstor_vg/rsc1_00000","allocated_size_kib":1048840,"usable_size_kib":1048576}},{"type":"STORAGE","data":{"volume_number":0,"device_path":"/dev/linstor_vg/rsc1_00000","allocated_size_kib":1052672,"usable_size_kib":1052672,"disk_state":"[]"}}],"uuid":"a8ba86a0-5114-4fb8-9934-35a75d33342a"}]}]`
-	ResourceOneOfflineQuorum  = `[{"name":"rsc1","node_name":"node-0","props":{"StorPoolName":"thinpool"},"layer_object":{"children":[{"type":"STORAGE","storage":{"storage_volumes":[{"volume_number":0,"device_path":"/dev/linstor_vg/rsc1_00000","allocated_size_kib":1052672,"usable_size_kib":1052672,"disk_state":"[]"}]}}],"type":"DRBD","drbd":{"drbd_resource_definition":{"peer_slots":7,"al_stripes":1,"al_stripe_size_kib":32,"port":7000,"transport_type":"IP","secret":"6uwedER7tGEifV9WzGMf","down":false},"node_id":0,"peer_slots":7,"al_stripes":1,"al_size":32,"drbd_volumes":[{"drbd_volume_definition":{"volume_number":0,"minor_number":1000},"device_path":"/dev/drbd1000","backing_device":"/dev/linstor_vg/rsc1_00000","allocated_size_kib":1048840,"usable_size_kib":1048576}]}},"uuid":"88e64cd1-bac2-4ef7-9abc-5f994c49bada","create_timestamp":1623230527247,"volumes":[{"volume_number":0,"storage_pool_name":"thinpool","provider_kind":"LVM_THIN","device_path":"/dev/drbd1000","allocated_size_kib":1052672,"props":{"Satellite/Device/Symlinks/0":"/dev/drbd/by-disk/linstor_vg/rsc1_00000","Satellite/Device/Symlinks/1":"/dev/drbd/by-res/rsc1/0"},"layer_data_list":[{"type":"DRBD","data":{"drbd_volume_definition":{"volume_number":0,"minor_number":1000},"device_path":"/dev/drbd1000","backing_device":"/dev/linstor_vg/rsc1_00000","allocated_size_kib":1048840,"usable_size_kib":1048576}},{"type":"STORAGE","data":{"volume_number":0,"device_path":"/dev/linstor_vg/rsc1_00000","allocated_size_kib":1052672,"usable_size_kib":1052672,"disk_state":"[]"}}],"uuid":"96069b58-f483-4897-b443-c89cdf7a0e73"}]},{"name":"rsc1","node_name":"node-1","props":{"StorPoolName":"thinpool"},"layer_object":{"children":[{"type":"STORAGE","storage":{"storage_volumes":[{"volume_number":0,"device_path":"/dev/linstor_vg/rsc1_00000","allocated_size_kib":1052672,"usable_size_kib":1052672,"disk_state":"[]"}]}}],"type":"DRBD","drbd":{"drbd_resource_definition":{"peer_slots":7,"al_stripes":1,"al_stripe_size_kib":32,"port":7000,"transport_type":"IP","secret":"6uwedER7tGEifV9WzGMf","down":false},"node_id":1,"peer_slots":7,"al_stripes":1,"al_size":32,"drbd_volumes":[{"drbd_volume_definition":{"volume_number":0,"minor_number":1000},"device_path":"/dev/drbd1000","backing_device":"/dev/linstor_vg/rsc1_00000","allocated_size_kib":1048840,"usable_size_kib":1048576}],"connections":{"node-2":{"connected":true,"message":"Connected"},"node-0":{"connected":false,"message":"Connecting"}},"promotion_score":10102,"may_promote":true}},"state":{"in_use":false},"uuid":"f8f3bac3-bb9c-4334-a9d7-c9e24f31feba","create_timestamp":1623230527453,"volumes":[{"volume_number":0,"storage_pool_name":"thinpool","provider_kind":"LVM_THIN","device_path":"/dev/drbd1000","allocated_size_kib":315,"props":{"Satellite/Device/Symlinks/0":"/dev/drbd/by-disk/linstor_vg/rsc1_00000","Satellite/Device/Symlinks/1":"/dev/drbd/by-res/rsc1/0"},"state":{"disk_state":"UpToDate"},"layer_data_list":[{"type":"DRBD","data":{"drbd_volume_definition":{"volume_number":0,"minor_number":1000},"device_path":"/dev/drbd1000","backing_device":"/dev/linstor_vg/rsc1_00000","allocated_size_kib":1048840,"usable_size_kib":1048576}},{"type":"STORAGE","data":{"volume_number":0,"device_path":"/dev/linstor_vg/rsc1_00000","allocated_size_kib":1052672,"usable_size_kib":1052672,"disk_state":"[]"}}],"uuid":"83aeff7b-ee69-4457-82b6-daa677265045"}]},{"name":"rsc1","node_name":"node-2","props":{"StorPoolName":"thinpool"},"layer_object":{"children":[{"type":"STORAGE","storage":{"storage_volumes":[{"volume_number":0,"device_path":"/dev/linstor_vg/rsc1_00000","allocated_size_kib":1052672,"usable_size_kib":1052672,"disk_state":"[]"}]}}],"type":"DRBD","drbd":{"drbd_resource_definition":{"peer_slots":7,"al_stripes":1,"al_stripe_size_kib":32,"port":7000,"transport_type":"IP","secret":"6uwedER7tGEifV9WzGMf","down":false},"node_id":2,"peer_slots":7,"al_stripes":1,"al_size":32,"drbd_volumes":[{"drbd_volume_definition":{"volume_number":0,"minor_number":1000},"device_path":"/dev/drbd1000","backing_device":"/dev/linstor_vg/rsc1_00000","allocated_size_kib":1048840,"usable_size_kib":1048576}],"connections":{"node-1":{"connected":true,"message":"Connected"},"node-0":{"connected":false,"message":"Connecting"}},"promotion_score":10102,"may_promote":true}},"state":{"in_use":false},"uuid":"9ef08b80-3152-46a6-b53d-705395414fbe","create_timestamp":1623230527299,"volumes":[{"volume_number":0,"storage_pool_name":"thinpool","provider_kind":"LVM_THIN","device_path":"/dev/drbd1000","allocated_size_kib":315,"props":{"Satellite/Device/Symlinks/0":"/dev/drbd/by-disk/linstor_vg/rsc1_00000","Satellite/Device/Symlinks/1":"/dev/drbd/by-res/rsc1/0"},"state":{"disk_state":"UpToDate"},"layer_data_list":[{"type":"DRBD","data":{"drbd_volume_definition":{"volume_number":0,"minor_number":1000},"device_path":"/dev/drbd1000","backing_device":"/dev/linstor_vg/rsc1_00000","allocated_size_kib":1048840,"usable_size_kib":1048576}},{"type":"STORAGE","data":{"volume_number":0,"device_path":"/dev/linstor_vg/rsc1_00000","allocated_size_kib":1052672,"usable_size_kib":1052672,"disk_state":"[]"}}],"uuid":"a8ba86a0-5114-4fb8-9934-35a75d33342a"}]}]`
-	ResourceSharedStoragePool = `[{"name":"rsc1","node_name":"node-0","props":{"StorPoolName":"shared"},"layer_object":{"children":[{"type":"STORAGE","storage":{"storage_volumes":[{"volume_number":0,"device_path":"/dev/linstor_shared_vg/rsc1_00000","allocated_size_kib":1052672,"usable_size_kib":1052672,"disk_state":"[]"}]}}],"type":"DRBD","drbd":{"drbd_resource_definition":{"peer_slots":7,"al_stripes":1,"al_stripe_size_kib":32,"port":7000,"transport_type":"IP","secret":"QGFBOyTJILQtUyfYgQrq","down":false},"node_id":0,"peer_slots":7,"al_stripes":1,"al_size":32,"flags":["INITIALIZED"],"drbd_volumes":[{"drbd_volume_definition":{"volume_number":0,"minor_number":1000},"device_path":"/dev/drbd1000","backing_device":"/dev/linstor_shared_vg/rsc1_00000","allocated_size_kib":1048840,"usable_size_kib":1048576}],"promotion_score":10101,"may_promote":true}},"state":{"in_use":false},"uuid":"c448d3d8-2278-4840-a982-80c1e425e40f","create_timestamp":1623240635046,"volumes":[{"volume_number":0,"storage_pool_name":"shared","provider_kind":"LVM","device_path":"/dev/drbd1000","allocated_size_kib":1052672,"props":{"Satellite/Device/Symlinks/0":"/dev/drbd/by-res/rsc1/0","Satellite/Device/Symlinks/1":"/dev/drbd/by-disk/linstor_shared_vg/rsc1_00000"},"state":{"disk_state":"UpToDate"},"layer_data_list":[{"type":"DRBD","data":{"drbd_volume_definition":{"volume_number":0,"minor_number":1000},"device_path":"/dev/drbd1000","backing_device":"/dev/linstor_shared_vg/rsc1_00000","allocated_size_kib":1048840,"usable_size_kib":1048576}},{"type":"STORAGE","data":{"volume_number":0,"device_path":"/dev/linstor_shared_vg/rsc1_00000","allocated_size_kib":1052672,"usable_size_kib":1052672,"disk_state":"[]"}}],"uuid":"81d1b9b4-2138-4326-b541-168c59daddc4"}],"shared_name":"shared"},{"name":"rsc1","node_name":"node-1","props":{"StorPoolName":"shared"},"flags":["INACTIVE"],"layer_object":{"children":[{"type":"STORAGE","storage":{"storage_volumes":[{"volume_number":0,"allocated_size_kib":1052672,"usable_size_kib":1052672,"disk_state":"[]"}]}}],"type":"DRBD","drbd":{"drbd_resource_definition":{"peer_slots":7,"al_stripes":1,"al_stripe_size_kib":32,"port":7000,"transport_type":"IP","secret":"QGFBOyTJILQtUyfYgQrq","down":false},"node_id":0,"peer_slots":7,"al_stripes":1,"al_size":32,"flags":["INITIALIZED"],"drbd_volumes":[{"drbd_volume_definition":{"volume_number":0,"minor_number":1000},"allocated_size_kib":1048840,"usable_size_kib":1048576}]}},"state":{},"uuid":"e4c40a9a-2c28-41f9-8714-d6ef0fab4e4c","create_timestamp":1623240634461,"volumes":[{"volume_number":0,"storage_pool_name":"shared","provider_kind":"LVM","allocated_size_kib":1052672,"layer_data_list":[{"type":"DRBD","data":{"drbd_volume_definition":{"volume_number":0,"minor_number":1000},"allocated_size_kib":1048840,"usable_size_kib":1048576}},{"type":"STORAGE","data":{"volume_number":0,"allocated_size_kib":1052672,"usable_size_kib":1052672,"disk_state":"[]"}}],"uuid":"4508140a-b6de-4de9-a3c2-9b9d45b7cc3b"}],"shared_name":"shared"},{"name":"rsc1","node_name":"node-2","props":{"StorPoolName":"shared"},"flags":["INACTIVE"],"layer_object":{"children":[{"type":"STORAGE","storage":{"storage_volumes":[{"volume_number":0,"allocated_size_kib":1052672,"usable_size_kib":1052672,"disk_state":"[]"}]}}],"type":"DRBD","drbd":{"drbd_resource_definition":{"peer_slots":7,"al_stripes":1,"al_stripe_size_kib":32,"port":7000,"transport_type":"IP","secret":"QGFBOyTJILQtUyfYgQrq","down":false},"node_id":0,"peer_slots":7,"al_stripes":1,"al_size":32,"flags":["INITIALIZED"],"drbd_volumes":[{"drbd_volume_definition":{"volume_number":0,"minor_number":1000},"allocated_size_kib":1048840,"usable_size_kib":1048576}]}},"state":{},"uuid":"fb4b32fb-65cc-4c73-9000-b4c4ee8ec2de","create_timestamp":1623240634019,"volumes":[{"volume_number":0,"storage_pool_name":"shared","provider_kind":"LVM","allocated_size_kib":1052672,"layer_data_list":[{"type":"DRBD","data":{"drbd_volume_definition":{"volume_number":0,"minor_number":1000},"allocated_size_kib":1048840,"usable_size_kib":1048576}},{"type":"STORAGE","data":{"volume_number":0,"allocated_size_kib":1052672,"usable_size_kib":1052672,"disk_state":"[]"}}],"uuid":"d1f5247e-251b-4b7e-8ef3-964e2a5a9724"}],"shared_name":"shared"}]`
-)
+const ExampleResourceID = "rsc1"
 
 func TestLinstor_Attach(t *testing.T) {
-	fromJson := func(s string) ([]lapi.Resource, error) {
-		var result []lapi.Resource
-
-		err := json.Unmarshal([]byte(s), &result)
-		if err != nil {
-			return nil, err
-		}
-
-		return result, nil
-	}
-
-	t.Run("existing resource", func(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
 		m := mocks.ResourceProvider{}
-		rv, rvErr := fromJson(ResourceAllOnline)
 
-		m.EXPECT().GetAll(mock.Anything, ExampleResourceID).Return(rv, rvErr)
-		m.EXPECT().MakeAvailable(mock.Anything, ExampleResourceID, "node-2", lapi.ResourceMakeAvailable{Diskful: false}).Return(nil)
+		m.EXPECT().MakeAvailable(mock.Anything, ExampleResourceID, "node-2", lapi.ResourceMakeAvailable{}).Return(nil)
 		m.EXPECT().GetVolume(mock.Anything, ExampleResourceID, "node-2", 0).Return(lapi.Volume{DevicePath: "/dev/vol1"}, nil)
 		cl := Linstor{client: &lc.HighLevelClient{Client: &lapi.Client{Resources: &m}}, log: logrus.WithField("test", t.Name())}
 
@@ -180,16 +161,14 @@ func TestLinstor_Attach(t *testing.T) {
 		m.AssertExpectations(t)
 	})
 
-	t.Run("no resource with expected diskfull resources", func(t *testing.T) {
+	t.Run("rwx block", func(t *testing.T) {
 		m := mocks.ResourceProvider{}
-		rv, rvErr := fromJson(ResourceOneOfflineQuorum)
 
-		m.EXPECT().GetAll(mock.Anything, ExampleResourceID).Return(rv, rvErr)
-		m.EXPECT().MakeAvailable(mock.Anything, ExampleResourceID, "node-3", lapi.ResourceMakeAvailable{Diskful: false}).Return(nil)
-		m.EXPECT().GetVolume(mock.Anything, ExampleResourceID, "node-3", 0).Return(lapi.Volume{DevicePath: "/dev/vol1"}, nil)
+		m.EXPECT().MakeAvailable(mock.Anything, ExampleResourceID, "node-2", lapi.ResourceMakeAvailable{AutoManageDualPrimary: true}).Return(nil)
+		m.EXPECT().GetVolume(mock.Anything, ExampleResourceID, "node-2", 0).Return(lapi.Volume{DevicePath: "/dev/vol1"}, nil)
 		cl := Linstor{client: &lc.HighLevelClient{Client: &lapi.Client{Resources: &m}}, log: logrus.WithField("test", t.Name())}
 
-		path, err := cl.Attach(context.Background(), volume.ID{ResourceName: ExampleResourceID}, "node-3", false)
+		path, err := cl.Attach(context.Background(), volume.ID{ResourceName: ExampleResourceID}, "node-2", true)
 		assert.NoError(t, err)
 		assert.Equal(t, "/dev/vol1", path)
 		m.AssertExpectations(t)
@@ -312,6 +291,72 @@ func TestLinstor_CapacityBytes(t *testing.T) {
 			cap, err := cl.CapacityBytes(context.Background(), testcase.storagePools, nil, testcase.topology)
 			assert.NoError(t, err)
 			assert.Equal(t, testcase.expectedCapacity, cap)
+		})
+	}
+}
+
+func TestLinstor_OnlySharedStoragePools(t *testing.T) {
+	t.Parallel()
+
+	view := []lapi.StoragePool{
+		{StoragePoolName: "shared-pool", NodeName: "node-1", FreeSpaceMgrName: "shared-space"},
+		{StoragePoolName: "shared-pool", NodeName: "node-2", FreeSpaceMgrName: "shared-space"},
+		{StoragePoolName: "local-pool", NodeName: "node-1", FreeSpaceMgrName: "node-1;local-pool"},
+		{StoragePoolName: "local-pool", NodeName: "node-2", FreeSpaceMgrName: "node-2;local-pool"},
+	}
+
+	testcases := []struct {
+		name           string
+		pools          []string
+		expectedShared bool
+		expectedError  string
+	}{
+		{
+			name: "no pools selected",
+		},
+		{
+			name:           "shared pool",
+			pools:          []string{"shared-pool"},
+			expectedShared: true,
+		},
+		{
+			name:  "non-shared pool",
+			pools: []string{"local-pool"},
+		},
+		{
+			name:  "mixed pools",
+			pools: []string{"shared-pool", "local-pool"},
+		},
+		{
+			name:          "pool not found on any node",
+			pools:         []string{"shared-pool", "missing-pool"},
+			expectedError: "storage pool(s) missing-pool not found on any node",
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			t.Parallel()
+
+			m := mocks.NodeProvider{}
+
+			// Without a pool selection the result is known without fetching the view.
+			if len(testcase.pools) > 0 {
+				yes := true
+				m.EXPECT().GetStoragePoolView(mock.Anything, &lapi.ListOpts{Cached: &yes}).Return(view, nil)
+			}
+
+			cl := Linstor{client: &lc.HighLevelClient{Client: &lapi.Client{Nodes: &m}}, log: logrus.WithField("test", t.Name())}
+
+			shared, err := cl.OnlySharedStoragePools(context.Background(), testcase.pools)
+			if testcase.expectedError != "" {
+				assert.EqualError(t, err, testcase.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, testcase.expectedShared, shared)
+			m.AssertExpectations(t)
 		})
 	}
 }

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -527,9 +527,30 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 	}
 
 	if len(params.LayerList) > 0 && params.LayerList[0] != devicelayerkind.Drbd {
+		rwxBlock := false
+
 		for _, c := range req.GetVolumeCapabilities() {
-			if c.GetAccessMode().GetMode() == csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER {
-				return nil, status.Errorf(codes.InvalidArgument, "ReadWriteMany volumes require a DRBD layer")
+			if c.GetAccessMode().GetMode() != csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER {
+				continue
+			}
+
+			if c.GetBlock() == nil {
+				return nil, status.Errorf(codes.InvalidArgument, "ReadWriteMany volumes require a DRBD layer or shared storage")
+			}
+
+			rwxBlock = true
+		}
+
+		// RWX block volumes also work without DRBD when all storage pools are backed by
+		// shared storage: LINSTOR activates the resource on the nodes that need it.
+		if rwxBlock {
+			shared, err := d.linstorClient.OnlySharedStoragePools(ctx, params.StoragePools)
+			if err != nil {
+				return nil, status.Errorf(codes.Internal, "CreateVolume failed for %s: %v", req.GetName(), err)
+			}
+
+			if !shared {
+				return nil, status.Errorf(codes.InvalidArgument, "ReadWriteMany volumes require a DRBD layer or shared storage")
 			}
 		}
 	}

--- a/pkg/linstor/const.go
+++ b/pkg/linstor/const.go
@@ -43,9 +43,6 @@ const (
 	// ConsistencyGroupLabel is the PVC label whose value groups a namespace's volumes into one LINSTOR resource.
 	ConsistencyGroupLabel = DriverName + "/consistency-group"
 
-	// PropertyAllowTwoPrimaries is DRBD option to allow second primary. Mainly used for live-migration.
-	PropertyAllowTwoPrimaries = lc.NamespcDrbdNetOptions + "/allow-two-primaries"
-
 	// CreatedForTemporaryDisklessAttach marks a resource as temporary, i.e. it should be removed after it is no longer
 	// needed.
 	CreatedForTemporaryDisklessAttach = "temporary-diskless-attach"

--- a/pkg/linstor/highlevelclient/high_level_client.go
+++ b/pkg/linstor/highlevelclient/high_level_client.go
@@ -32,10 +32,41 @@ import (
 	"github.com/piraeusdatastore/linstor-csi/pkg/volume"
 )
 
+// The REST API version that introduced the APIs the driver depends on: resource-definition
+// truncate, snapshot delete with resource-definition cleanup, unmake-available and
+// make-available with auto-manage-dual-primary. Shipped with LINSTOR 1.35.
+const (
+	MinimumRestApiMajor = 1
+	MinimumRestApiMinor = 29
+)
+
 // HighLevelClient is a golinstor client with convience functions.
 type HighLevelClient struct {
 	*lapi.Client
 	PropertyNamespace string
+}
+
+// EnsureMinimumApiVersion returns an error if the connected LINSTOR controller does not provide
+// the REST API version the driver requires.
+func (c *HighLevelClient) EnsureMinimumApiVersion(ctx context.Context) error {
+	version, err := c.Controller.GetVersion(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to fetch LINSTOR version: %w", err)
+	}
+
+	var major, minor int
+
+	_, err = fmt.Sscanf(version.RestApiVersion, "%d.%d", &major, &minor)
+	if err != nil {
+		return fmt.Errorf("failed to parse LINSTOR REST API version '%s': %w", version.RestApiVersion, err)
+	}
+
+	if major != MinimumRestApiMajor || minor < MinimumRestApiMinor {
+		return fmt.Errorf("LINSTOR %s (REST API %s) is not supported: the driver requires REST API %d.%d or newer in the %d.x series, shipped with LINSTOR 1.35",
+			version.Version, version.RestApiVersion, MinimumRestApiMajor, MinimumRestApiMinor, MinimumRestApiMajor)
+	}
+
+	return nil
 }
 
 // NewHighLevelClient returns a pointer to a golinstor client with convience.


### PR DESCRIPTION
Use the APIs introduced with LINSTOR 1.35:

* ControllerPublishVolume always invokes MakeAvailable, letting LINSTOR manage allow-two-primaries for RWX volumes via auto-manage-dual-primary instead of toggling the property manually.
* ControllerUnpublishVolume reverts the attachment with UnmakeAvailable.
* Volume deletion truncates the resource definition in one server-side operation, replacing the diskless-first delete loop and the balancer workaround.
* Snapshot deletion removes the empty resource definition together with the last snapshot, replacing the client-side check-then-delete.
* RWX block volumes no longer require a DRBD layer when all configured storage pools are backed by shared storage.
* Fail at startup when the controller does not provide REST API 1.29 (LINSTOR 1.35).