### PR TITLE
driver: limit shared-storage RWX to safe layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- RWX block volumes with a bare storage layer (shared storage) skip the KubeVirt
-  VM ownership validation; coordinating concurrent access is left to the users.
+- RWX block volumes on shared storage without DRBD skip the KubeVirt VM
+  ownership validation; coordinating concurrent access is left to the users.
+
+### Fixed
+
+- RWX block volumes without DRBD are only provisioned with the "storage" or
+  "luks storage" layer list; cache layers keep node-local data.
 
 ## [1.13.0] - 2026-09-02
 

--- a/cmd/linstor-csi/linstor-csi.go
+++ b/cmd/linstor-csi/linstor-csi.go
@@ -61,7 +61,7 @@ func main() {
 		enableRWX                 = flag.Bool("enable-rwx", false, "Enable RWX support via NFS (requires running in Kubernetes).")
 		namespace                 = flag.String("nfs-service-namespace", "", "The namespace the NFS service is running in.")
 		reactorConfigMapName      = flag.String("nfs-reactor-config-map-name", "linstor-csi-nfs-reactor-config", "Name of the config map used to store promoter configuration")
-		disableRWXBlockValidation = flag.Bool("disable-rwx-block-validation", false, "Disable KubeVirt VM ownership validation for RWX block volumes. Storage-only volumes on shared storage are never validated; coordinating concurrent access is left to the users.")
+		disableRWXBlockValidation = flag.Bool("disable-rwx-block-validation", false, "Disable KubeVirt VM ownership validation for RWX block volumes. Volumes on shared storage without DRBD are never validated; coordinating concurrent access is left to the users.")
 		enableConsistencyGroups   = flag.Bool("enable-consistency-groups", false, "Place PVCs sharing a linstor.csi.linbit.com/consistency-group label as separate volumes of one LINSTOR resource (requires running in Kubernetes).")
 		enableSnapshotClasses     = flag.Bool("enable-volume-snapshot-classes", true, "Enable VolumeSnapshotClass handling: reconcile VolumeSnapshotClasses and read snapshot-class parameters (requires running in Kubernetes).")
 	)

--- a/pkg/client/linstor.go
+++ b/pkg/client/linstor.go
@@ -311,16 +311,19 @@ func (s *Linstor) volumeInfoFromResourceDefinition(id volume.ID, resDef lapi.Res
 		return nil
 	}
 
-	isStorageOnly := len(resDef.LayerData) == 1 && resDef.LayerData[0].Type == devicelayerkind.Storage
+	layers := make([]devicelayerkind.DeviceLayerKind, 0, len(resDef.LayerData))
+	for i := range resDef.LayerData {
+		layers = append(layers, resDef.LayerData[i].Type)
+	}
 
 	return &volume.Info{
-		ID:            id,
-		DeviceBytes:   deviceBytes,
-		ResourceGroup: resDef.ResourceGroupName,
-		FsType:        fsType,
-		Properties:    props,
-		UseQuorum:     resDef.Props["DrbdOptions/Resource/quorum"] != "off",
-		IsStorageOnly: isStorageOnly,
+		ID:                id,
+		DeviceBytes:       deviceBytes,
+		ResourceGroup:     resDef.ResourceGroupName,
+		FsType:            fsType,
+		Properties:        props,
+		UseQuorum:         resDef.Props["DrbdOptions/Resource/quorum"] != "off",
+		SharedStorageSafe: volume.IsSharedStorageSafe(layers),
 	}
 }
 

--- a/pkg/client/linstor_test.go
+++ b/pkg/client/linstor_test.go
@@ -321,27 +321,33 @@ func TestLinstor_OnlySharedStoragePools(t *testing.T) {
 	}
 }
 
-func TestLinstor_VolumeInfoIsStorageOnly(t *testing.T) {
+func TestLinstor_VolumeInfoSharedStorageSafe(t *testing.T) {
 	t.Parallel()
 
 	testcases := []struct {
-		name          string
-		layers        []lapi.ResourceDefinitionLayer
-		isStorageOnly bool
+		name   string
+		layers []lapi.ResourceDefinitionLayer
+		safe   bool
 	}{
 		{
-			name:          "storage only",
-			layers:        []lapi.ResourceDefinitionLayer{{Type: devicelayerkind.Storage}},
-			isStorageOnly: true,
+			name:   "storage only",
+			layers: []lapi.ResourceDefinitionLayer{{Type: devicelayerkind.Storage}},
+			safe:   true,
+		},
+		{
+			// dm-crypt is a stateless per-sector transform, as safe as the bare LV.
+			name:   "luks over storage",
+			layers: []lapi.ResourceDefinitionLayer{{Type: devicelayerkind.Luks}, {Type: devicelayerkind.Storage}},
+			safe:   true,
 		},
 		{
 			name:   "drbd over storage",
 			layers: []lapi.ResourceDefinitionLayer{{Type: devicelayerkind.Drbd}, {Type: devicelayerkind.Storage}},
 		},
 		{
-			// Intentionally not exempt: LUKS/cache on top is not safe on two nodes at once.
-			name:   "luks over storage",
-			layers: []lapi.ResourceDefinitionLayer{{Type: devicelayerkind.Luks}, {Type: devicelayerkind.Storage}},
+			// A cache keeps dirty or stale blocks on the local cache device.
+			name:   "cache over storage",
+			layers: []lapi.ResourceDefinitionLayer{{Type: devicelayerkind.Cache}, {Type: devicelayerkind.Storage}},
 		},
 		{
 			name: "unknown layer stack",
@@ -360,7 +366,7 @@ func TestLinstor_VolumeInfoIsStorageOnly(t *testing.T) {
 				VolumeDefinitions:  []lapi.VolumeDefinition{{VolumeNumber: &vnr, SizeKib: 1024}},
 			})
 			require.NotNil(t, info)
-			assert.Equal(t, testcase.isStorageOnly, info.IsStorageOnly)
+			assert.Equal(t, testcase.safe, info.SharedStorageSafe)
 		})
 	}
 }

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -197,8 +197,8 @@ func ConfigureRWX(cl kubernetes.Interface, namespace, reactorConfigMap string) f
 
 // EnableRWXBlockValidation enables the KubeVirt VM ownership validation for RWX block volumes.
 // When enabled, the driver checks that multiple pods using the same RWX block volume belong to
-// the same VM, guarding against misuse of allow-two-primaries. Storage-only volumes (shared storage
-// without DRBD) are exempt.
+// the same VM, guarding against misuse of allow-two-primaries. Volumes on shared storage without DRBD
+// are exempt.
 func EnableRWXBlockValidation(validator *utils.RWXBlockValidator) func(*Driver) error {
 	return func(d *Driver) error {
 		d.rwxBlockValidator = validator
@@ -526,9 +526,13 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 			rwxBlock = true
 		}
 
-		// RWX block volumes also work without DRBD when all storage pools are backed by
-		// shared storage: LINSTOR activates the resource on the nodes that need it.
+		// Without DRBD, LINSTOR activates the resource on every node that needs it, so RWX block needs shared
+		// storage and a layer stack without node-local state (a cache would serve stale blocks).
 		if rwxBlock {
+			if !volume.IsSharedStorageSafe(params.LayerList) {
+				return nil, status.Errorf(codes.InvalidArgument, "ReadWriteMany block volumes without DRBD require one of the layer lists %v on shared storage", volume.SharedStorageSafeLayerStacks)
+			}
+
 			shared, err := d.linstorClient.OnlySharedStoragePools(ctx, params.StoragePools)
 			if err != nil {
 				return nil, status.Errorf(codes.Internal, "CreateVolume failed for %s: %v", req.GetName(), err)
@@ -850,9 +854,9 @@ func (d *Driver) ControllerPublishVolume(ctx context.Context, req *csi.Controlle
 	// ReadWriteMany block volume
 	rwxBlock := req.VolumeCapability.AccessMode.GetMode() == csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER && req.VolumeCapability.GetBlock() != nil
 
-	// Only DRBD's allow-two-primaries needs guarding, and a bare LV on shared storage has none: users coordinate
-	// access themselves. LUKS or cache layers on top are unsafe on two nodes at once, so such stacks stay validated.
-	if rwxBlock && !existingVolume.IsStorageOnly && d.rwxBlockValidator != nil {
+	// Only DRBD's allow-two-primaries needs guarding; a shared-storage-safe stack has none, and users coordinate
+	// access themselves. Everything else, including cache stacks provisioned before this check, stays validated.
+	if rwxBlock && !existingVolume.SharedStorageSafe && d.rwxBlockValidator != nil {
 		if _, err := d.rwxBlockValidator.ValidateAttachment(ctx, req.GetVolumeId()); err != nil {
 			return nil, status.Errorf(codes.FailedPrecondition,
 				"ControllerPublishVolume failed for %s: %v", req.GetVolumeId(), err)

--- a/pkg/volume/parameter.go
+++ b/pkg/volume/parameter.go
@@ -440,6 +440,20 @@ func ParseXReplicasOnDifferent(prefix, s string) (map[string]int, error) {
 	return expanded, nil
 }
 
+// SharedStorageSafeLayerStacks keep no node-local state, so a volume on shared storage may be active on several
+// nodes at once. Caches hold dirty or stale blocks on the local cache device; DRBD replicates instead.
+var SharedStorageSafeLayerStacks = [][]devicelayerkind.DeviceLayerKind{
+	{devicelayerkind.Storage},
+	{devicelayerkind.Luks, devicelayerkind.Storage},
+}
+
+// IsSharedStorageSafe reports whether layers is one of SharedStorageSafeLayerStacks.
+func IsSharedStorageSafe(layers []devicelayerkind.DeviceLayerKind) bool {
+	return slices.ContainsFunc(SharedStorageSafeLayerStacks, func(safe []devicelayerkind.DeviceLayerKind) bool {
+		return slices.Equal(safe, layers)
+	})
+}
+
 // ParseLayerList returns a slice of LayerType from a string of space-separated layers.
 func ParseLayerList(s string) ([]devicelayerkind.DeviceLayerKind, error) {
 	list := strings.Split(s, " ")

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -41,8 +41,8 @@ type Info struct {
 	FsType        string
 	Properties    map[string]string
 	UseQuorum     bool
-	// IsStorageOnly marks volumes whose layer stack is just the storage layer, i.e. no DRBD replication.
-	IsStorageOnly bool
+	// SharedStorageSafe marks a layer stack without node-local state, see SharedStorageSafeLayerStacks.
+	SharedStorageSafe bool
 }
 
 func (i *Info) Size() int64 {


### PR DESCRIPTION
Without DRBD, LINSTOR activates a shared-storage resource on every node that needs it, so any layer keeping node-local state breaks RWX even for perfectly coordinated consumers: dm-cache and dm-writecache hold dirty or stale blocks on the local cache device, and a flush never pushes them to the shared origin. dm-crypt is a stateless per-sector transform and is as safe as the bare LV.

Only provision RWX block volumes without DRBD for the "storage" and "luks storage" layer lists, and use the same table to decide which volumes skip the KubeVirt validation on publish. This replaces the storage-only marker with volume.Info.SharedStorageSafe.

Follow up from #496 