### PR TITLE
driver: skip KubeVirt check for storage-only RWX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- RWX block volumes with a bare storage layer (shared storage) skip the KubeVirt
+  VM ownership validation; coordinating concurrent access is left to the users.
+
 ## [1.13.0] - 2026-09-02
 
 ### Added

--- a/cmd/linstor-csi/linstor-csi.go
+++ b/cmd/linstor-csi/linstor-csi.go
@@ -61,7 +61,7 @@ func main() {
 		enableRWX                 = flag.Bool("enable-rwx", false, "Enable RWX support via NFS (requires running in Kubernetes).")
 		namespace                 = flag.String("nfs-service-namespace", "", "The namespace the NFS service is running in.")
 		reactorConfigMapName      = flag.String("nfs-reactor-config-map-name", "linstor-csi-nfs-reactor-config", "Name of the config map used to store promoter configuration")
-		disableRWXBlockValidation = flag.Bool("disable-rwx-block-validation", false, "Disable KubeVirt VM ownership validation for RWX block volumes.")
+		disableRWXBlockValidation = flag.Bool("disable-rwx-block-validation", false, "Disable KubeVirt VM ownership validation for RWX block volumes. Storage-only volumes on shared storage are never validated; coordinating concurrent access is left to the users.")
 		enableConsistencyGroups   = flag.Bool("enable-consistency-groups", false, "Place PVCs sharing a linstor.csi.linbit.com/consistency-group label as separate volumes of one LINSTOR resource (requires running in Kubernetes).")
 		enableSnapshotClasses     = flag.Bool("enable-volume-snapshot-classes", true, "Enable VolumeSnapshotClass handling: reconcile VolumeSnapshotClasses and read snapshot-class parameters (requires running in Kubernetes).")
 	)

--- a/pkg/client/linstor.go
+++ b/pkg/client/linstor.go
@@ -41,6 +41,7 @@ import (
 	lapiconsts "github.com/LINBIT/golinstor"
 	lapi "github.com/LINBIT/golinstor/client"
 	"github.com/LINBIT/golinstor/clonestatus"
+	"github.com/LINBIT/golinstor/devicelayerkind"
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/pborman/uuid"
 	"github.com/sirupsen/logrus"
@@ -310,6 +311,8 @@ func (s *Linstor) volumeInfoFromResourceDefinition(id volume.ID, resDef lapi.Res
 		return nil
 	}
 
+	isStorageOnly := len(resDef.LayerData) == 1 && resDef.LayerData[0].Type == devicelayerkind.Storage
+
 	return &volume.Info{
 		ID:            id,
 		DeviceBytes:   deviceBytes,
@@ -317,6 +320,7 @@ func (s *Linstor) volumeInfoFromResourceDefinition(id volume.ID, resDef lapi.Res
 		FsType:        fsType,
 		Properties:    props,
 		UseQuorum:     resDef.Props["DrbdOptions/Resource/quorum"] != "off",
+		IsStorageOnly: isStorageOnly,
 	}
 }
 

--- a/pkg/client/linstor_test.go
+++ b/pkg/client/linstor_test.go
@@ -29,10 +29,12 @@ import (
 
 	lapiconsts "github.com/LINBIT/golinstor"
 	lapi "github.com/LINBIT/golinstor/client"
+	"github.com/LINBIT/golinstor/devicelayerkind"
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/piraeusdatastore/linstor-csi/pkg/client/mocks"
 	"github.com/piraeusdatastore/linstor-csi/pkg/linstor"
@@ -315,6 +317,50 @@ func TestLinstor_OnlySharedStoragePools(t *testing.T) {
 
 			assert.Equal(t, testcase.expectedShared, shared)
 			m.AssertExpectations(t)
+		})
+	}
+}
+
+func TestLinstor_VolumeInfoIsStorageOnly(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		name          string
+		layers        []lapi.ResourceDefinitionLayer
+		isStorageOnly bool
+	}{
+		{
+			name:          "storage only",
+			layers:        []lapi.ResourceDefinitionLayer{{Type: devicelayerkind.Storage}},
+			isStorageOnly: true,
+		},
+		{
+			name:   "drbd over storage",
+			layers: []lapi.ResourceDefinitionLayer{{Type: devicelayerkind.Drbd}, {Type: devicelayerkind.Storage}},
+		},
+		{
+			// Intentionally not exempt: LUKS/cache on top is not safe on two nodes at once.
+			name:   "luks over storage",
+			layers: []lapi.ResourceDefinitionLayer{{Type: devicelayerkind.Luks}, {Type: devicelayerkind.Storage}},
+		},
+		{
+			name: "unknown layer stack",
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			t.Parallel()
+
+			vnr := int32(0)
+			cl := Linstor{}
+
+			info := cl.volumeInfoFromResourceDefinition(volume.ID{ResourceName: ExampleResourceID}, lapi.ResourceDefinitionWithVolumeDefinition{
+				ResourceDefinition: lapi.ResourceDefinition{Name: ExampleResourceID, LayerData: testcase.layers},
+				VolumeDefinitions:  []lapi.VolumeDefinition{{VolumeNumber: &vnr, SizeKib: 1024}},
+			})
+			require.NotNil(t, info)
+			assert.Equal(t, testcase.isStorageOnly, info.IsStorageOnly)
 		})
 	}
 }

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -197,7 +197,8 @@ func ConfigureRWX(cl kubernetes.Interface, namespace, reactorConfigMap string) f
 
 // EnableRWXBlockValidation enables the KubeVirt VM ownership validation for RWX block volumes.
 // When enabled, the driver checks that multiple pods using the same RWX block volume belong to
-// the same VM, guarding against misuse of allow-two-primaries.
+// the same VM, guarding against misuse of allow-two-primaries. Storage-only volumes (shared storage
+// without DRBD) are exempt.
 func EnableRWXBlockValidation(validator *utils.RWXBlockValidator) func(*Driver) error {
 	return func(d *Driver) error {
 		d.rwxBlockValidator = validator
@@ -849,8 +850,9 @@ func (d *Driver) ControllerPublishVolume(ctx context.Context, req *csi.Controlle
 	// ReadWriteMany block volume
 	rwxBlock := req.VolumeCapability.AccessMode.GetMode() == csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER && req.VolumeCapability.GetBlock() != nil
 
-	// Validate RWX block attachment to prevent misuse of allow-two-primaries
-	if rwxBlock && d.rwxBlockValidator != nil {
+	// Only DRBD's allow-two-primaries needs guarding, and a bare LV on shared storage has none: users coordinate
+	// access themselves. LUKS or cache layers on top are unsafe on two nodes at once, so such stacks stay validated.
+	if rwxBlock && !existingVolume.IsStorageOnly && d.rwxBlockValidator != nil {
 		if _, err := d.rwxBlockValidator.ValidateAttachment(ctx, req.GetVolumeId()); err != nil {
 			return nil, status.Errorf(codes.FailedPrecondition,
 				"ControllerPublishVolume failed for %s: %v", req.GetVolumeId(), err)

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -41,6 +41,8 @@ type Info struct {
 	FsType        string
 	Properties    map[string]string
 	UseQuorum     bool
+	// IsStorageOnly marks volumes whose layer stack is just the storage layer, i.e. no DRBD replication.
+	IsStorageOnly bool
 }
 
 func (i *Info) Size() int64 {


### PR DESCRIPTION
The KubeVirt VM ownership validation guards DRBD's allow-two-primaries. RWX block volumes without a DRBD layer only pass CreateVolume when all storage pools are shared, so there is nothing to guard: concurrent access happens on the shared LV and is coordinated by the users.

Expose this as volume.Info.IsStorageOnly, derived from the resource definition's layer stack, and skip the validator for such volumes in ControllerPublishVolume.