### PR TITLE
ci: keep provenance out of build metadata

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+    env:
+      # Keep the SLSA provenance out of the build metadata output, otherwise the
+      # BUILD_METADATA env var in the "Sign images" step grows large enough to
+      # blow past ARG_MAX ("Argument list too long"). The provenance attestation
+      # is still pushed to the registry; this only trims the metadata output.
+      BUILDX_METADATA_PROVENANCE: disabled
     steps:
       - uses: actions/checkout@v7
       - name: Set up QEMU


### PR DESCRIPTION
The "Sign images" step passes the build metadata output as the `BUILD_METADATA` environment variable. Recent buildx versions include the full SLSA provenance in that output, which makes the variable large enough to exceed ARG_MAX when starting bash ("Argument list too long"), so the step fails before running.

Set `BUILDX_METADATA_PROVENANCE=disabled` at the job level so provenance stays out of the metadata output. The provenance attestation is still pushed to the registry; only the metadata output is trimmed.

Same fix as piraeusdatastore/piraeus-operator@6a4377a52c2b610ec44d576ec8db6acd6d8ed2de.