### PR TITLE
install nfs-ganesha from backports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The driver now requires LINSTOR 1.35 or newer and refuses to start against
   older controllers.
 
+### Fixed
+
+- The NFS server image installs NFS-Ganesha from Debian backports (9.14 instead
+  of 6.5). Ganesha 6.5 answers `GET_DIR_DELEGATION` with `OP_ILLEGAL` rather
+  than `NFS4ERR_NOTSUPP`, which fails the whole COMPOUND and reaches userspace
+  as `EREMOTEIO` on RWX volumes. Linux 6.19 and newer request directory
+  delegations by default, so every client on such a kernel was affected.
+
 ## [1.12.0] - 2026-07-24
 
 ### Added

--- a/nfs/Dockerfile
+++ b/nfs/Dockerfile
@@ -28,13 +28,19 @@ RUN --mount=type=cache,target=/var/cache,sharing=private \
     wget https://packages.linbit.com/public/linbit-keyring/trixie/linbit-keyring.deb -O /var/cache/linbit-keyring.deb && \
     dpkg -i /var/cache/linbit-keyring.deb && \
     . /etc/os-release && \
-    echo "deb [signed-by=/etc/apt/trusted.gpg.d/linbit-keyring.gpg] http://packages.linbit.com/public $VERSION_CODENAME misc" > /etc/apt/sources.list.d/linbit.list
+    echo "deb [signed-by=/etc/apt/trusted.gpg.d/linbit-keyring.gpg] http://packages.linbit.com/public $VERSION_CODENAME misc" > /etc/apt/sources.list.d/linbit.list && \
+    echo "deb http://deb.debian.org/debian $VERSION_CODENAME-backports main" > /etc/apt/sources.list.d/backports.list
 
+# Ganesha is pulled from backports: 6.5 in trixie answers GET_DIR_DELEGATION with
+# OP_ILLEGAL, failing the COMPOUND and surfacing as EREMOTEIO on clients that ask
+# for a directory delegation (Linux 6.19+ does by default).
 RUN --mount=type=cache,target=/var/cache,sharing=private \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=private \
     --mount=type=tmpfs,target=/var/log \
+    . /etc/os-release && \
     apt-get update && \
-    apt-get install -y --no-install-recommends drbd-reactor nfs-ganesha nfs-ganesha-vfs systemd psmisc procps e2fsprogs xfsprogs && \
+    apt-get install -y --no-install-recommends drbd-reactor systemd psmisc procps e2fsprogs xfsprogs && \
+    apt-get install -y --no-install-recommends -t "$VERSION_CODENAME-backports" nfs-ganesha nfs-ganesha-vfs && \
     sed -e 's/usage-count yes;/usage-count no;/' -i /etc/drbd.d/global_common.conf
 
 COPY --from=builder --link /nfs-helper /usr/bin/nfs-helper


### PR DESCRIPTION
Fixes #490.

`nfs/Dockerfile`: adds trixie-backports and installs `nfs-ganesha` + `nfs-ganesha-vfs` from there (9.14 instead of 6.5), in a second apt call so the LINBIT packages keep coming from trixie.

Built for amd64: ganesha reports V9.14, and the repo's `default-config.tmpl` parses and starts unchanged. `9.14-1~bpo13+1` exists for both amd64 and arm64.